### PR TITLE
yarn start local script

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -167,8 +167,6 @@ Here are some issues encountered when building on macOS:
 
 ### Run the Android app
 
-In `packages/host/public/config.js` change `API_HOST` to `API_HOST: 'https://localhost:8000'` to use the remote server running on Android.
-
 Run:
 ```
 yarn android:build:debug
@@ -182,11 +180,13 @@ This will:
 The steps, if you need to run them manually are:
 
 ```
-yarn build
+yarn build-local
 npx cap copy
 ```
 
 Open the `android` folder in Android Studio and start the app.
+Note that the `build-local` script will set the `API_HOST` to `API_HOST: 'https://localhost:8000'` in  `packages/host/public/config.js` which is required when running the remote server running on Android.
+
 
 
 ### Release build

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "start-remote": "lerna run --scope @openmsupply-client/* --parallel start-remote",
     "start": "yarn start-remote",
     "build": "lerna run --scope @openmsupply-client/* build",
+    "build-local": "lerna run --scope @openmsupply-client/* build-local",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",
     "clean": "lerna run --scope @openmsupply-client/* --parallel clean",
     "compile": "lerna run --scope @openmsupply-client/* --parallel tsc --since HEAD",
@@ -18,8 +19,8 @@
     "generate": "graphql-codegen --config codegen.yml",
     "android:run": "npx cap run android",
     "android:build-remote_server": "cd ./packages/android && ./build_remote_server_libs.sh",
-    "android:build:debug": "yarn build && npx cap copy && cd ./packages/android && ./gradlew assembleDebug",
-    "android:build:release": "yarn build && npx cap copy && cd ./packages/android && ./gradlew assembleRelease",
+    "android:build:debug": "yarn build-local && npx cap copy && cd ./packages/android && ./gradlew assembleDebug",
+    "android:build:release": "yarn build-local && npx cap copy && cd ./packages/android && ./gradlew assembleRelease",
     "i18n-unused-display": "i18n-unused display-unused",
     "i18n-unused-remove": "i18n-unused remove-unused",
     "i18n-missing": "i18n-unused display-missed"

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start-local": "lerna run --scope @openmsupply-client/* --parallel start-local",
-    "start": "lerna run --scope @openmsupply-client/* --parallel start",
+    "start-remote": "lerna run --scope @openmsupply-client/* --parallel start-remote",
+    "start": "yarn start-remote",
     "build": "lerna run --scope @openmsupply-client/* build",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",
     "clean": "lerna run --scope @openmsupply-client/* --parallel clean",

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.2",
   "private": true,
   "scripts": {
+    "start-local": "lerna run --scope @openmsupply-client/* --parallel start-local",
     "start": "lerna run --scope @openmsupply-client/* --parallel start",
     "build": "lerna run --scope @openmsupply-client/* build",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -20,7 +20,7 @@
     "webpack-dev-server": "^4.8.1"
   },
   "scripts": {
-    "start": "webpack-cli serve",
+    "start-remote": "webpack-cli serve",
     "start-local": "webpack-cli serve --env local",
     "build": "yarn clean && webpack --env production",
     "serve": "serve dist -p 3003",

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -23,6 +23,7 @@
     "start-remote": "webpack-cli serve",
     "start-local": "webpack-cli serve --env local",
     "build": "yarn clean && webpack --env production",
+    "build-local": "yarn clean && webpack --env production local",
     "serve": "serve dist -p 3003",
     "clean": "rimraf dist",
     "tsc": "tsc --build"

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "start": "webpack-cli serve",
+    "start-local": "webpack-cli serve --env local",
     "build": "yarn clean && webpack --env production",
     "serve": "serve dist -p 3003",
     "clean": "rimraf dist",

--- a/client/packages/host/public/config.js
+++ b/client/packages/host/public/config.js
@@ -1,4 +1,3 @@
 window.env = {
-  // API_HOST: 'https://localhost:8000', // - default URL for the backend graphql server
   API_HOST: 'https://demo-open.msupply.org:8000', // Demo - site URL
 };

--- a/client/packages/host/public/config.local.js
+++ b/client/packages/host/public/config.local.js
@@ -1,0 +1,3 @@
+window.env = {
+  API_HOST: 'https://localhost:8000', // - default URL for the backend graphql server
+};

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -99,7 +99,10 @@ module.exports = env => {
       new CopyPlugin({
         patterns: [
           { from: './public/mockServiceWorker.js', to: 'mockServiceWorker.js' },
-          { from: './public/config.js', to: 'config.js' },
+          {
+            from: env.local ? './public/config.local.js' : './public/config.js',
+            to: 'config.js',
+          },
           {
             context: path.resolve(
               __dirname,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0-beta.3",
   "private": true,
   "scripts": {
-    "start": "cd ./server && cargo run & cd ./client && yarn start"
+    "start": "cd ./server && cargo run & cd ./client && yarn start-local"
   }
 }


### PR DESCRIPTION
Fixes #9 

( the incorrectly named branch is because of repo confusion soz )

Adds a `start-local` and `start-remote` script, and an alias for `yarn start` which gives you the remote, or `config.js` version. Technically the `remote` option can be local too, if you choose to update the config file, but let's ignore that for now.

Currently when running the remote server locally I get this, which is not caused by this PR.. local server was working on Thursday 🤷 

```
ERROR actix_http::h1::dispatcher] stream error: Request parse error: Invalid Header provided
```