### PR TITLE
241 reinstate sync integration transaction and errors

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1071,7 +1071,6 @@ dependencies = [
  "chrono",
  "clap",
  "diesel",
- "env_logger 0.8.4",
  "graphql",
  "log 0.4.16",
  "repository",
@@ -4071,7 +4070,6 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "env_logger 0.8.4",
  "graphql",
  "graphql_core",
  "graphql_types",
@@ -4106,7 +4104,6 @@ dependencies = [
  "anymap",
  "bcrypt",
  "chrono",
- "env_logger 0.8.4",
  "failure",
  "headless_chrome",
  "httpmock",
@@ -4832,6 +4829,7 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "env_logger 0.8.4",
  "sha2",
  "uuid",
 ]

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -26,7 +26,6 @@ diesel = { version = "1.4.7", default-features = false, features = ["chrono"] }
 chrono = { version = "0.4"}
 reqwest = { version = "0.11.10" } 
 tokio = { version = "1.17.0", features = ["macros" ] }
-env_logger = "0.8.3"
 log = "0.4.14"
 
 [dev-dependencies]

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -130,7 +130,7 @@ async fn initialise_from_central(settings: Settings, users: &str) -> StorageConn
 
 #[tokio::main]
 async fn main() {
-    init_logger();
+    init_logger(LogLevel::Info);
 
     let args = Args::parse();
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -26,7 +26,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
-use util::{init_logger, inline_init};
+use util::{init_logger, inline_init, LogLevel};
 
 const DATA_EXPORT_FOLDER: &'static str = "data";
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -22,11 +22,11 @@ use service::{
     token_bucket::TokenBucket,
 };
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
-use util::inline_init;
+use util::{init_logger, inline_init};
 
 const DATA_EXPORT_FOLDER: &'static str = "data";
 
@@ -130,8 +130,7 @@ async fn initialise_from_central(settings: Settings, users: &str) -> StorageConn
 
 #[tokio::main]
 async fn main() {
-    env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    init_logger();
 
     let args = Args::parse();
 

--- a/server/repository/src/db_diesel/unit_row.rs
+++ b/server/repository/src/db_diesel/unit_row.rs
@@ -11,7 +11,7 @@ table! {
     }
 }
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[table_name = "unit"]
 pub struct UnitRow {
     pub id: String,

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -32,7 +32,6 @@ openssl = { version = "0.10", features = ["v110"] }
 anyhow = "1.0.44"
 config = "0.11.0"
 chrono = { version = "0.4", features = ["serde"] }
-env_logger = "0.8.3"
 log = "0.4.14"
 reqwest = { version = "0.11.10", features = ["json"] }
 rustls = "0.20.4"

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -7,7 +7,7 @@ use util::init_logger;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    init_logger();
+    init_logger(LogLevel::Info);
 
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -1,18 +1,13 @@
 #![allow(where_clauses_object_safety)]
 
-use std::env;
-
 use server::{configuration, start_server};
 use service::settings::Settings;
 use tokio::sync::oneshot;
+use util::init_logger;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    if env::var("RUST_LOG").is_err() {
-        //Default rust log level to info
-        env::set_var("RUST_LOG", "info");
-    }
-    env_logger::init();
+    init_logger();
 
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -3,7 +3,7 @@
 use server::{configuration, start_server};
 use service::settings::Settings;
 use tokio::sync::oneshot;
-use util::init_logger;
+use util::{init_logger, LogLevel};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -31,7 +31,6 @@ actix-web = { version= "4.0.1" }
 actix-rt = "2.6.0"
 httpmock = "0.6.6"
 rand = "0.8.5"
-env_logger = "0.8.3"
 
 [features]
 default = ["sqlite"]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -14,23 +14,25 @@ use crate::sync::{
 use super::{
     sync_api_v3::SyncApiV3,
     sync_api_v5::{RemoteSyncActionV5, RemoteSyncBatchV5},
-    SyncApiV5,
+    SyncApiV5, SyncConnectionError,
 };
 
 #[derive(Error, Debug)]
-#[error("{msg}: {source}")]
-pub struct RemoteSyncError {
-    msg: &'static str,
-    source: anyhow::Error,
-}
-
-impl From<RepositoryError> for RemoteSyncError {
-    fn from(err: RepositoryError) -> Self {
-        RemoteSyncError {
-            msg: "Internal DB error",
-            source: anyhow::Error::from(err),
-        }
-    }
+#[error("Failed to send initialisation request: {0:?}")]
+pub(crate) struct PostInitialisationError(SyncConnectionError);
+#[derive(Error, Debug)]
+#[error("Failed to set initialised state: {0:?}")]
+pub(crate) struct SetInitialisedError(RepositoryError);
+#[derive(Error, Debug)]
+pub(crate) enum RemotPullError {
+    #[error("Api error while pulling remote records: {0:?}")]
+    PullError(SyncConnectionError),
+    #[error("Failed to acknowledge sync records: {0:?}")]
+    AcknowledgedError(SyncConnectionError),
+    #[error("Failed to save sync buffer rows {0:?}")]
+    SaveSyncBufferError(RepositoryError),
+    #[error("Failed to parse V5 remote record into sync buffer row: {0:?}")]
+    ParsingV5RecordError(ParsingV5RecordError),
 }
 
 pub struct RemoteDataSynchroniser {
@@ -40,18 +42,14 @@ pub struct RemoteDataSynchroniser {
     pub central_server_site_id: u32,
 }
 
-#[allow(unused_assignments)]
 impl RemoteDataSynchroniser {
     /// Request initialisation
-    pub async fn request_initialisation(&self) -> Result<(), RemoteSyncError> {
+    pub(crate) async fn request_initialisation(&self) -> Result<(), PostInitialisationError> {
         info!("Initialising remote sync records...");
         self.sync_api_v5
             .post_initialise()
             .await
-            .map_err(|error| RemoteSyncError {
-                msg: "Failed to post sync queue initialisation request to the central server",
-                source: anyhow::Error::from(error),
-            })?;
+            .map_err(PostInitialisationError)?;
 
         info!("Initialised remote sync records");
 
@@ -59,23 +57,34 @@ impl RemoteDataSynchroniser {
     }
 
     /// Request initialisation
-    pub fn set_initialised(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
+    pub(crate) fn set_initialised(
+        &self,
+        connection: &StorageConnection,
+    ) -> Result<(), SetInitialisedError> {
+        use SetInitialisedError as Error;
         let remote_sync_state = RemoteSyncState::new(&connection);
         // Update push cursor after initial sync, i.e. set it to the end of the just received data
         // so we only push new data to the central server
         let cursor = ChangelogRowRepository::new(connection)
-            .latest_changelog()?
+            .latest_changelog()
+            .map_err(Error)?
             .map(|row| row.id)
             .unwrap_or(0) as u32;
-        remote_sync_state.update_push_cursor(cursor + 1)?;
+        remote_sync_state
+            .update_push_cursor(cursor + 1)
+            .map_err(Error)?;
 
-        remote_sync_state.set_site_id(self.site_id as i32)?;
-        remote_sync_state.set_initial_remote_data_synced()?;
+        remote_sync_state
+            .set_site_id(self.site_id as i32)
+            .map_err(Error)?;
+        remote_sync_state
+            .set_initial_remote_data_synced()
+            .map_err(Error)?;
         Ok(())
     }
 
     /// Pull all records from the central server
-    pub(crate) async fn pull(&self, connection: &StorageConnection) -> Result<(), anyhow::Error> {
+    pub(crate) async fn pull(&self, connection: &StorageConnection) -> Result<(), RemotPullError> {
         // Arbitrary batch size TODO: should come from settings
         const BATCH_SIZE: u32 = 500;
         let sync_buffer_repository = SyncBufferRowRepository::new(connection);
@@ -83,11 +92,17 @@ impl RemoteDataSynchroniser {
         loop {
             info!("Pulling remote sync records...");
 
-            let sync_batch = self.sync_api_v5.get_queued_records(BATCH_SIZE).await?;
+            let sync_batch = self
+                .sync_api_v5
+                .get_queued_records(BATCH_SIZE)
+                .await
+                .map_err(RemotPullError::PullError)?;
 
             let total_queue_length = sync_batch.queue_length;
             let sync_ids = sync_batch.extract_sync_ids();
-            let sync_buffer_rows = sync_batch.to_sync_buffer_rows()?;
+            let sync_buffer_rows = sync_batch
+                .to_sync_buffer_rows()
+                .map_err(RemotPullError::ParsingV5RecordError)?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u32;
 
@@ -98,10 +113,15 @@ impl RemoteDataSynchroniser {
             );
 
             if number_of_pulled_records > 0 {
-                sync_buffer_repository.upsert_many(&sync_buffer_rows)?;
+                sync_buffer_repository
+                    .upsert_many(&sync_buffer_rows)
+                    .map_err(RemotPullError::SaveSyncBufferError)?;
 
                 info!("Acknowledging remote sync records...");
-                self.sync_api_v5.post_acknowledge_records(sync_ids).await?;
+                self.sync_api_v5
+                    .post_acknowledge_records(sync_ids)
+                    .await
+                    .map_err(RemotPullError::AcknowledgedError)?;
                 info!("Acknowledged remote sync records");
             } else {
                 break;
@@ -191,20 +211,30 @@ impl RemoteSyncActionV5 {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("{source:?} {record:?}")]
+pub(crate) struct ParsingV5RecordError {
+    source: serde_json::Error,
+    record: Option<serde_json::Value>,
+}
 impl RemoteSyncBatchV5 {
     fn extract_sync_ids(&self) -> Vec<String> {
         self.data.iter().map(|r| r.sync_id.clone()).collect()
     }
 
-    fn to_sync_buffer_rows(self) -> Result<Vec<SyncBufferRow>, serde_json::Error> {
+    fn to_sync_buffer_rows(self) -> Result<Vec<SyncBufferRow>, ParsingV5RecordError> {
         self.data
             .into_iter()
             .map(|record| {
+                let data = record.data;
                 Ok(SyncBufferRow {
                     table_name: record.table,
                     record_id: record.record_id,
                     action: record.action.to_row_action(),
-                    data: serde_json::to_string(&record.data)?,
+                    data: serde_json::to_string(&data).map_err(|e| ParsingV5RecordError {
+                        source: e,
+                        record: data.clone(),
+                    })?,
                     received_datetime: Utc::now().naive_utc(),
                     integration_datetime: None,
                     integration_error: None,

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -61,25 +61,24 @@ impl RemoteDataSynchroniser {
         &self,
         connection: &StorageConnection,
     ) -> Result<(), SetInitialisedError> {
-        use SetInitialisedError as Error;
         let remote_sync_state = RemoteSyncState::new(&connection);
         // Update push cursor after initial sync, i.e. set it to the end of the just received data
         // so we only push new data to the central server
         let cursor = ChangelogRowRepository::new(connection)
             .latest_changelog()
-            .map_err(Error)?
+            .map_err(SetInitialisedError)?
             .map(|row| row.id)
             .unwrap_or(0) as u32;
         remote_sync_state
             .update_push_cursor(cursor + 1)
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
 
         remote_sync_state
             .set_site_id(self.site_id as i32)
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
         remote_sync_state
             .set_initial_remote_data_synced()
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
         Ok(())
     }
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -8,9 +8,12 @@ use crate::sync::{
     translations::table_name_to_central,
 };
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
+use util::init_logger;
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
+    init_logger();
+
     let (_, connection, _, _) =
         test_db::setup_all("test_sync_pull_and_push", MockDataInserts::all()).await;
 
@@ -22,10 +25,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_reords)
         .unwrap();
 
-    let (upserts, deletes) = integrate_and_translate_sync_buffer(&connection).unwrap();
-
-    println!("Upsert translation result {:#?}", upserts.all_errors());
-    println!("Delete translation restul {:#?}", deletes.all_errors());
+    integrate_and_translate_sync_buffer(&connection).unwrap();
 
     check_records_against_database(&connection, test_records).await;
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -8,11 +8,11 @@ use crate::sync::{
     translations::table_name_to_central,
 };
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
-use util::init_logger;
+use util::{init_logger, LogLevel};
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
-    init_logger();
+    init_logger(LogLevel::Warn);
 
     let (_, connection, _, _) =
         test_db::setup_all("test_sync_pull_and_push", MockDataInserts::all()).await;

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -67,7 +67,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &translation_error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", translation_error);
+                    warn!("{:?} {:?}", translation_error, sync_record);
                     // Next sync_record
                     continue;
                 }
@@ -81,7 +81,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", error);
+                    warn!("{:?} {:?}", error, sync_record);
                     // Next sync_record
                     continue;
                 }
@@ -101,7 +101,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", error);
+                    warn!("{:?} {:?} {:?}", error, sync_record, integration_records);
                 }
             }
         }

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/lib.rs"
 sha2 = "0.9.5"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4.19"
+env_logger = "0.8.3"

--- a/server/util/src/lib.rs
+++ b/server/util/src/lib.rs
@@ -3,6 +3,9 @@ pub mod hash;
 pub mod timezone;
 pub mod uuid;
 
+mod logger;
+pub use logger::*;
+
 mod inline_init;
 pub use inline_init::*;
 

--- a/server/util/src/logger.rs
+++ b/server/util/src/logger.rs
@@ -1,9 +1,19 @@
 use std::env;
 
-pub fn init_logger() {
+pub enum LogLevel {
+    Info,
+    Warn,
+}
+pub fn init_logger(level: LogLevel) {
     if env::var("RUST_LOG").is_err() {
         //Default rust log level to info
-        env::set_var("RUST_LOG", "info");
+        env::set_var(
+            "RUST_LOG",
+            match level {
+                LogLevel::Info => "info",
+                LogLevel::Warn => "warn",
+            },
+        );
     }
     env_logger::init();
 }

--- a/server/util/src/logger.rs
+++ b/server/util/src/logger.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+pub fn init_logger() {
+    if env::var("RUST_LOG").is_err() {
+        //Default rust log level to info
+        env::set_var("RUST_LOG", "info");
+    }
+    env_logger::init();
+}


### PR DESCRIPTION
closes: #241 
closes: #229 

* Removed excessive integration and translation result (should just be a summary of errors and success counts), and use env_logger (now common in utils) to see why check_records_against_database fails
* Added integration transactions and test
* Remote and Central errors to use this error for nicer console printing. I think we should try and use thiserror (since it's easy to define console friendly messages and it keeps the original error) as much as possible and only use anyhow in dynamic context (i.e. translations use anyhow, i think it should be common serde error variant, database variant and another variant for generic anyhow). It's a very good idea to keep errors types for matching and to log as much information as possible from the start (we had many times now where we had to add extra information to errors, and quite a few time we've suggested that full error should be kept), and example of why we would want to match error in synchroniser -> on connection error next sync interval should be super quick, on a stronger error like parsing of SyncV5Record interval can be longer (or even pause sync).
