### PR TITLE
Improve logging when unable to connect to database

### DIFF
--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -102,39 +102,21 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
 pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageConnectionManager {
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
-    let result = Pool::new(connection_manager);
-    let pool = match result {
-        Ok(pool) => pool,
-        Err(err) => panic!(
-            "Failed to connect to postgres database {} - {}",
-            &settings.database_name, err
-        ),
-    };
+    let pool = Pool::new(connection_manager).expect("Failed to connect to database");
     StorageConnectionManager::new(pool)
 }
 
 // feature sqlite
 #[cfg(not(feature = "postgres"))]
 pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageConnectionManager {
-    use core::panic;
-
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
-    let result = Pool::builder()
+    let pool = Pool::builder()
         .connection_customizer(Box::new(SqliteConnectionOptions {
             enable_wal: true,
             busy_timeout_ms: Some(SQLITE_LOCKWAIT_MS),
         }))
-        .build(connection_manager);
-
-    let pool = match result {
-        Ok(pool) => pool,
-        Err(err) => panic!(
-            "Failed to connect to sqlite database {} - {}",
-            &settings.connection_string(),
-            err
-        ),
-    };
-
+        .build(connection_manager)
+        .expect("Failed to connect to database");
     StorageConnectionManager::new(pool)
 }

--- a/server/server/src/sync/central_data_synchroniser.rs
+++ b/server/server/src/sync/central_data_synchroniser.rs
@@ -14,17 +14,17 @@ use super::{sync_api_v5::CentralSyncRecordV5, SyncImportError};
 
 #[derive(Error, Debug)]
 pub enum CentralSyncError {
-    #[error("Failed to pull central sync records")]
+    #[error("Failed to pull central sync records - {source:?}")]
     PullCentralSyncRecordsError { source: SyncConnectionError },
-    #[error("Failed to update central sync buffer records")]
+    #[error("Failed to update central sync buffer records - {source:?}")]
     UpdateCentralSyncBufferRecordsError { source: RepositoryError },
-    #[error("Failed to get central sync cursor record")]
+    #[error("Failed to get central sync cursor record - {source:?}")]
     GetCentralSyncCursorRecordError { source: RepositoryError },
-    #[error("Failed to get central sync buffer records")]
+    #[error("Failed to get central sync buffer records - {source:?}")]
     GetCentralSyncBufferRecordsError { source: RepositoryError },
-    #[error("Failed to import central sync buffer records")]
+    #[error("Failed to import central sync buffer records - {source:?}")]
     ImportCentralSyncRecordsError { source: SyncImportError },
-    #[error("Failed to remove central sync buffer records")]
+    #[error("Failed to remove central sync buffer records - {source:?}")]
     RemoveCentralSyncBufferRecordsError { source: RepositoryError },
     #[error("Failed to connect to DB - {source:?}")]
     DBConnectionError { source: RepositoryError },

--- a/server/server/src/sync/central_data_synchroniser.rs
+++ b/server/server/src/sync/central_data_synchroniser.rs
@@ -26,7 +26,7 @@ pub enum CentralSyncError {
     ImportCentralSyncRecordsError { source: SyncImportError },
     #[error("Failed to remove central sync buffer records")]
     RemoveCentralSyncBufferRecordsError { source: RepositoryError },
-    #[error("Failed to connect to DB")]
+    #[error("Failed to connect to DB - {source:?}")]
     DBConnectionError { source: RepositoryError },
 }
 


### PR DESCRIPTION
Closes #85 

Now that I've done, this I'm not sure it's needed? The r2d2 errors seem sufficient?

@mark-prins you mentioned this on the demo server. Did you see any r2d2 errors on demo?

Example error with postgres:
```
[2022-06-07T03:15:59Z ERROR r2d2] connection to server at "localhost" (::1), port 5432 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
    connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
    
thread 'main' panicked at 'Failed to connect to postgres database omsupply-database - timed out waiting for connection: connection to server at "localhost" (::1), port 5432 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
```
Example error with sqlite:
```
[2022-06-07T03:23:04Z ERROR r2d2] Unable to open the database file
thread 'main' panicked at 'Failed to connect to sqlite database omsupply-database - timed out waiting for connection: Unable to open the database file',
```