### PR TITLE
57 sqlite concurrent transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+server/omsupply-database-shm
+server/omsupply-database-wal

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "thiserror",
+ "tokio",
  "util",
  "uuid",
 ]

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.14"
 
 [dev-dependencies]
 actix-rt = "2.6.0"
+tokio = "1.17.0"
 
 [features]
 default = ["sqlite"]

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -23,8 +23,8 @@ thiserror = "1"
 log = "0.4.14"
 
 [dev-dependencies]
+tokio = {version = "1.17.0", features=["time","rt-multi-thread","macros"]}
 actix-rt = "2.6.0"
-tokio = "1.17.0"
 
 [features]
 default = ["sqlite"]

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -1,7 +1,15 @@
-use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::{
+    connection::SimpleConnection,
+    r2d2::{ConnectionManager, Pool},
+    SqliteConnection,
+};
 use serde;
 
 use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
+
+//WAIT up to 5 SECONDS for lock in SQLITE(https://www.sqlite.org/c3ref/busy_timeout.html)
+#[cfg(not(feature = "postgres"))]
+const SQLITE_LOCKWAIT_MS: u32 = 5000;
 
 #[derive(serde::Deserialize, Clone)]
 pub struct DatabaseSettings {
@@ -56,10 +64,64 @@ impl DatabaseSettings {
     }
 }
 
+// feature sqlite
+#[cfg(not(feature = "postgres"))]
+#[derive(Debug)]
+pub struct SqliteConnectionOptions {
+    pub enable_wal: bool,
+    pub enable_foreign_keys: bool,
+    pub busy_timeout_ms: Option<u32>,
+}
+// feature sqlite
+#[cfg(not(feature = "postgres"))]
+impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
+    for SqliteConnectionOptions
+{
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+        (|| {
+            if self.enable_wal {
+                // println!("Adding WAL");
+                let r =
+                    conn.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;");
+                println!("{:?}", r);
+            }
+            if self.enable_foreign_keys {
+                // println!("Adding foreign_keys");
+                let r = conn.batch_execute("PRAGMA foreign_keys = ON;");
+                println!("{:?}", r);
+            }
+            if let Some(d) = self.busy_timeout_ms {
+                // println!("Adding Busy Timeout");
+                let r = conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d));
+                println!("{:?}", r);
+            }
+            Ok(())
+        })()
+        .map_err(diesel::r2d2::Error::QueryError)
+    }
+}
+
+// feature postgres
+#[cfg(feature = "postgres")]
 pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageConnectionManager {
-    // TODO fix connection string for sqlite
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
     let pool = Pool::new(connection_manager).expect("Failed to connect to database");
+    StorageConnectionManager::new(pool)
+}
+
+// feature sqlite
+#[cfg(not(feature = "postgres"))]
+pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageConnectionManager {
+    let connection_manager =
+        ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
+    let pool = Pool::builder()
+        .connection_customizer(Box::new(SqliteConnectionOptions {
+            enable_wal: true,
+            enable_foreign_keys: true,
+            busy_timeout_ms: Some(SQLITE_LOCKWAIT_MS),
+        }))
+        .build(connection_manager)
+        .expect("Failed to connect to database");
     StorageConnectionManager::new(pool)
 }

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -7,7 +7,7 @@ use serde;
 
 use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
 
-//WAIT up to 5 SECONDS for lock in SQLITE(https://www.sqlite.org/c3ref/busy_timeout.html)
+//WAIT up to 5 SECONDS for lock in SQLITE (https://www.sqlite.org/c3ref/busy_timeout.html)
 #[cfg(not(feature = "postgres"))]
 const SQLITE_LOCKWAIT_MS: u32 = 5000;
 
@@ -81,19 +81,19 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         (|| {
             if self.enable_wal {
                 // println!("Adding WAL");
-                let r =
+                let _r =
                     conn.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;");
-                println!("{:?}", r);
+                // println!("{:?}", r);
             }
             if self.enable_foreign_keys {
                 // println!("Adding foreign_keys");
-                let r = conn.batch_execute("PRAGMA foreign_keys = ON;");
-                println!("{:?}", r);
+                let _r = conn.batch_execute("PRAGMA foreign_keys = ON;");
+                // println!("{:?}", r);
             }
             if let Some(d) = self.busy_timeout_ms {
                 // println!("Adding Busy Timeout");
-                let r = conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d));
-                println!("{:?}", r);
+                let _r = conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d));
+                // println!("{:?}", r);
             }
             Ok(())
         })()

--- a/server/repository/src/test_db.rs
+++ b/server/repository/src/test_db.rs
@@ -61,10 +61,10 @@ pub async fn setup(db_settings: &DatabaseSettings) -> StorageConnectionManager {
         ConnectionManager::<DBBackendConnection>::new(&db_settings.connection_string());
     const SQLITE_LOCKWAIT_MS: u32 = 5000; //5 second wait for test lock timeout
     let pool = Pool::builder()
-        //.max_size(1)
+        // .max_size(1)
         .min_idle(Some(1))
         .connection_customizer(Box::new(SqliteConnectionOptions {
-            enable_wal: false,
+            enable_wal: true,
             enable_foreign_keys: true,
             busy_timeout_ms: Some(SQLITE_LOCKWAIT_MS),
         }))


### PR DESCRIPTION
Closes #57 
Bug fix for sqlite's 'two writers upgrade to readers'
Comes with WAL (Write ahead log) which allows more parallel readers.

Note: Slightly different behaviour with Postgres vs Sqlite when there are two threads trying to write.

Not tested on Android yet...