### PR TITLE
Disable deadlock test for sqlite 'in memory'

### DIFF
--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -1189,10 +1189,10 @@ mod repository_test {
             test_db::setup_all("tx_deadlock", MockDataInserts::none()).await;
 
         // Note: this test is disabled when running tests using in 'memory' sqlite.
-        // When running in memory sqlite uses a shared cache and returns an SQLITE_LOCKED response when two threads try to write using the shared case concurrently
+        // When running in memory sqlite uses a shared cache and returns an SQLITE_LOCKED response when two threads try to write using the shared cache concurrently
         // https://sqlite.org/rescode.html#locked
-        // We are relying on busy_timeout handler to manage the SQLITE_BUSY response code in this test and there's no equivellent available for shared cache connections (SQLITE_LOCKED).
-        // If we were to shared cache in production, we'd probably need to use a mutex to protect the database connection.
+        // We are relying on busy_timeout handler to manage the SQLITE_BUSY response code in this test and there's no equivelant available for shared cache connections (SQLITE_LOCKED).
+        // If we were to use shared cache in production, we'd probably need to use a mutex (or similar) to protect the database connection.
 
         /*
             Issue Description...

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -1182,13 +1182,20 @@ mod repository_test {
         assert_eq!(result, Some(true));
     }
 
+    #[cfg(not(feature = "memory"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_tx_deadlock() {
         let (_, _, connection_manager, _) =
             test_db::setup_all("tx_deadlock", MockDataInserts::none()).await;
 
+        // Note: this test is disabled when running tests using in 'memory' sqlite.
+        // When running in memory sqlite uses a shared cache and returns an SQLITE_LOCKED response when two threads try to write using the shared case concurrently
+        // https://sqlite.org/rescode.html#locked
+        // We are relying on busy_timeout handler to manage the SQLITE_BUSY response code in this test and there's no equivellent available for shared cache connections (SQLITE_LOCKED).
+        // If we were to shared cache in production, we'd probably need to use a mutex to protect the database connection.
+
         /*
-            Issue Description..
+            Issue Description...
 
             From https://sqlite.org/forum/info/e4f30c1ed10b1cb5
             Connection A starts as a reader and does some processing.


### PR DESCRIPTION
Closes: #90 
This test is disabled when running tests using in 'memory' sqlite.
When running in memory sqlite uses a shared cache and returns an SQLITE_LOCKED response when two threads try to write using the shared case concurrently
https://sqlite.org/rescode.html#locked
We are relying on busy_timeout handler to manage the SQLITE_BUSY response code in this test and there's no equivalent available for shared cache connections (SQLITE_LOCKED).
If we were to shared cache in production, we'd probably need to use a mutex to protect the database connection.
