### PR TITLE
139 pull central report records

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -573,10 +573,10 @@ export type EqualFilterNumberInput = {
   notEqualTo?: InputMaybe<Scalars['Int']>;
 };
 
-export type EqualFilterReportCategoryInput = {
-  equalAny?: InputMaybe<Array<ReportCategory>>;
-  equalTo?: InputMaybe<ReportCategory>;
-  notEqualTo?: InputMaybe<ReportCategory>;
+export type EqualFilterReportContextInput = {
+  equalAny?: InputMaybe<Array<ReportContext>>;
+  equalTo?: InputMaybe<ReportContext>;
+  notEqualTo?: InputMaybe<ReportContext>;
 };
 
 export type EqualFilterRequisitionStatusInput = {
@@ -2191,28 +2191,29 @@ export type RefreshTokenErrorInterface = {
 
 export type RefreshTokenResponse = RefreshToken | RefreshTokenError;
 
-export enum ReportCategory {
-  Invoice = 'INVOICE',
-  Requisition = 'REQUISITION',
-  Resource = 'RESOURCE',
-  Stocktake = 'STOCKTAKE'
-}
-
 export type ReportConnector = {
   __typename: 'ReportConnector';
   nodes: Array<ReportNode>;
   totalCount: Scalars['Int'];
 };
 
+export enum ReportContext {
+  InboundShipment = 'INBOUND_SHIPMENT',
+  OutboundShipment = 'OUTBOUND_SHIPMENT',
+  Requisition = 'REQUISITION',
+  Resource = 'RESOURCE',
+  Stocktake = 'STOCKTAKE'
+}
+
 export type ReportFilterInput = {
-  category?: InputMaybe<EqualFilterReportCategoryInput>;
+  context?: InputMaybe<EqualFilterReportContextInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   name?: InputMaybe<SimpleStringFilterInput>;
 };
 
 export type ReportNode = {
   __typename: 'ReportNode';
-  category: ReportCategory;
+  context: ReportContext;
   id: Scalars['String'];
   /** Human readable name of the report */
   name: Scalars['String'];

--- a/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
@@ -6,7 +6,7 @@ import {
   Grid,
   useDetailPanel,
   useTranslation,
-  ReportCategory,
+  ReportContext,
   LoadingButton,
   PrinterIcon,
 } from '@openmsupply-client/common';
@@ -45,7 +45,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           onClick={() => onAddItem(true)}
         />
         <ReportSelector
-          category={ReportCategory.Stocktake}
+          context={ReportContext.Stocktake}
           onClick={printReport}
         >
           <LoadingButton

--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -7,7 +7,7 @@ import {
   useDetailPanel,
   useTranslation,
   PrinterIcon,
-  ReportCategory,
+  ReportContext,
   LoadingButton,
 } from '@openmsupply-client/common';
 import { useInbound } from '../api';
@@ -44,7 +44,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem(true)}
         />
-        <ReportSelector category={ReportCategory.Invoice} onClick={printReport}>
+        <ReportSelector context={ReportContext.InboundShipment} onClick={printReport}>
           <LoadingButton
             variant="outlined"
             startIcon={<PrinterIcon />}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
@@ -7,7 +7,7 @@ import {
   useDetailPanel,
   useTranslation,
   LoadingButton,
-  ReportCategory,
+  ReportContext,
   PrinterIcon,
 } from '@openmsupply-client/common';
 import { useOutbound } from '../api';
@@ -44,7 +44,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem()}
         />
-        <ReportSelector category={ReportCategory.Invoice} onClick={printReport}>
+        <ReportSelector context={ReportContext.OutboundShipment} onClick={printReport}>
           <LoadingButton
             variant="outlined"
             startIcon={<PrinterIcon />}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -8,7 +8,7 @@ import {
   useTranslation,
   PrinterIcon,
   LoadingButton,
-  ReportCategory,
+  ReportContext,
 } from '@openmsupply-client/common';
 import {
   ReportRowFragment,
@@ -52,7 +52,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <UseSuggestedQuantityButton />
 
         <ReportSelector
-          category={ReportCategory.Requisition}
+          context={ReportContext.Requisition}
           onClick={printReport}
         >
           <LoadingButton

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -4,7 +4,7 @@ import {
   Grid,
   LoadingButton,
   PrinterIcon,
-  ReportCategory,
+  ReportContext,
   useDetailPanel,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -34,7 +34,7 @@ export const AppBarButtonsComponent = () => {
         <CreateShipmentButton />
         <SupplyRequestedQuantityButton />
         <ReportSelector
-          category={ReportCategory.Requisition}
+          context={ReportContext.Requisition}
           onClick={printReport}
         >
           <LoadingButton

--- a/client/packages/system/src/Report/api/hooks/document/useReports.ts
+++ b/client/packages/system/src/Report/api/hooks/document/useReports.ts
@@ -1,9 +1,9 @@
-import { useQuery, ReportCategory } from '@openmsupply-client/common';
+import { useQuery, ReportContext } from '@openmsupply-client/common';
 import { useReportApi } from '../utils/useReportApi';
 
-export const useReports = (category?: ReportCategory) => {
+export const useReports = (context?: ReportContext) => {
   const api = useReportApi();
-  const filterBy = category ? { category: { equalTo: category } } : null;
+  const filterBy = context ? { context: { equalTo: context } } : null;
   const queryParams = {
     filterBy,
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },

--- a/client/packages/system/src/Report/api/operations.generated.ts
+++ b/client/packages/system/src/Report/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type ReportRowFragment = { __typename: 'ReportNode', category: Types.ReportCategory, id: string, name: string };
+export type ReportRowFragment = { __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string };
 
 export type ReportsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -14,7 +14,7 @@ export type ReportsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ReportsQuery = { __typename: 'FullQuery', reports: { __typename: 'ReportConnector', totalCount: number, nodes: Array<{ __typename: 'ReportNode', category: Types.ReportCategory, id: string, name: string }> } };
+export type ReportsQuery = { __typename: 'FullQuery', reports: { __typename: 'ReportConnector', totalCount: number, nodes: Array<{ __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string }> } };
 
 export type PrintReportQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -28,7 +28,7 @@ export type PrintReportQuery = { __typename: 'FullQuery', printReport: { __typen
 
 export const ReportRowFragmentDoc = gql`
     fragment ReportRow on ReportNode {
-  category
+  context
   id
   name
 }

--- a/client/packages/system/src/Report/api/operations.graphql
+++ b/client/packages/system/src/Report/api/operations.graphql
@@ -1,5 +1,5 @@
 fragment ReportRow on ReportNode {
-  category
+  context
   id
   name
 }

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -1,5 +1,5 @@
 import React, { FC, PropsWithChildren } from 'react';
-import { Box, ReportCategory, Typography } from '@openmsupply-client/common';
+import { Box, ReportContext, Typography } from '@openmsupply-client/common';
 import { AlertIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 import {
@@ -11,7 +11,7 @@ import {
 import { ReportRowFragment, useReport } from '../api';
 
 interface ReportSelectorProps {
-  category?: ReportCategory;
+  context?: ReportContext;
   onClick: (report: ReportRowFragment) => void;
 }
 
@@ -34,12 +34,12 @@ const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
 };
 
 export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
-  category,
+  context,
   children,
   onClick,
 }) => {
   const { hide, PaperClickPopover } = usePaperClickPopover();
-  const { data, isLoading } = useReport.document.list(category);
+  const { data, isLoading } = useReport.document.list(context);
   const t = useTranslation('app');
 
   const reportButtons = data?.nodes?.map(report => (

--- a/server/graphql/reports/src/reports.rs
+++ b/server/graphql/reports/src/reports.rs
@@ -8,7 +8,7 @@ use graphql_core::{
 };
 use graphql_core::{map_filter, ContextExt};
 use repository::{
-    EqualFilter, PaginationOption, ReportCategory as ReportCategoryDomain, ReportFilter, ReportRow,
+    EqualFilter, PaginationOption, ReportContext as ReportContextDomain, ReportFilter, ReportRow,
     ReportSort, ReportSortField, SimpleStringFilter,
 };
 use service::auth::{Resource, ResourceAccessRequest};
@@ -31,8 +31,9 @@ pub struct ReportSortInput {
 
 #[derive(Debug, Enum, Copy, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ReportCategory {
-    Invoice,
+pub enum ReportContext {
+    InboundShipment,
+    OutboundShipment,
     Requisition,
     Stocktake,
     Resource,
@@ -40,9 +41,9 @@ pub enum ReportCategory {
 
 #[derive(InputObject, Clone)]
 pub struct EqualFilterReportCategoryInput {
-    pub equal_to: Option<ReportCategory>,
-    pub equal_any: Option<Vec<ReportCategory>>,
-    pub not_equal_to: Option<ReportCategory>,
+    pub equal_to: Option<ReportContext>,
+    pub equal_any: Option<Vec<ReportContext>>,
+    pub not_equal_to: Option<ReportContext>,
 }
 
 #[derive(InputObject, Clone)]
@@ -78,12 +79,13 @@ impl ReportNode {
     pub async fn name(&self) -> &str {
         &self.row.name
     }
-    pub async fn category(&self) -> ReportCategory {
+    pub async fn context(&self) -> ReportContext {
         match self.row.context {
-            ReportCategoryDomain::Invoice => ReportCategory::Invoice,
-            ReportCategoryDomain::Requisition => ReportCategory::Requisition,
-            ReportCategoryDomain::Stocktake => ReportCategory::Stocktake,
-            ReportCategoryDomain::Resource => ReportCategory::Resource,
+            ReportContextDomain::InboundShipment => ReportContext::InboundShipment,
+            ReportContextDomain::OutboundShipment => ReportContext::OutboundShipment,
+            ReportContextDomain::Requisition => ReportContext::Requisition,
+            ReportContextDomain::Stocktake => ReportContext::Stocktake,
+            ReportContextDomain::Resource => ReportContext::Resource,
         }
     }
 }
@@ -130,7 +132,7 @@ impl ReportFilterInput {
             r#type: None,
             category: self
                 .category
-                .map(|t| map_filter!(t, ReportCategory::to_domain)),
+                .map(|t| map_filter!(t, ReportContext::to_domain)),
         }
     }
 }
@@ -148,13 +150,14 @@ impl ReportSortInput {
     }
 }
 
-impl ReportCategory {
-    pub fn to_domain(self) -> ReportCategoryDomain {
+impl ReportContext {
+    pub fn to_domain(self) -> ReportContextDomain {
         match self {
-            ReportCategory::Invoice => ReportCategoryDomain::Invoice,
-            ReportCategory::Requisition => ReportCategoryDomain::Requisition,
-            ReportCategory::Stocktake => ReportCategoryDomain::Stocktake,
-            ReportCategory::Resource => ReportCategoryDomain::Resource,
+            ReportContext::InboundShipment => ReportContextDomain::InboundShipment,
+            ReportContext::OutboundShipment => ReportContextDomain::OutboundShipment,
+            ReportContext::Requisition => ReportContextDomain::Requisition,
+            ReportContext::Stocktake => ReportContextDomain::Stocktake,
+            ReportContext::Resource => ReportContextDomain::Resource,
         }
     }
 }

--- a/server/graphql/reports/src/reports.rs
+++ b/server/graphql/reports/src/reports.rs
@@ -40,7 +40,7 @@ pub enum ReportContext {
 }
 
 #[derive(InputObject, Clone)]
-pub struct EqualFilterReportCategoryInput {
+pub struct EqualFilterReportContextInput {
     pub equal_to: Option<ReportContext>,
     pub equal_any: Option<Vec<ReportContext>>,
     pub not_equal_to: Option<ReportContext>,
@@ -50,7 +50,7 @@ pub struct EqualFilterReportCategoryInput {
 pub struct ReportFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub name: Option<SimpleStringFilterInput>,
-    pub category: Option<EqualFilterReportCategoryInput>,
+    pub context: Option<EqualFilterReportContextInput>,
 }
 
 #[derive(Union)]
@@ -130,8 +130,8 @@ impl ReportFilterInput {
             id: self.id.map(EqualFilter::from),
             name: self.name.map(SimpleStringFilter::from),
             r#type: None,
-            category: self
-                .category
+            context: self
+                .context
                 .map(|t| map_filter!(t, ReportContext::to_domain)),
         }
     }

--- a/server/repository/migrations/postgres/2022-03-15T10-00_report_table/up.sql
+++ b/server/repository/migrations/postgres/2022-03-15T10-00_report_table/up.sql
@@ -1,9 +1,13 @@
 CREATE TYPE report_type AS ENUM (
-    'OM_REPORT'
+    'OM_SUPPLY'
 );
 
 CREATE TYPE category_type AS ENUM (
-    'INVOICE', 'REQUISITION', 'STOCKTAKE', 'RESOURCE'
+    'INBOUND_SHIPMENT',
+    'OUTBOUND_SHIPMENT',
+    'REQUISITION',
+    'STOCKTAKE',
+    'RESOURCE'
 );
 
 
@@ -11,6 +15,7 @@ CREATE TABLE report (
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
     type report_type NOT NULL,
-    data TEXT NOT NULL,
-    context category_type NOT NULL
+    template TEXT NOT NULL,
+    context category_type NOT NULL,
+    comment TEXT
 )

--- a/server/repository/migrations/postgres/2022-03-15T10-00_report_table/up.sql
+++ b/server/repository/migrations/postgres/2022-03-15T10-00_report_table/up.sql
@@ -2,7 +2,7 @@ CREATE TYPE report_type AS ENUM (
     'OM_SUPPLY'
 );
 
-CREATE TYPE category_type AS ENUM (
+CREATE TYPE context_type AS ENUM (
     'INBOUND_SHIPMENT',
     'OUTBOUND_SHIPMENT',
     'REQUISITION',
@@ -16,6 +16,6 @@ CREATE TABLE report (
     name TEXT NOT NULL,
     type report_type NOT NULL,
     template TEXT NOT NULL,
-    context category_type NOT NULL,
+    context context_type NOT NULL,
     comment TEXT
 )

--- a/server/repository/migrations/sqlite/2022-03-15T10-00_report_table/up.sql
+++ b/server/repository/migrations/sqlite/2022-03-15T10-00_report_table/up.sql
@@ -1,7 +1,14 @@
 CREATE TABLE report (
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
-    type TEXT CHECK (type IN ('OM_REPORT')) NOT NULL,
-    data TEXT NOT NULL,
-    context TEXT CHECK (context IN ('INVOICE', 'REQUISITION', 'STOCKTAKE', "RESOURCE")) NOT NULL
+    type TEXT CHECK (type IN ('OM_SUPPLY')) NOT NULL,
+    template TEXT NOT NULL,
+    context TEXT CHECK (context IN (
+        'INBOUND_SHIPMENT',
+        'OUTBOUND_SHIPMENT',
+        'REQUISITION',
+        'STOCKTAKE',
+        'RESOURCE'
+    )) NOT NULL,
+    comment TEXT
 )

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -133,6 +133,7 @@ pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageCon
 mod database_setting_test {
     use super::DatabaseSettings;
 
+    #[allow(dead_code)]
     pub fn empty_db_settings_with_init_sql(init_sql: Option<String>) -> DatabaseSettings {
         DatabaseSettings {
             username: "".to_string(),

--- a/server/repository/src/db_diesel/report.rs
+++ b/server/repository/src/db_diesel/report.rs
@@ -1,6 +1,6 @@
 use super::{
     report_row::{report, report::dsl as report_dsl},
-    ReportCategory, ReportRow, ReportType, StorageConnection,
+    ReportContext, ReportRow, ReportType, StorageConnection,
 };
 
 use crate::diesel_macros::{apply_equal_filter, apply_sort_no_case};
@@ -17,7 +17,7 @@ pub struct ReportFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<SimpleStringFilter>,
     pub r#type: Option<EqualFilter<ReportType>>,
-    pub category: Option<EqualFilter<ReportCategory>>,
+    pub category: Option<EqualFilter<ReportContext>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -48,7 +48,7 @@ impl ReportFilter {
         self
     }
 
-    pub fn category(mut self, filter: EqualFilter<ReportCategory>) -> Self {
+    pub fn category(mut self, filter: EqualFilter<ReportContext>) -> Self {
         self.category = Some(filter);
         self
     }

--- a/server/repository/src/db_diesel/report.rs
+++ b/server/repository/src/db_diesel/report.rs
@@ -17,7 +17,7 @@ pub struct ReportFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<SimpleStringFilter>,
     pub r#type: Option<EqualFilter<ReportType>>,
-    pub category: Option<EqualFilter<ReportContext>>,
+    pub context: Option<EqualFilter<ReportContext>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -48,8 +48,8 @@ impl ReportFilter {
         self
     }
 
-    pub fn category(mut self, filter: EqualFilter<ReportContext>) -> Self {
-        self.category = Some(filter);
+    pub fn context(mut self, filter: EqualFilter<ReportContext>) -> Self {
+        self.context = Some(filter);
         self
     }
 }
@@ -137,13 +137,13 @@ fn create_filtered_query(filter: Option<ReportFilter>) -> BoxedStoreQuery {
             id,
             name,
             r#type,
-            category,
+            context,
         } = f;
 
         apply_equal_filter!(query, id, report_dsl::id);
         apply_simple_string_filter!(query, name, report_dsl::name);
         apply_equal_filter!(query, r#type, report_dsl::type_);
-        apply_equal_filter!(query, category, report_dsl::context);
+        apply_equal_filter!(query, context, report_dsl::context);
     }
 
     query

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -43,7 +43,7 @@ pub struct ReportRow {
     #[column_name = "type_"]
     pub r#type: ReportType,
     pub template: String,
-    /// Used to store the report category
+    /// Used to store the report context
     pub context: ReportContext,
     pub comment: Option<String>,
 }

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -9,13 +9,14 @@ use diesel_derive_enum::DbEnum;
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum ReportType {
-    OmReport,
+    OmSupply,
 }
 
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
-pub enum ReportCategory {
-    Invoice,
+pub enum ReportContext {
+    InboundShipment,
+    OutboundShipment,
     Requisition,
     Stocktake,
     /// Not an actual report but a resource entry used by other reports, e.g. to provide footers or
@@ -28,8 +29,9 @@ table! {
       id -> Text,
       name -> Text,
       #[sql_name = "type"] type_ -> crate::db_diesel::report_row::ReportTypeMapping,
-      data -> Text,
-      context ->  crate::db_diesel::report_row::ReportCategoryMapping,
+      template -> Text,
+      context -> crate::db_diesel::report_row::ReportContextMapping,
+      comment -> Nullable<Text>,
   }
 }
 
@@ -40,9 +42,10 @@ pub struct ReportRow {
     pub name: String,
     #[column_name = "type_"]
     pub r#type: ReportType,
-    pub data: String,
+    pub template: String,
     /// Used to store the report category
-    pub context: ReportCategory,
+    pub context: ReportContext,
+    pub comment: Option<String>,
 }
 
 pub struct ReportRowRepository<'a> {

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -42,6 +42,7 @@ pub struct ReportRow {
     pub name: String,
     #[column_name = "type_"]
     pub r#type: ReportType,
+    /// The template format depends on the report type
     pub template: String,
     /// Used to store the report context
     pub context: ReportContext,

--- a/server/server/src/sync/translation_central/report.rs
+++ b/server/server/src/sync/translation_central/report.rs
@@ -58,7 +58,7 @@ impl CentralPushTranslation for ReportTranslation {
 
         let data = serde_json::from_str::<LegacyReportRow>(&sync_record.data)?;
 
-        let t = match data.editor {
+        let r#type = match data.editor {
             LegacyReportEditor::OmSupply => ReportType::OmSupply,
             LegacyReportEditor::Others => return Ok(None),
         };
@@ -72,7 +72,7 @@ impl CentralPushTranslation for ReportTranslation {
         Ok(Some(IntegrationUpsertRecord::Report(ReportRow {
             id: data.id.to_string(),
             name: data.report_name.to_string(),
-            r#type: t,
+            r#type,
             template: data.template,
             context,
             comment: data.comment,

--- a/server/server/src/sync/translation_central/report.rs
+++ b/server/server/src/sync/translation_central/report.rs
@@ -1,0 +1,109 @@
+use crate::sync::{
+    sync_serde::empty_str_as_option, translation_central::TRANSLATION_RECORD_REPORT,
+};
+use repository::{CentralSyncBufferRow, ReportContext, ReportRow, ReportType};
+
+use serde::{Deserialize, Serialize};
+
+use super::{CentralPushTranslation, IntegrationUpsertRecord};
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub enum LegacyReportEditor {
+    #[serde(rename = "omsupply")]
+    OmSupply,
+    #[serde(other)]
+    Others,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub enum LegacyReportContext {
+    #[serde(rename = "Customer Invoice")]
+    CustomerInvoice,
+    #[serde(rename = "Supplier Invoice")]
+    SupplierInvoice,
+    #[serde(rename = "Requisition")]
+    Requisition,
+    #[serde(rename = "Stock Take")]
+    Stocktake,
+
+    #[serde(other)]
+    Others,
+}
+
+#[allow(non_snake_case)]
+#[derive(Deserialize, Serialize)]
+pub struct LegacyReportRow {
+    #[serde(rename = "ID")]
+    pub id: String,
+    pub report_name: String,
+    pub editor: LegacyReportEditor,
+    pub context: LegacyReportContext,
+    pub template: String,
+
+    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(rename = "Comment")]
+    pub comment: Option<String>,
+}
+
+pub struct ReportTranslation {}
+impl CentralPushTranslation for ReportTranslation {
+    fn try_translate(
+        &self,
+        sync_record: &CentralSyncBufferRow,
+    ) -> Result<Option<IntegrationUpsertRecord>, anyhow::Error> {
+        let table_name = TRANSLATION_RECORD_REPORT;
+        if sync_record.table_name != table_name {
+            return Ok(None);
+        }
+
+        let data = serde_json::from_str::<LegacyReportRow>(&sync_record.data)?;
+
+        let t = match data.editor {
+            LegacyReportEditor::OmSupply => ReportType::OmSupply,
+            LegacyReportEditor::Others => return Ok(None),
+        };
+        let context = match data.context {
+            LegacyReportContext::CustomerInvoice => ReportContext::OutboundShipment,
+            LegacyReportContext::SupplierInvoice => ReportContext::InboundShipment,
+            LegacyReportContext::Requisition => ReportContext::Requisition,
+            LegacyReportContext::Stocktake => ReportContext::Stocktake,
+            LegacyReportContext::Others => return Ok(None),
+        };
+        Ok(Some(IntegrationUpsertRecord::Report(ReportRow {
+            id: data.id.to_string(),
+            name: data.report_name.to_string(),
+            r#type: t,
+            template: data.template,
+            context,
+            comment: data.comment,
+        })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CentralPushTranslation, ReportTranslation};
+    use crate::sync::translation_central::{
+        test_data::{report::get_test_report_records, TestSyncDataRecord},
+        IntegrationUpsertRecord,
+    };
+
+    #[test]
+    fn test_report_translation() {
+        for record in get_test_report_records() {
+            match record.translated_record {
+                TestSyncDataRecord::Report(translated_record) => {
+                    assert_eq!(
+                        ReportTranslation {}
+                            .try_translate(&record.central_sync_buffer_row)
+                            .unwrap(),
+                        translated_record.map(|r| (IntegrationUpsertRecord::Report(r))),
+                        "{}",
+                        record.identifier
+                    )
+                }
+                _ => panic!("Testing wrong record type {:#?}", record.translated_record),
+            }
+        }
+    }
+}

--- a/server/server/src/sync/translation_central/test_data/mod.rs
+++ b/server/server/src/sync/translation_central/test_data/mod.rs
@@ -3,14 +3,16 @@ pub mod master_list;
 pub mod master_list_line;
 pub mod master_list_name_join;
 pub mod name;
+pub mod report;
 pub mod store;
 pub mod unit;
 
 use repository::{
     CentralSyncBufferRow, ItemRow, ItemRowRepository, MasterListLineRow,
     MasterListLineRowRepository, MasterListNameJoinRepository, MasterListNameJoinRow,
-    MasterListRow, MasterListRowRepository, NameRow, NameRowRepository, RepositoryError,
-    StorageConnection, StoreRow, StoreRowRepository, UnitRow, UnitRowRepository,
+    MasterListRow, MasterListRowRepository, NameRow, NameRowRepository, ReportRow,
+    ReportRowRepository, RepositoryError, StorageConnection, StoreRow, StoreRowRepository, UnitRow,
+    UnitRowRepository,
 };
 
 #[allow(dead_code)]
@@ -23,6 +25,7 @@ pub enum TestSyncDataRecord {
     MasterList(Option<MasterListRow>),
     MasterListLine(Option<MasterListLineRow>),
     MasterListNameJoin(Option<MasterListNameJoinRow>),
+    Report(Option<ReportRow>),
 }
 #[allow(dead_code)]
 #[derive(Clone)]
@@ -123,6 +126,12 @@ pub async fn check_records_against_database(
                     from_option_to_db_result(comparison_record)
                 )
             }
+            TestSyncDataRecord::Report(comparison_record) => assert_eq!(
+                ReportRowRepository::new(&connection)
+                    .find_one_by_id(&record.central_sync_buffer_row.record_id)
+                    .and_then(|v| Ok(v.unwrap())),
+                from_option_to_db_result(comparison_record)
+            ),
         }
     }
 }

--- a/server/server/src/sync/translation_central/test_data/report.rs
+++ b/server/server/src/sync/translation_central/test_data/report.rs
@@ -1,0 +1,47 @@
+use crate::sync::translation_central::{
+    test_data::{TestSyncDataRecord, TestSyncRecord},
+    TRANSLATION_RECORD_REPORT,
+};
+use repository::{CentralSyncBufferRow, ReportContext, ReportRow, ReportType};
+
+const REPORT_1: (&'static str, &'static str) = (
+    "76B6C424E1935C4DAF36A7A8F451FE72",
+    r#"{
+        "ID": "76B6C424E1935C4DAF36A7A8F451FE72",
+        "report_name": "Test",
+        "report_blob": "blob",
+        "permission_ID": "",
+        "last_updated": "0000-00-00",
+        "type": "cus",
+        "user_created_ID": "0763E2E3053D4C478E1E6B6B03FEC207",
+        "Custom_name": "Test",
+        "Comment": "Test comment",
+        "default": false,
+        "context": "Stock Take",
+        "editor": "omsupply",
+        "orientation": "",
+        "disabled": false,
+        "template": "template data"
+    }"#,
+);
+
+#[allow(dead_code)]
+pub fn get_test_report_records() -> Vec<TestSyncRecord> {
+    vec![TestSyncRecord {
+        translated_record: TestSyncDataRecord::Report(Some(ReportRow {
+            id: "76B6C424E1935C4DAF36A7A8F451FE72".to_string(),
+            name: "Test".to_string(),
+            r#type: ReportType::OmSupply,
+            template: "template data".to_string(),
+            context: ReportContext::Stocktake,
+            comment: Some("Test comment".to_string()),
+        })),
+        identifier: "REPORT_1",
+        central_sync_buffer_row: CentralSyncBufferRow {
+            id: 600,
+            table_name: TRANSLATION_RECORD_REPORT.to_owned(),
+            record_id: REPORT_1.0.to_owned(),
+            data: REPORT_1.1.to_owned(),
+        },
+    }]
+}

--- a/server/service/src/report/dummy_reports.rs
+++ b/server/service/src/report/dummy_reports.rs
@@ -13,7 +13,7 @@ pub struct DummyReport {
     id: String,
     name: String,
     report: ReportDefinition,
-    category: ReportContext,
+    context: ReportContext,
 }
 
 pub fn invoice_report() -> DummyReport {
@@ -57,7 +57,7 @@ pub fn invoice_report() -> DummyReport {
         id: "dummy_report_invoice".to_string(),
         name: "Dummy invoice report".to_string(),
         report,
-        category: ReportContext::InboundShipment,
+        context: ReportContext::InboundShipment,
     }
 }
 
@@ -102,7 +102,7 @@ pub fn stocktake_report() -> DummyReport {
         id: "dummy_report_stocktake".to_string(),
         name: "Dummy stocktake report".to_string(),
         report,
-        category: ReportContext::Stocktake,
+        context: ReportContext::Stocktake,
     }
 }
 
@@ -147,7 +147,7 @@ pub fn requisition_report() -> DummyReport {
         id: "dummy_report_requisition".to_string(),
         name: "Dummy requisition report".to_string(),
         report,
-        category: ReportContext::Requisition,
+        context: ReportContext::Requisition,
     }
 }
 
@@ -159,7 +159,7 @@ pub fn insert_dummy_reports(connection: &StorageConnection) -> Result<(), Reposi
             name: report.name,
             r#type: ReportType::OmSupply,
             template: serde_json::to_string(&report.report).unwrap(),
-            context: report.category,
+            context: report.context,
             comment: None,
         };
         ReportRowRepository::new(connection).upsert_one(&row)?;

--- a/server/service/src/report/dummy_reports.rs
+++ b/server/service/src/report/dummy_reports.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use repository::{
-    ReportCategory, ReportRow, ReportType,
+    ReportContext, ReportRow, ReportType,
     ReportRowRepository, RepositoryError, StorageConnection,
 };
 
@@ -13,7 +13,7 @@ pub struct DummyReport {
     id: String,
     name: String,
     report: ReportDefinition,
-    category: ReportCategory,
+    category: ReportContext,
 }
 
 pub fn invoice_report() -> DummyReport {
@@ -57,7 +57,7 @@ pub fn invoice_report() -> DummyReport {
         id: "dummy_report_invoice".to_string(),
         name: "Dummy invoice report".to_string(),
         report,
-        category: ReportCategory::Invoice,
+        category: ReportContext::InboundShipment,
     }
 }
 
@@ -102,7 +102,7 @@ pub fn stocktake_report() -> DummyReport {
         id: "dummy_report_stocktake".to_string(),
         name: "Dummy stocktake report".to_string(),
         report,
-        category: ReportCategory::Stocktake,
+        category: ReportContext::Stocktake,
     }
 }
 
@@ -147,7 +147,7 @@ pub fn requisition_report() -> DummyReport {
         id: "dummy_report_requisition".to_string(),
         name: "Dummy requisition report".to_string(),
         report,
-        category: ReportCategory::Requisition,
+        category: ReportContext::Requisition,
     }
 }
 
@@ -157,9 +157,10 @@ pub fn insert_dummy_reports(connection: &StorageConnection) -> Result<(), Reposi
         let row = ReportRow {
             id: report.id,
             name: report.name,
-            r#type: ReportType::OmReport,
-            data: serde_json::to_string(&report.report).unwrap(),
+            r#type: ReportType::OmSupply,
+            template: serde_json::to_string(&report.report).unwrap(),
             context: report.category,
+            comment: None,
         };
         ReportRowRepository::new(connection).upsert_one(&row)?;
     }

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -261,7 +261,7 @@ fn query_reports(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let filter = filter
         .unwrap_or(ReportFilter::new())
-        .r#type(ReportType::OmReport.equal_to());
+        .r#type(ReportType::OmSupply.equal_to());
     Ok(repo.query(pagination, Some(filter.clone()), sort)?)
 }
 
@@ -471,7 +471,7 @@ fn load_report_definition(
             })
         }
     };
-    let def = serde_json::from_str::<ReportDefinition>(&row.data).map_err(|err| {
+    let def = serde_json::from_str::<ReportDefinition>(&row.template).map_err(|err| {
         ReportError::InvalidReportDefinition(format!("Can't parse report: {}", err))
     })?;
     Ok((row.name, def))
@@ -533,7 +533,7 @@ mod report_service_test {
     use std::collections::HashMap;
 
     use repository::{
-        mock::MockDataInserts, test_db::setup_all, ReportCategory, ReportRow, ReportRowRepository,
+        mock::MockDataInserts, test_db::setup_all, ReportContext, ReportRow, ReportRowRepository,
         ReportType,
     };
 
@@ -598,17 +598,19 @@ mod report_service_test {
         repo.upsert_one(&ReportRow {
             id: "report_1".to_string(),
             name: "Report 1".to_string(),
-            r#type: ReportType::OmReport,
-            data: serde_json::to_string(&report_1).unwrap(),
-            context: ReportCategory::Invoice,
+            r#type: ReportType::OmSupply,
+            template: serde_json::to_string(&report_1).unwrap(),
+            context: ReportContext::InboundShipment,
+            comment: None,
         })
         .unwrap();
         repo.upsert_one(&ReportRow {
             id: "report_base_1".to_string(),
             name: "Report base 1".to_string(),
-            r#type: ReportType::OmReport,
-            data: serde_json::to_string(&report_base_1).unwrap(),
-            context: ReportCategory::Resource,
+            r#type: ReportType::OmSupply,
+            template: serde_json::to_string(&report_base_1).unwrap(),
+            context: ReportContext::Resource,
+            comment: None,
         })
         .unwrap();
 


### PR DESCRIPTION
- Pull reports from central server
- Better match column names from existing report table (category -> context)
- Rename category -> context in API and FE / update schema
- Split Invoice context into Inbound and OutboundShipment

Closes #139 