### PR TITLE
244 hanlde deletes when pulling central records

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1071,7 +1071,6 @@ dependencies = [
  "chrono",
  "clap",
  "diesel",
- "env_logger 0.8.4",
  "graphql",
  "log 0.4.16",
  "repository",
@@ -4071,7 +4070,6 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "env_logger 0.8.4",
  "graphql",
  "graphql_core",
  "graphql_types",
@@ -4106,7 +4104,6 @@ dependencies = [
  "anymap",
  "bcrypt",
  "chrono",
- "env_logger 0.8.4",
  "failure",
  "headless_chrome",
  "httpmock",
@@ -4832,6 +4829,7 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "env_logger 0.8.4",
  "sha2",
  "uuid",
 ]

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -26,7 +26,6 @@ diesel = { version = "1.4.7", default-features = false, features = ["chrono"] }
 chrono = { version = "0.4"}
 reqwest = { version = "0.11.10" } 
 tokio = { version = "1.17.0", features = ["macros" ] }
-env_logger = "0.8.3"
 log = "0.4.14"
 
 [dev-dependencies]

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -130,7 +130,7 @@ async fn initialise_from_central(settings: Settings, users: &str) -> StorageConn
 
 #[tokio::main]
 async fn main() {
-    init_logger();
+    init_logger(LogLevel::Info);
 
     let args = Args::parse();
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -26,7 +26,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
-use util::{init_logger, inline_init};
+use util::{init_logger, inline_init, LogLevel};
 
 const DATA_EXPORT_FOLDER: &'static str = "data";
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -22,11 +22,11 @@ use service::{
     token_bucket::TokenBucket,
 };
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
-use util::inline_init;
+use util::{init_logger, inline_init};
 
 const DATA_EXPORT_FOLDER: &'static str = "data";
 
@@ -130,8 +130,7 @@ async fn initialise_from_central(settings: Settings, users: &str) -> StorageConn
 
 #[tokio::main]
 async fn main() {
-    env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    init_logger();
 
     let args = Args::parse();
 

--- a/server/repository/src/db_diesel/item_row.rs
+++ b/server/repository/src/db_diesel/item_row.rs
@@ -121,4 +121,9 @@ impl<'a> ItemRowRepository<'a> {
             .load(&self.connection.connection)?;
         Ok(result)
     }
+
+    pub fn delete(&self, item_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(item.filter(id.eq(item_id))).execute(&self.connection.connection)?;
+        Ok(())
+    }
 }

--- a/server/repository/src/db_diesel/master_list_line_row.rs
+++ b/server/repository/src/db_diesel/master_list_line_row.rs
@@ -1,4 +1,7 @@
-use super::{master_list_line_row::master_list_line::dsl::*, StorageConnection, master_list_row::master_list, item_row::item};
+use super::{
+    item_row::item, master_list_line_row::master_list_line::dsl::*, master_list_row::master_list,
+    StorageConnection,
+};
 
 use crate::repository_error::RepositoryError;
 
@@ -59,5 +62,22 @@ impl<'a> MasterListLineRowRepository<'a> {
             .filter(id.eq(line_id))
             .first(&self.connection.connection)?;
         Ok(result)
+    }
+
+    pub fn find_one_by_id_option(
+        &self,
+        line_id: &str,
+    ) -> Result<Option<MasterListLineRow>, RepositoryError> {
+        let result = master_list_line
+            .filter(id.eq(line_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, line_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(master_list_line.filter(id.eq(line_id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
     }
 }

--- a/server/repository/src/db_diesel/master_list_name_join.rs
+++ b/server/repository/src/db_diesel/master_list_name_join.rs
@@ -56,11 +56,28 @@ impl<'a> MasterListNameJoinRepository<'a> {
 
     pub async fn find_one_by_id(
         &self,
-        item_id: &str,
+        row_id: &str,
     ) -> Result<MasterListNameJoinRow, RepositoryError> {
         let result = master_list_name_join
-            .filter(id.eq(item_id))
+            .filter(id.eq(row_id))
             .first(&self.connection.connection)?;
         Ok(result)
+    }
+
+    pub fn find_one_by_id_option(
+        &self,
+        row_id: &str,
+    ) -> Result<Option<MasterListNameJoinRow>, RepositoryError> {
+        let result = master_list_name_join
+            .filter(id.eq(row_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, row_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(master_list_name_join.filter(id.eq(row_id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
     }
 }

--- a/server/repository/src/db_diesel/master_list_row.rs
+++ b/server/repository/src/db_diesel/master_list_row.rs
@@ -50,10 +50,30 @@ impl<'a> MasterListRowRepository<'a> {
         Ok(())
     }
 
-    pub async fn find_one_by_id(&self, item_id: &str) -> Result<MasterListRow, RepositoryError> {
+    pub async fn find_one_by_id(
+        &self,
+        master_list_id: &str,
+    ) -> Result<MasterListRow, RepositoryError> {
         let result = master_list
-            .filter(id.eq(item_id))
+            .filter(id.eq(master_list_id))
             .first(&self.connection.connection)?;
         Ok(result)
+    }
+
+    pub fn find_one_by_id_option(
+        &self,
+        master_list_id: &str,
+    ) -> Result<Option<MasterListRow>, RepositoryError> {
+        let result = master_list
+            .filter(id.eq(master_list_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, master_list_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(master_list.filter(id.eq(master_list_id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
     }
 }

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -84,4 +84,10 @@ impl<'a> ReportRowRepository<'a> {
             .execute(&self.connection.connection)?;
         Ok(())
     }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(report_dsl::report.filter(report_dsl::id.eq(id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
 }

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -96,4 +96,12 @@ impl<'a> StockLineRowRepository<'a> {
             .load::<StockLineRow>(&self.connection.connection)
             .map_err(RepositoryError::from)
     }
+
+    pub fn find_one_by_id_option(&self, id: &str) -> Result<Option<StockLineRow>, RepositoryError> {
+        let result = stock_line_dsl::stock_line
+            .filter(stock_line_dsl::id.eq(id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
 }

--- a/server/repository/src/db_diesel/store_row.rs
+++ b/server/repository/src/db_diesel/store_row.rs
@@ -86,4 +86,10 @@ impl<'a> StoreRowRepository<'a> {
         let result = store_dsl::store.load(&self.connection.connection)?;
         Ok(result)
     }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(store_dsl::store.filter(store_dsl::id.eq(id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
 }

--- a/server/repository/src/db_diesel/unit_row.rs
+++ b/server/repository/src/db_diesel/unit_row.rs
@@ -11,7 +11,7 @@ table! {
     }
 }
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[table_name = "unit"]
 pub struct UnitRow {
     pub id: String,

--- a/server/repository/src/db_diesel/unit_row.rs
+++ b/server/repository/src/db_diesel/unit_row.rs
@@ -54,4 +54,17 @@ impl<'a> UnitRowRepository<'a> {
             .first(&self.connection.connection)?;
         Ok(result)
     }
+
+    pub fn find_one_by_id_option(&self, unit_id: &str) -> Result<Option<UnitRow>, RepositoryError> {
+        let result = unit
+            .filter(id.eq(unit_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn delete(&self, unit_id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(unit.filter(id.eq(unit_id))).execute(&self.connection.connection)?;
+        Ok(())
+    }
 }

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -32,7 +32,6 @@ openssl = { version = "0.10", features = ["v110"] }
 anyhow = "1.0.44"
 config = "0.11.0"
 chrono = { version = "0.4", features = ["serde"] }
-env_logger = "0.8.3"
 log = "0.4.14"
 reqwest = { version = "0.11.10", features = ["json"] }
 rustls = "0.20.4"

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -7,7 +7,7 @@ use util::init_logger;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    init_logger();
+    init_logger(LogLevel::Info);
 
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -1,18 +1,13 @@
 #![allow(where_clauses_object_safety)]
 
-use std::env;
-
 use server::{configuration, start_server};
 use service::settings::Settings;
 use tokio::sync::oneshot;
+use util::init_logger;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    if env::var("RUST_LOG").is_err() {
-        //Default rust log level to info
-        env::set_var("RUST_LOG", "info");
-    }
-    env_logger::init();
+    init_logger();
 
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -3,7 +3,7 @@
 use server::{configuration, start_server};
 use service::settings::Settings;
 use tokio::sync::oneshot;
-use util::init_logger;
+use util::{init_logger, LogLevel};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -31,7 +31,6 @@ actix-web = { version= "4.0.1" }
 actix-rt = "2.6.0"
 httpmock = "0.6.6"
 rand = "0.8.5"
-env_logger = "0.8.3"
 
 [features]
 default = ["sqlite"]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -14,23 +14,25 @@ use crate::sync::{
 use super::{
     sync_api_v3::SyncApiV3,
     sync_api_v5::{RemoteSyncActionV5, RemoteSyncBatchV5},
-    SyncApiV5,
+    SyncApiV5, SyncConnectionError,
 };
 
 #[derive(Error, Debug)]
-#[error("{msg}: {source}")]
-pub struct RemoteSyncError {
-    msg: &'static str,
-    source: anyhow::Error,
-}
-
-impl From<RepositoryError> for RemoteSyncError {
-    fn from(err: RepositoryError) -> Self {
-        RemoteSyncError {
-            msg: "Internal DB error",
-            source: anyhow::Error::from(err),
-        }
-    }
+#[error("Failed to send initialisation request: {0:?}")]
+pub(crate) struct PostInitialisationError(SyncConnectionError);
+#[derive(Error, Debug)]
+#[error("Failed to set initialised state: {0:?}")]
+pub(crate) struct SetInitialisedError(RepositoryError);
+#[derive(Error, Debug)]
+pub(crate) enum RemotPullError {
+    #[error("Api error while pulling remote records: {0:?}")]
+    PullError(SyncConnectionError),
+    #[error("Failed to acknowledge sync records: {0:?}")]
+    AcknowledgedError(SyncConnectionError),
+    #[error("Failed to save sync buffer rows {0:?}")]
+    SaveSyncBufferError(RepositoryError),
+    #[error("Failed to parse V5 remote record into sync buffer row: {0:?}")]
+    ParsingV5RecordError(ParsingV5RecordError),
 }
 
 pub struct RemoteDataSynchroniser {
@@ -40,18 +42,14 @@ pub struct RemoteDataSynchroniser {
     pub central_server_site_id: u32,
 }
 
-#[allow(unused_assignments)]
 impl RemoteDataSynchroniser {
     /// Request initialisation
-    pub async fn request_initialisation(&self) -> Result<(), RemoteSyncError> {
+    pub(crate) async fn request_initialisation(&self) -> Result<(), PostInitialisationError> {
         info!("Initialising remote sync records...");
         self.sync_api_v5
             .post_initialise()
             .await
-            .map_err(|error| RemoteSyncError {
-                msg: "Failed to post sync queue initialisation request to the central server",
-                source: anyhow::Error::from(error),
-            })?;
+            .map_err(PostInitialisationError)?;
 
         info!("Initialised remote sync records");
 
@@ -59,23 +57,34 @@ impl RemoteDataSynchroniser {
     }
 
     /// Request initialisation
-    pub fn set_initialised(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
+    pub(crate) fn set_initialised(
+        &self,
+        connection: &StorageConnection,
+    ) -> Result<(), SetInitialisedError> {
+        use SetInitialisedError as Error;
         let remote_sync_state = RemoteSyncState::new(&connection);
         // Update push cursor after initial sync, i.e. set it to the end of the just received data
         // so we only push new data to the central server
         let cursor = ChangelogRowRepository::new(connection)
-            .latest_changelog()?
+            .latest_changelog()
+            .map_err(Error)?
             .map(|row| row.id)
             .unwrap_or(0) as u32;
-        remote_sync_state.update_push_cursor(cursor + 1)?;
+        remote_sync_state
+            .update_push_cursor(cursor + 1)
+            .map_err(Error)?;
 
-        remote_sync_state.set_site_id(self.site_id as i32)?;
-        remote_sync_state.set_initial_remote_data_synced()?;
+        remote_sync_state
+            .set_site_id(self.site_id as i32)
+            .map_err(Error)?;
+        remote_sync_state
+            .set_initial_remote_data_synced()
+            .map_err(Error)?;
         Ok(())
     }
 
     /// Pull all records from the central server
-    pub(crate) async fn pull(&self, connection: &StorageConnection) -> Result<(), anyhow::Error> {
+    pub(crate) async fn pull(&self, connection: &StorageConnection) -> Result<(), RemotPullError> {
         // Arbitrary batch size TODO: should come from settings
         const BATCH_SIZE: u32 = 500;
         let sync_buffer_repository = SyncBufferRowRepository::new(connection);
@@ -83,11 +92,17 @@ impl RemoteDataSynchroniser {
         loop {
             info!("Pulling remote sync records...");
 
-            let sync_batch = self.sync_api_v5.get_queued_records(BATCH_SIZE).await?;
+            let sync_batch = self
+                .sync_api_v5
+                .get_queued_records(BATCH_SIZE)
+                .await
+                .map_err(RemotPullError::PullError)?;
 
             let total_queue_length = sync_batch.queue_length;
             let sync_ids = sync_batch.extract_sync_ids();
-            let sync_buffer_rows = sync_batch.to_sync_buffer_rows()?;
+            let sync_buffer_rows = sync_batch
+                .to_sync_buffer_rows()
+                .map_err(RemotPullError::ParsingV5RecordError)?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u32;
 
@@ -98,10 +113,15 @@ impl RemoteDataSynchroniser {
             );
 
             if number_of_pulled_records > 0 {
-                sync_buffer_repository.upsert_many(&sync_buffer_rows)?;
+                sync_buffer_repository
+                    .upsert_many(&sync_buffer_rows)
+                    .map_err(RemotPullError::SaveSyncBufferError)?;
 
                 info!("Acknowledging remote sync records...");
-                self.sync_api_v5.post_acknowledge_records(sync_ids).await?;
+                self.sync_api_v5
+                    .post_acknowledge_records(sync_ids)
+                    .await
+                    .map_err(RemotPullError::AcknowledgedError)?;
                 info!("Acknowledged remote sync records");
             } else {
                 break;
@@ -191,20 +211,30 @@ impl RemoteSyncActionV5 {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("{source:?} {record:?}")]
+pub(crate) struct ParsingV5RecordError {
+    source: serde_json::Error,
+    record: Option<serde_json::Value>,
+}
 impl RemoteSyncBatchV5 {
     fn extract_sync_ids(&self) -> Vec<String> {
         self.data.iter().map(|r| r.sync_id.clone()).collect()
     }
 
-    fn to_sync_buffer_rows(self) -> Result<Vec<SyncBufferRow>, serde_json::Error> {
+    fn to_sync_buffer_rows(self) -> Result<Vec<SyncBufferRow>, ParsingV5RecordError> {
         self.data
             .into_iter()
             .map(|record| {
+                let data = record.data;
                 Ok(SyncBufferRow {
                     table_name: record.table,
                     record_id: record.record_id,
                     action: record.action.to_row_action(),
-                    data: serde_json::to_string(&record.data)?,
+                    data: serde_json::to_string(&data).map_err(|e| ParsingV5RecordError {
+                        source: e,
+                        record: data.clone(),
+                    })?,
                     received_datetime: Utc::now().naive_utc(),
                     integration_datetime: None,
                     integration_error: None,

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -61,25 +61,24 @@ impl RemoteDataSynchroniser {
         &self,
         connection: &StorageConnection,
     ) -> Result<(), SetInitialisedError> {
-        use SetInitialisedError as Error;
         let remote_sync_state = RemoteSyncState::new(&connection);
         // Update push cursor after initial sync, i.e. set it to the end of the just received data
         // so we only push new data to the central server
         let cursor = ChangelogRowRepository::new(connection)
             .latest_changelog()
-            .map_err(Error)?
+            .map_err(SetInitialisedError)?
             .map(|row| row.id)
             .unwrap_or(0) as u32;
         remote_sync_state
             .update_push_cursor(cursor + 1)
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
 
         remote_sync_state
             .set_site_id(self.site_id as i32)
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
         remote_sync_state
             .set_initial_remote_data_synced()
-            .map_err(Error)?;
+            .map_err(SetInitialisedError)?;
         Ok(())
     }
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -8,9 +8,12 @@ use crate::sync::{
     translations::table_name_to_central,
 };
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
+use util::init_logger;
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
+    init_logger();
+
     let (_, connection, _, _) =
         test_db::setup_all("test_sync_pull_and_push", MockDataInserts::all()).await;
 
@@ -22,10 +25,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_reords)
         .unwrap();
 
-    let (upserts, deletes) = integrate_and_translate_sync_buffer(&connection).unwrap();
-
-    println!("Upsert translation result {:#?}", upserts.all_errors());
-    println!("Delete translation restul {:#?}", deletes.all_errors());
+    integrate_and_translate_sync_buffer(&connection).unwrap();
 
     check_records_against_database(&connection, test_records).await;
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -8,11 +8,11 @@ use crate::sync::{
     translations::table_name_to_central,
 };
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
-use util::init_logger;
+use util::{init_logger, LogLevel};
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
-    init_logger();
+    init_logger(LogLevel::Warn);
 
     let (_, connection, _, _) =
         test_db::setup_all("test_sync_pull_and_push", MockDataInserts::all()).await;

--- a/server/service/src/sync/test/test_data/item.rs
+++ b/server/service/src/sync/test/test_data/item.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 use repository::{ItemRow, ItemRowType};
 
@@ -162,7 +162,7 @@ const ITEM_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
             LegacyTableName::ITEM,
@@ -189,4 +189,12 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             }),
         ),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::ITEM,
+        ITEM_2.0,
+        PullDeleteRecordTable::Item,
+    )]
 }

--- a/server/service/src/sync/test/test_data/location.rs
+++ b/server/service/src/sync/test/test_data/location.rs
@@ -26,7 +26,7 @@ const LOCATION_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
         LegacyTableName::LOCATION,
         LOCATION_1,

--- a/server/service/src/sync/test/test_data/master_list.rs
+++ b/server/service/src/sync/test/test_data/master_list.rs
@@ -2,7 +2,7 @@ use repository::MasterListRow;
 
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 
 const MASTER_LIST_1: (&'static str, &'static str) = (
@@ -43,7 +43,7 @@ const MASTER_LIST_2: (&'static str, &'static str) = (
 }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
             LegacyTableName::LIST_MASTER,
@@ -66,4 +66,12 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             }),
         ),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::LIST_MASTER,
+        MASTER_LIST_1.0,
+        PullDeleteRecordTable::MasterList,
+    )]
 }

--- a/server/service/src/sync/test/test_data/master_list_line.rs
+++ b/server/service/src/sync/test/test_data/master_list_line.rs
@@ -2,7 +2,7 @@ use repository::MasterListLineRow;
 
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 
 const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
@@ -17,7 +17,7 @@ const MASTER_LIST_LINE_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
         LegacyTableName::LIST_MASTER_LINE,
         MASTER_LIST_LINE_1,
@@ -26,5 +26,13 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             item_id: "8F252B5884B74888AAB73A0D42C09E7F".to_owned(),
             master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
         }),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::LIST_MASTER_LINE,
+        MASTER_LIST_LINE_1.0,
+        PullDeleteRecordTable::MasterListLine,
     )]
 }

--- a/server/service/src/sync/test/test_data/master_list_name_join.rs
+++ b/server/service/src/sync/test/test_data/master_list_name_join.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 use repository::MasterListNameJoinRow;
 
@@ -18,7 +18,7 @@ const LIST_MASTER_NAME_JOIN_1: (&'static str, &'static str) = (
   }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
         LegacyTableName::LIST_MASTER_NAME_JOIN,
         LIST_MASTER_NAME_JOIN_1,
@@ -27,5 +27,13 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             master_list_id: "87027C44835B48E6989376F42A58F7E3".to_owned(),
             name_id: "1FB32324AF8049248D929CFB35F255BA".to_owned(),
         }),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::LIST_MASTER_NAME_JOIN,
+        LIST_MASTER_NAME_JOIN_1.0,
+        PullDeleteRecordTable::MasterListNameJoin,
     )]
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -19,26 +19,41 @@ pub(crate) mod trans_line;
 pub(crate) mod transact;
 pub(crate) mod unit;
 
-pub(crate) fn get_all_pull_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_upsert_test_records() -> Vec<TestSyncPullRecord> {
     let mut test_records = Vec::new();
-    test_records.append(&mut item::test_pull_records());
-    test_records.append(&mut location::test_pull_records());
-    test_records.append(&mut master_list_line::test_pull_records());
-    test_records.append(&mut master_list_name_join::test_pull_records());
-    test_records.append(&mut master_list::test_pull_records());
-    test_records.append(&mut name_store_join::test_pull_records());
-    test_records.append(&mut name::test_pull_records());
-    test_records.append(&mut number::test_pull_records());
-    test_records.append(&mut report::test_pull_records());
-    test_records.append(&mut requisition_line::test_pull_records());
-    test_records.append(&mut requisition::test_pull_records());
-    test_records.append(&mut stock_line::test_pull_records());
-    test_records.append(&mut stocktake_line::test_pull_records());
-    test_records.append(&mut stocktake::test_pull_records());
-    test_records.append(&mut store::test_pull_records());
-    test_records.append(&mut trans_line::test_pull_records());
-    test_records.append(&mut transact::test_pull_records());
-    test_records.append(&mut unit::test_pull_records());
+    test_records.append(&mut item::test_pull_upsert_records());
+    test_records.append(&mut location::test_pull_upsert_records());
+    test_records.append(&mut master_list_line::test_pull_upsert_records());
+    test_records.append(&mut master_list_name_join::test_pull_upsert_records());
+    test_records.append(&mut master_list::test_pull_upsert_records());
+    test_records.append(&mut name_store_join::test_pull_upsert_records());
+    test_records.append(&mut name::test_pull_upsert_records());
+    test_records.append(&mut number::test_pull_upsert_records());
+    test_records.append(&mut report::test_pull_upsert_records());
+    test_records.append(&mut requisition_line::test_pull_upsert_records());
+    test_records.append(&mut requisition::test_pull_upsert_records());
+    test_records.append(&mut stock_line::test_pull_upsert_records());
+    test_records.append(&mut stocktake_line::test_pull_upsert_records());
+    test_records.append(&mut stocktake::test_pull_upsert_records());
+    test_records.append(&mut store::test_pull_upsert_records());
+    test_records.append(&mut trans_line::test_pull_upsert_records());
+    test_records.append(&mut transact::test_pull_upsert_records());
+    test_records.append(&mut unit::test_pull_upsert_records());
+
+    test_records
+}
+
+pub(crate) fn get_all_pull_delete_test_records() -> Vec<TestSyncPullRecord> {
+    let mut test_records = Vec::new();
+    test_records.append(&mut unit::test_pull_delete_records());
+    test_records.append(&mut item::test_pull_delete_records());
+    test_records.append(&mut master_list_line::test_pull_delete_records());
+    test_records.append(&mut master_list_name_join::test_pull_delete_records());
+    test_records.append(&mut master_list::test_pull_delete_records());
+    test_records.append(&mut name::test_pull_delete_records());
+    test_records.append(&mut report::test_pull_delete_records());
+    test_records.append(&mut store::test_pull_delete_records());
+    test_records.append(&mut unit::test_pull_delete_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
 };
 use chrono::NaiveDate;
 use repository::{Gender, NameRow, NameType};
@@ -511,6 +511,14 @@ fn name_4() -> TestSyncPullRecord {
     )
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![name_1(), name_2(), name_3(), name_4()]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::NAME,
+        NAME_4.0,
+        PullDeleteRecordTable::Name,
+    )]
 }

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -86,7 +86,7 @@ fn name_store_join_3_pull_record() -> TestSyncPullRecord {
     )
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         name_store_join_1_pull_record(),
         name_store_join_2_pull_record(),

--- a/server/service/src/sync/test/test_data/number.rs
+++ b/server/service/src/sync/test/test_data/number.rs
@@ -185,7 +185,7 @@ fn number_supplier_invoice_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         number_stock_take_pull_record(),
         number_inv_adjustment_pull_record(),

--- a/server/service/src/sync/test/test_data/report.rs
+++ b/server/service/src/sync/test/test_data/report.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 use repository::{ReportContext, ReportRow, ReportType};
 
@@ -25,7 +25,7 @@ const REPORT_1: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![TestSyncPullRecord::new_pull_upsert(
         LegacyTableName::REPORT,
         REPORT_1,
@@ -37,5 +37,13 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             context: ReportContext::Stocktake,
             comment: Some("Test comment".to_string()),
         }),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::REPORT,
+        REPORT_1.0,
+        PullDeleteRecordTable::Report,
     )]
 }

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -290,7 +290,7 @@ fn requisition_om_fields_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         requisition_request_pull_record(),
         requisition_response_pull_record(),

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -161,7 +161,7 @@ fn requisition_line_om_fields_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         requisition_line_request_pull_record(),
         requisition_line_om_fields_pull_record(),

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -189,7 +189,7 @@ fn item_line_2_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![item_line_1_pull_record(), item_line_2_pull_record()]
 }
 

--- a/server/service/src/sync/test/test_data/stocktake.rs
+++ b/server/service/src/sync/test/test_data/stocktake.rs
@@ -155,7 +155,7 @@ fn stocktake_om_field_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![stocktake_pull_record(), stocktake_om_field_pull_record()]
 }
 

--- a/server/service/src/sync/test/test_data/stocktake_line.rs
+++ b/server/service/src/sync/test/test_data/stocktake_line.rs
@@ -157,7 +157,7 @@ fn stocktake_line_om_field_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         stocktake_line_pull_record(),
         stocktake_line_om_field_pull_record(),

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
 };
 use repository::{StoreRow, SyncBufferRow};
 use util::inline_init;
@@ -231,6 +231,14 @@ fn store_4() -> TestSyncPullRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![store_1(), store_2(), store_3(), store_4()]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::STORE,
+        STORE_4.0,
+        PullDeleteRecordTable::Store,
+    )]
 }

--- a/server/service/src/sync/test/test_data/trans_line.rs
+++ b/server/service/src/sync/test/test_data/trans_line.rs
@@ -475,7 +475,7 @@ fn trans_line_om_fields_unset_tax_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         trans_line_1_pull_record(),
         trans_line_2_pull_record(),

--- a/server/service/src/sync/test/test_data/transact.rs
+++ b/server/service/src/sync/test/test_data/transact.rs
@@ -475,7 +475,7 @@ fn transact_om_fields_push_record() -> TestSyncPushRecord {
     }
 }
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         transact_1_pull_record(),
         transact_2_pull_record(),

--- a/server/service/src/sync/test/test_data/unit.rs
+++ b/server/service/src/sync/test/test_data/unit.rs
@@ -2,7 +2,7 @@ use repository::UnitRow;
 
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
 };
 
 const UNIT_1: (&'static str, &'static str) = (
@@ -35,7 +35,7 @@ const UNIT_3: (&'static str, &'static str) = (
     }"#,
 );
 
-pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
             LegacyTableName::UNIT,
@@ -68,4 +68,12 @@ pub(crate) fn test_pull_records() -> Vec<TestSyncPullRecord> {
             }),
         ),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::UNIT,
+        UNIT_1.0,
+        PullDeleteRecordTable::Unit,
+    )]
 }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -67,7 +67,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &translation_error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", translation_error);
+                    warn!("{:?} {:?}", translation_error, sync_record);
                     // Next sync_record
                     continue;
                 }
@@ -81,7 +81,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", error);
+                    warn!("{:?} {:?}", error, sync_record);
                     // Next sync_record
                     continue;
                 }
@@ -101,7 +101,7 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?}", error);
+                    warn!("{:?} {:?} {:?}", error, sync_record, integration_records);
                 }
             }
         }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -151,7 +151,7 @@ pub struct LegacyTransactRow {
 
 pub(crate) struct InvoiceTranslation {}
 impl SyncTranslation for InvoiceTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -506,9 +506,9 @@ mod tests {
         )
         .await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -67,7 +67,7 @@ pub struct LegacyTransLineRow {
 
 pub(crate) struct InvoiceLineTranslation {}
 impl SyncTranslation for InvoiceLineTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -242,9 +242,9 @@ mod tests {
         )
         .await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -1,7 +1,9 @@
 use repository::{ItemRow, ItemRowType, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+};
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize)]
@@ -29,16 +31,18 @@ fn to_item_type(type_of: LegacyItemType) -> ItemRowType {
     }
 }
 
+fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
+    sync_record.table_name == LegacyTableName::ITEM
+}
+
 pub(crate) struct ItemTranslation {}
 impl SyncTranslation for ItemTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let table_name = LegacyTableName::ITEM;
-
-        if sync_record.table_name != table_name {
+        if !match_pull_table(sync_record) {
             return Ok(None);
         }
         let data = serde_json::from_str::<LegacyItemRow>(&sync_record.data)?;
@@ -60,6 +64,18 @@ impl SyncTranslation for ItemTranslation {
             PullUpsertRecord::Item(result),
         )))
     }
+
+    fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        let result = match_pull_table(sync_record).then(|| {
+            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Item)
+        });
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -75,9 +91,17 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_item_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            let translation_result = translator
+                .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -23,7 +23,7 @@ pub struct LegacyLocationRow {
 
 pub(crate) struct LocationTranslation {}
 impl SyncTranslation for LocationTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -108,9 +108,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_location_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -4,7 +4,9 @@ use repository::{Gender, NameRow, NameType, StorageConnection, SyncBufferRow};
 
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum LegacyNameType {
@@ -117,15 +119,18 @@ pub struct LegacyNameRow {
     //pub om_gender: Option<Gender>,
 }
 
+fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
+    sync_record.table_name == LegacyTableName::NAME
+}
+
 pub(crate) struct NameTranslation {}
 impl SyncTranslation for NameTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let table_name = LegacyTableName::NAME;
-        if sync_record.table_name != table_name {
+        if !match_pull_table(sync_record) {
             return Ok(None);
         }
 
@@ -182,6 +187,18 @@ impl SyncTranslation for NameTranslation {
             PullUpsertRecord::Name(result),
         )))
     }
