### PR TITLE
Remove yarn clean from host package.json

### DIFF
--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -23,7 +23,7 @@
     "start": "webpack-cli serve",
     "start-remote": "webpack-cli serve --env API_HOST='https://demo-open.msupply.org'",
     "start-local": "webpack-cli serve --env API_HOST='http://localhost:8000'",
-    "build": "yarn clean && webpack --env production",
+    "build": "webpack --env production",
     "serve": "serve dist -p 3003",
     "tsc": "tsc --build"
   },

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -12,7 +12,6 @@
     "lint-staged": "^12.3.8",
     "prettier": "^2.3.2",
     "react-refresh": "^0.12.0",
-    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "typescript": "^4.3.5",
     "webpack": "^5.72.0",


### PR DESCRIPTION
closes #64 

as per issue, I messed up a conflict resolution during merge, and here is reason why i removed yarn clean in the first place: https://github.com/openmsupply/open-msupply/commit/cd831cd4b957263f7396a8354b734c95db979cb8

Thanks @mark-prins for noticing here: https://github.com/openmsupply/open-msupply/pull/41/files#r884355521, and i should have tried to build before merging that PR