### PR TITLE
Only evaluate the debug_no_access_control flag if no token is provided

### DIFF
--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -245,16 +245,15 @@ pub fn validate_auth(
     auth_data: &AuthData,
     auth_token: &Option<String>,
 ) -> Result<ValidatedUserAuth, AuthError> {
-    if auth_data.debug_no_access_control {
-        return Ok(dummy_user_auth());
-    }
-
     let auth_token = match auth_token {
         Some(token) => token,
         None => {
+            if auth_data.debug_no_access_control {
+                return Ok(dummy_user_auth());
+            }
             return Err(AuthError::Denied(AuthDeniedKind::NotAuthenticated(
                 "Missing auth token".to_string(),
-            )))
+            )));
         }
     };
     let service = TokenService::new(

--- a/server/service/src/auth_data.rs
+++ b/server/service/src/auth_data.rs
@@ -7,6 +7,8 @@ pub struct AuthData {
     pub token_bucket: Arc<RwLock<TokenBucket>>,
     /// Indicates if we run in debug mode without ssl certificate
     pub no_ssl: bool,
-    /// Disable access control (e.g. for testing)
+    /// Disable access control, i.e. no access token is required to do an API request (e.g. for
+    /// testing).
+    /// However, if a token is provided this token is fully evaluate.
     pub debug_no_access_control: bool,
 }


### PR DESCRIPTION
This avoid problems in the UI, i.e. since a dummy user was used with the
flag the UI doesn't behave as expected.
With this patch its possible to do unauthenticated API calls, e.g. for
debugging or testing while having a working UI with normal token
authentication.