### PR TITLE
Add children node to the document registry node

### DIFF
--- a/server/graphql/core/src/loader/document_registry.rs
+++ b/server/graphql/core/src/loader/document_registry.rs
@@ -1,0 +1,38 @@
+use repository::{DocumentRegistry, RepositoryError};
+
+use actix_web::web::Data;
+use async_graphql::dataloader::*;
+use async_graphql::*;
+use service::service_provider::ServiceProvider;
+use std::collections::HashMap;
+
+pub struct DocumentRegistryChildrenLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<String> for DocumentRegistryChildrenLoader {
+    type Value = Vec<DocumentRegistry>;
+    type Error = RepositoryError;
+
+    async fn load(&self, entries: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let ctx = self.service_provider.context()?;
+
+        let children = self
+            .service_provider
+            .document_registry_service
+            .get_children(&ctx, entries)?;
+
+        let mut out = HashMap::new();
+        for child in children {
+            let parent_id = child.parent_id.clone().ok_or(RepositoryError::DBError {
+                msg: "Error in registry children query".to_string(),
+                extra: "".to_string(),
+            })?;
+            let entry = out.entry(parent_id).or_insert(vec![]);
+            entry.push(child);
+        }
+
+        Ok(out)
+    }
+}

--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -195,6 +195,13 @@ pub async fn get_loaders(
         async_std::task::spawn,
     );
 
+    let doc_registry_children_loader = DataLoader::new(
+        DocumentRegistryChildrenLoader {
+            service_provider: service_provider.clone(),
+        },
+        async_std::task::spawn,
+    );
+
     loaders.insert(item_loader);
     loaders.insert(name_by_id_loader);
     loaders.insert(store_by_id_loader);
@@ -219,6 +226,7 @@ pub async fn get_loaders(
     loaders.insert(name_row_loader);
     loaders.insert(document_loader);
     loaders.insert(schema_loader);
+    loaders.insert(doc_registry_children_loader);
 
     loaders
 }

--- a/server/graphql/core/src/loader/mod.rs
+++ b/server/graphql/core/src/loader/mod.rs
@@ -1,4 +1,5 @@
 mod document;
+mod document_registry;
 mod invoice;
 mod invoice_line;
 mod item;
@@ -20,6 +21,7 @@ mod user;
 use std::{collections::HashSet, hash::Hasher};
 
 pub use document::*;
+pub use document_registry::*;
 pub use invoice::*;
 pub use invoice_line::*;
 pub use item::ItemLoader;

--- a/server/graphql/document/src/queries/document_registry.rs
+++ b/server/graphql/document/src/queries/document_registry.rs
@@ -3,11 +3,8 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
+use service::auth::{Resource, ResourceAccessRequest};
 use service::usize_to_u32;
-use service::{
-    auth::{Resource, ResourceAccessRequest},
-    document::document_registry::DocumentRegistryError,
-};
 
 use crate::types::document_registry::{DocumentRegistryConnector, DocumentRegistryNode};
 
@@ -32,16 +29,8 @@ pub fn document_registry(ctx: &Context<'_>) -> Result<DocumentRegistryResponse> 
         .document_registry_service
         .get_entries(&context)
         .map_err(|err| {
-            let formated_err = format! {"{:?}", err};
-            let error = match err {
-                DocumentRegistryError::InternalError(_) => {
-                    StandardGraphqlError::InternalError(formated_err)
-                }
-                DocumentRegistryError::RepositoryError(_) => {
-                    StandardGraphqlError::InternalError(formated_err)
-                }
-            };
-            error.extend()
+            let formatted_err = format! {"{:?}", err};
+            StandardGraphqlError::InternalError(formatted_err).extend()
         })?;
     Ok(DocumentRegistryResponse::Response(
         DocumentRegistryConnector {

--- a/server/repository/src/db_diesel/document_registry.rs
+++ b/server/repository/src/db_diesel/document_registry.rs
@@ -35,7 +35,7 @@ pub struct DocumentRegistryRepository<'a> {
     connection: &'a StorageConnection,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct DocumentRegistry {
     pub id: String,
     pub parent_id: Option<String>,


### PR DESCRIPTION
For example, this makes it convenient to get all encounter types for a
given program.

Also simplify the query error type.

#32 