### PR TITLE
Save machine UUID

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2740,6 +2740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "machine-uid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1595709b0a7386bcd56ba34d250d626e5503917d05d32cdccddcd68603e212"
+dependencies = [
+ "winreg 0.6.2",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4078,7 @@ dependencies = [
  "httpmock",
  "local-ip-address",
  "log 0.4.16",
+ "machine-uid",
  "mime_guess",
  "openssl",
  "rand 0.8.5",

--- a/server/configuration/base.yaml
+++ b/server/configuration/base.yaml
@@ -7,6 +7,7 @@ server:
       https://demo-open.msupply.org,
       http://localhost:8000,
     ] # Used to set the allowed Origin in Cross Origin Requst Security
+  base_dir: "app_data"
 database:
   host: "localhost"
   port: 5432

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -47,6 +47,7 @@ mime_guess = "2.0.4"
 local-ip-address = { version = "0.4.4",  optional = true }
 simple-dns = "0.4.6"
 simple-mdns = "0.3.9"
+machine-uid = "0.2.0"
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -88,7 +88,7 @@ async fn run_stage0(
     {
         service_provider
             .app_data_service
-            .set_hardware_id(machine_uid::get().expect("Failed to generate hardware UID"))?;
+            .set_hardware_id(machine_uid::get().expect("Failed to query OS for hardware id"))?;
     }
 
     let service_provider_data = Data::new(service_provider);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate machine_uid;
 use crate::{
     certs::Certificates, configuration::get_or_create_token_secret, cors::cors_policy,
     serve_frontend::config_server_frontend, static_files::config_static_files,
@@ -26,7 +27,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio::sync::{oneshot, Mutex};
-use util::uuid::uuid;
 
 pub mod certs;
 pub mod configuration;
@@ -88,7 +88,7 @@ async fn run_stage0(
     {
         service_provider
             .app_data_service
-            .set_hardware_id(uuid().to_ascii_uppercase())?;
+            .set_hardware_id(machine_uid::get().unwrap())?;
     }
 
     let service_provider_data = Data::new(service_provider);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -88,7 +88,7 @@ async fn run_stage0(
     {
         service_provider
             .app_data_service
-            .set_hardware_id(machine_uid::get().unwrap())?;
+            .set_hardware_id(machine_uid::get().expect("Failed to generate hardware UID"))?;
     }
 
     let service_provider_data = Data::new(service_provider);


### PR DESCRIPTION
Closes #131 

Save machine UUID instead of randomly generating it. Works for Linux, Windows and Mac (only tested on Mac so far 🤔 )