### PR TITLE
Better sync api error message

### DIFF
--- a/server/server/src/sync/sync_api_v5.rs
+++ b/server/server/src/sync/sync_api_v5.rs
@@ -93,7 +93,7 @@ fn generate_headers(hardware_id: &str) -> HeaderMap {
 }
 
 async fn check_status(response: Response) -> Result<Response, anyhow::Error> {
-    if response.status().is_client_error() || response.status().is_server_error() {
+    if !response.status().is_success() {
         let err = response.text().await?;
         return Err(anyhow::Error::msg(err));
     }

--- a/server/server/src/sync/sync_api_v5.rs
+++ b/server/server/src/sync/sync_api_v5.rs
@@ -9,13 +9,6 @@ use serde::{Deserialize, Serialize};
 
 pub type SyncConnectionError = anyhow::Error;
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct ResponseError {
-    pub code: String,
-    pub message: String,
-    pub status: i32,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum RemoteSyncActionV5 {
     #[serde(alias = "insert")]
@@ -101,11 +94,8 @@ fn generate_headers(hardware_id: &str) -> HeaderMap {
 
 async fn check_status(response: Response) -> Result<Response, anyhow::Error> {
     if response.status().is_client_error() || response.status().is_server_error() {
-        let err = response.json::<ResponseError>().await?;
-        return Err(anyhow::Error::msg(format!(
-            "status: {}, code: {}, message: {}",
-            err.status, err.code, err.message
-        )));
+        let err = response.text().await?;
+        return Err(anyhow::Error::msg(err));
     }
     Ok(response)
 }


### PR DESCRIPTION
Shows something like:

[2022-06-22T02:57:10Z ERROR server] Failed to perform the initial sync:
Failed to pull central sync records - status: 401, code: site_incorrect_hardware_id, message: Site hardware ID does not match

instead of just "unauthorized"