### PR TITLE
97 update output during sync

### DIFF
--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -31,6 +31,7 @@ log = "0.4.14"
 
 [dev-dependencies]
 actix-rt = "2.6.0"
+tokio = {version = "1.17.0", features=["time","rt-multi-thread","macros"]}
 
 [features]
 default = ["sqlite"]


### PR DESCRIPTION
closes #97 

There is zip file in the issue, looks better now

[out.txt.zip](https://github.com/openmsupply/open-msupply/files/8852401/out.txt.zip)

Still quite a few warnings/errors:

* 3 stores ignored, those are system store
* MastListNameJoin foreign key violation (name with id doesn't exist)
* number records (that we don't want to integrate yet, although some requisitions in there, we only handle request_requisition and response_requisition https://github.com/openmsupply/open-msupply/issues/69
* decimal points in item_line : /
* a bunch of name store joins with no name (patients, which are integrating in remote, but queried in translations, it's ok to ignore those, although we should query buffer if we doing this sort of check)
* name store join for system name
* invoice lines linked to stock lines that don't actually exist in central data file
