### PR TITLE
Fix language resource path

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -39,7 +39,7 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
             },
             {
               /* options for secondary backend */
-              loadPath: './locales/{{lng}}/{{ns}}.json',
+              loadPath: '/locales/{{lng}}/{{ns}}.json',
             },
           ],
         },

--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -22,6 +22,13 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       : // TODO: change back to a week when things are stable
         60 * minuteInMilliseconds; // 7 * 24 * 60 * minuteInMilliseconds;
 
+    // backend path for loading locale files
+    // electron app: requires a relative path
+    // browser: requires an absolute path
+    const userAgent = navigator.userAgent.toLowerCase();
+    const isElectron = userAgent.indexOf(' electron/') > -1;
+    const loadPath = `${isElectron ? '.' : ''}/locales/{{lng}}/{{ns}}.json`;
+
     i18next
       .use(initReactI18next) // passes i18n down to react-i18next
       .use(Backend)
@@ -39,7 +46,7 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
             },
             {
               /* options for secondary backend */
-              loadPath: '/locales/{{lng}}/{{ns}}.json',
+              loadPath,
             },
           ],
         },

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -23,9 +23,8 @@
     "start": "webpack-cli serve",
     "start-remote": "webpack-cli serve --env API_HOST='https://demo-open.msupply.org'",
     "start-local": "webpack-cli serve --env API_HOST='http://localhost:8000'",
-    "build": "yarn clean && webpack --env production",
+    "build": "webpack --env production",
     "serve": "serve dist -p 3003",
-    "clean": "rimraf ./dist/*",
     "tsc": "tsc --build"
   },
   "dependencies": {

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -25,6 +25,7 @@
     "start-local": "webpack-cli serve --env API_HOST='http://localhost:8000'",
     "build": "yarn clean && webpack --env production",
     "serve": "serve dist -p 3003",
+    "clean": "rimraf ./dist/*",
     "tsc": "tsc --build"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #72 

The cause is [this change](https://github.com/openmsupply/open-msupply/blob/8ea07ec316298c8998f7c11cc6c0285338e3863d/client/packages/common/src/intl/context/IntlContext.tsx#L42) 

I've tested by running locally with `cargo run` and compiling a release build and loading the server-hosted version. Both work fine - so I'm not sure of the reason for the change.