### PR TITLE
113 document endpoint

### DIFF
--- a/server/graphql/core/src/loader/document.rs
+++ b/server/graphql/core/src/loader/document.rs
@@ -42,9 +42,10 @@ impl Loader<DocumentLoaderInput> for DocumentLoader {
             let result = self.service_provider.document_service.get_documents(
                 &ctx,
                 &store_id,
-                Some(DocumentFilter::new().name(Some(EqualFilter::equal_any(
-                    doc_names.into_iter().collect(),
-                )))),
+                Some(
+                    DocumentFilter::new()
+                        .name(EqualFilter::equal_any(doc_names.into_iter().collect())),
+                ),
             )?;
             for doc in result {
                 out.insert(

--- a/server/graphql/document/src/lib.rs
+++ b/server/graphql/document/src/lib.rs
@@ -9,6 +9,7 @@ use mutations::patient::insert::InsertPatientResponse;
 use mutations::update_document::update_document;
 use mutations::update_document::UpdateDocumentInput;
 use mutations::update_document::UpdateDocumentResponse;
+use types::document::DocumentNode;
 
 mod mutations;
 
@@ -29,6 +30,15 @@ impl DocumentQueries {
         #[graphql(desc = "The document filter")] filter: Option<DocumentFilterInput>,
     ) -> Result<DocumentResponse> {
         documents(ctx, store_id, filter)
+    }
+
+    pub async fn document(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Store id")] store_id: String,
+        #[graphql(desc = "The document name")] name: String,
+    ) -> Result<Option<DocumentNode>> {
+        document(ctx, store_id, name)
     }
 
     pub async fn document_history(

--- a/server/graphql/document/src/queries/document.rs
+++ b/server/graphql/document/src/queries/document.rs
@@ -24,6 +24,32 @@ fn to_domain_filter(f: DocumentFilterInput) -> DocumentFilter {
     }
 }
 
+pub fn document(ctx: &Context<'_>, store_id: String, name: String) -> Result<Option<DocumentNode>> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryDocument,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let context = service_provider.context()?;
+
+    let node = service_provider
+        .document_service
+        .get_documents(
+            &context,
+            &store_id,
+            Some(DocumentFilter::new().name(EqualFilter::equal_to(&name))),
+        )?
+        .into_iter()
+        .map(|document| DocumentNode { document })
+        .next();
+
+    Ok(node)
+}
+
 pub fn documents(
     ctx: &Context<'_>,
     store_id: String,

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -109,8 +109,8 @@ impl DocumentFilter {
         }
     }
 
-    pub fn name(mut self, name: Option<EqualFilter<String>>) -> Self {
-        self.name = name;
+    pub fn name(mut self, name: EqualFilter<String>) -> Self {
+        self.name = Some(name);
         self
     }
 }

--- a/server/service/src/document/document_service.rs
+++ b/server/service/src/document/document_service.rs
@@ -58,7 +58,7 @@ pub trait DocumentServiceTrait: Sync + Send {
         store_id: &str,
         filter: Option<DocumentFilter>,
     ) -> Result<Vec<Document>, RepositoryError> {
-        let filter = filter.map(|mut f| {
+        let filter = filter.or(Some(DocumentFilter::new())).map(|mut f| {
             f.store_id = Some(EqualFilter::equal_to(store_id));
             f
         });


### PR DESCRIPTION
@andreievg did we discuss the return type for single node endpoints? did we plan to update it? Did we got a conclusion? In this PR I return a `Result<Option<DocumentNode>>` so either node is found or not and the remaining DB error is returned as a standard error.

Existing way would be: 
```rust
#[derive(Union)]
pub enum DocumentResponse {
    Error(NodeError),
    Response(DocumentNode),
}
```
 What do you think?

Closes #113