+
+    fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        let result = match_pull_table(sync_record).then(|| {
+            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Name)
+        });
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -197,9 +214,17 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_name_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            let translation_result = translator
+                .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -18,7 +18,8 @@ pub struct LegacyNameStoreJoinRow {
 
 pub(crate) struct NameStoreJoinTranslation {}
 impl SyncTranslation for NameStoreJoinTranslation {
-    fn try_translate_pull(
+    // DELETE H ERE TOO
+    fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -72,9 +73,9 @@ mod tests {
         )
         .await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/number.rs
+++ b/server/service/src/sync/translations/number.rs
@@ -19,7 +19,7 @@ pub struct LegacyNumberRow {
 
 pub(crate) struct NumberTranslation {}
 impl SyncTranslation for NumberTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -133,9 +133,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_number_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -122,7 +122,7 @@ pub struct LegacyRequisitionRow {
 
 pub(crate) struct RequisitionTranslation {}
 impl SyncTranslation for RequisitionTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -386,9 +386,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_requisition_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -39,7 +39,7 @@ pub struct LegacyRequisitionLineRow {
 
 pub(crate) struct RequisitionLineTranslation {}
 impl SyncTranslation for RequisitionLineTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -135,9 +135,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_requisition_line_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -34,7 +34,7 @@ pub struct LegacyStockLineRow {
 
 pub(crate) struct StockLineTranslation {}
 impl SyncTranslation for StockLineTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -133,9 +133,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_stock_line_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -70,7 +70,7 @@ pub struct LegacyStocktakeRow {
 
 pub(crate) struct StocktakeTranslation {}
 impl SyncTranslation for StocktakeTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -199,9 +199,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_stocktake_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -43,7 +43,7 @@ pub struct LegacyStocktakeLineRow {
 
 pub(crate) struct StocktakeLineTranslation {}
 impl SyncTranslation for StocktakeLineTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
@@ -161,9 +161,9 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_stock_take_line_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/unit.rs
+++ b/server/service/src/sync/translations/unit.rs
@@ -2,7 +2,9 @@ use repository::{StorageConnection, SyncBufferRow, UnitRow};
 
 use serde::Deserialize;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -13,15 +15,18 @@ pub struct LegacyUnitRow {
     order_number: i32,
 }
 
+fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
+    sync_record.table_name == LegacyTableName::UNIT
+}
+
 pub(crate) struct UnitTranslation {}
 impl SyncTranslation for UnitTranslation {
-    fn try_translate_pull(
+    fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let table_name = LegacyTableName::UNIT;
-        if sync_record.table_name != table_name {
+        if !match_pull_table(sync_record) {
             return Ok(None);
         }
 
@@ -41,6 +46,18 @@ impl SyncTranslation for UnitTranslation {
             PullUpsertRecord::Unit(result),
         )))
     }
+
+    fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        let result = match_pull_table(sync_record).then(|| {
+            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Unit)
+        });
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -56,9 +73,17 @@ mod tests {
         let (_, connection, _, _) =
             setup_all("test_unit_translation", MockDataInserts::none()).await;
 
-        for record in test_data::test_pull_records() {
+        for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
-                .try_translate_pull(&connection, &record.sync_buffer_row)
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            let translation_result = translator
+                .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/lib.rs"
 sha2 = "0.9.5"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4.19"
+env_logger = "0.8.3"

--- a/server/util/src/lib.rs
+++ b/server/util/src/lib.rs
@@ -3,6 +3,9 @@ pub mod hash;
 pub mod timezone;
 pub mod uuid;
 
+mod logger;
+pub use logger::*;
+
 mod inline_init;
 pub use inline_init::*;
 

--- a/server/util/src/logger.rs
+++ b/server/util/src/logger.rs
@@ -1,9 +1,19 @@
 use std::env;
 
-pub fn init_logger() {
+pub enum LogLevel {
+    Info,
+    Warn,
+}
+pub fn init_logger(level: LogLevel) {
     if env::var("RUST_LOG").is_err() {
         //Default rust log level to info
-        env::set_var("RUST_LOG", "info");
+        env::set_var(
+            "RUST_LOG",
+            match level {
+                LogLevel::Info => "info",
+                LogLevel::Warn => "warn",
+            },
+        );
     }
     env_logger::init();
 }

--- a/server/util/src/logger.rs
+++ b/server/util/src/logger.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+pub fn init_logger() {
+    if env::var("RUST_LOG").is_err() {
+        //Default rust log level to info
+        env::set_var("RUST_LOG", "info");
+    }
+    env_logger::init();
+}


### PR DESCRIPTION
closes: #244 

* Change SyncTranslation trati
   * try_translate_pull_delete -> try_translate_pull_upsert
   * added try_translate_pull_delete
* Add common match table methods to translations for both delete and upsert, and added delete tests to translations
* Added test data for delete and changed current pull test data to be upsert pull tests data
* Added deletes to repositories and integration
* Sync buffer in service now filters by action
* I had an itch about check_records_against_database being quite cumbersome, so added more macros which required common find one by id methods (name it find_one_by_id_option, since renaming existing one would be a lot of changes). On hindsight, this could have been done in another PR (Actually i really like @Chris-Petty suggestion of deriving upsert, find_one_by_id and perhaps delete traits straight on the data types vs having repositories to do it, I think if we had a bit of time to think about things before repositories were created, would be great if they were implementations on types, would allow boxing of upsert record vs enums, plus would be useful in many other places)

I think upstream changes were worth it, certainly quite easy to add deletes and tests etc..
