### PR TITLE
246 handle sync remote data deletes

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -39,6 +39,7 @@ fn get_timestamp_fields() -> Vec<TableAndFieldName> {
     .collect()
 }
 
+#[cfg(test)]
 #[cfg(feature = "postgres")]
 fn get_exclude_timestamp_fields() -> Vec<TableAndFieldName> {
     vec![

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -65,4 +65,10 @@ impl<'a> NameStoreJoinRepository<'a> {
             .optional()?;
         Ok(result)
     }
+
+    pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        diesel::delete(name_store_join_dsl::name_store_join.filter(name_store_join_dsl::id.eq(id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
 }

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -13,38 +13,14 @@ mod sync_serde;
 pub mod synchroniser;
 pub(crate) mod translation_and_integration;
 pub(crate) mod translations;
-use repository::RepositoryError;
 pub use sync_api_credentials::SyncCredentials;
 pub use sync_api_v5::{SyncApiV5, SyncConnectionError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 #[error("Failed to translate {table_name} sync record: {record}")]
-pub struct SyncTranslationError {
+pub(crate) struct SyncTranslationError {
     pub table_name: String,
     pub source: anyhow::Error,
     pub record: String,
-}
-
-#[derive(Error, Debug)]
-pub enum SyncImportError {
-    #[error("Failed to translate sync records")]
-    TranslationError {
-        #[from]
-        source: SyncTranslationError,
-    },
-    #[error("Failed to integrate sync records: {extra}, {source}")]
-    IntegrationError {
-        source: RepositoryError,
-        extra: String,
-    },
-}
-
-impl SyncImportError {
-    pub fn as_integration_error<T: std::fmt::Debug>(error: RepositoryError, extra: T) -> Self {
-        SyncImportError::IntegrationError {
-            source: error,
-            extra: format!("{:?}", extra),
-        }
-    }
 }

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -232,11 +232,13 @@ pub(crate) async fn check_records_against_database(
                     check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id)
                 }
                 Report => check_delete_record_by_id!(ReportRowRepository, con, id),
-                NameStoreJoin => todo!(),
-                Invoice => todo!(),
-                InvoiceLine => todo!(),
-                Requisition => todo!(),
-                RequisitionLine => todo!(),
+                NameStoreJoin => check_delete_record_by_id!(ReportRowRepository, con, id),
+                Invoice => check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id),
+                InvoiceLine => {
+                    check_delete_record_by_id_option!(MasterListNameJoinRepository, con, id)
+                }
+                Requisition => check_delete_record_by_id!(ReportRowRepository, con, id),
+                RequisitionLine => check_delete_record_by_id!(ReportRowRepository, con, id),
             }
         }
     }

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -31,18 +31,6 @@ async fn test_sync_pull_and_push() {
 
     check_records_against_database(&connection, test_records).await;
 
-    // Test Pull Delete
-    let test_records = get_all_pull_delete_test_records();
-    let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
-
-    SyncBufferRowRepository::new(&connection)
-        .upsert_many(&sync_reords)
-        .unwrap();
-
-    integrate_and_translate_sync_buffer(&connection).unwrap();
-
-    check_records_against_database(&connection, test_records).await;
-
     // Test Push
     let test_records = get_all_push_test_records();
     for record in test_records {
@@ -62,4 +50,16 @@ async fn test_sync_pull_and_push() {
         assert_eq!(result.record_type, expected_table_name);
         assert_eq!(data, record.push_data);
     }
+
+    // Test Pull Delete
+    let test_records = get_all_pull_delete_test_records();
+    let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
+
+    SyncBufferRowRepository::new(&connection)
+        .upsert_many(&sync_reords)
+        .unwrap();
+
+    integrate_and_translate_sync_buffer(&connection).unwrap();
+
+    check_records_against_database(&connection, test_records).await;
 }

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     test::TestSyncPullRecord,
     translations::{
         invoice::{LegacyTransactRow, LegacyTransactStatus, LegacyTransactType, TransactMode},
-        LegacyTableName, PullUpsertRecord,
+        LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
     },
 };
 use chrono::{Duration, NaiveDate, NaiveTime};
@@ -481,6 +481,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         transact_2_pull_record(),
         transact_om_fields_pull_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::TRANSACT,
+        TRANSACT_OM_FIELDS.0,
+        PullDeleteRecordTable::Invoice,
+    )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {

--- a/server/service/src/sync/test/test_data/invoice_line.rs
+++ b/server/service/src/sync/test/test_data/invoice_line.rs
@@ -3,7 +3,7 @@ use crate::sync::{
     test::TestSyncPullRecord,
     translations::{
         invoice_line::{LegacyTransLineRow, LegacyTransLineType},
-        LegacyTableName, PullUpsertRecord,
+        LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
     },
 };
 use chrono::NaiveDate;
@@ -482,6 +482,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         trans_line_om_fields_pull_record(),
         trans_line_om_fields_unset_tax_pull_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::TRANS_LINE,
+        TRANS_LINE_OM_UNSET_TAX_FIELDS.0,
+        PullDeleteRecordTable::InvoiceLine,
+    )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -1,5 +1,7 @@
 use super::{TestSyncPullRecord, TestSyncPushRecord};
 
+pub(crate) mod invoice;
+pub(crate) mod invoice_line;
 pub(crate) mod item;
 pub(crate) mod location;
 pub(crate) mod master_list;
@@ -15,8 +17,6 @@ pub(crate) mod stock_line;
 pub(crate) mod stocktake;
 pub(crate) mod stocktake_line;
 pub(crate) mod store;
-pub(crate) mod trans_line;
-pub(crate) mod transact;
 pub(crate) mod unit;
 
 pub(crate) fn get_all_pull_upsert_test_records() -> Vec<TestSyncPullRecord> {
@@ -36,8 +36,8 @@ pub(crate) fn get_all_pull_upsert_test_records() -> Vec<TestSyncPullRecord> {
     test_records.append(&mut stocktake_line::test_pull_upsert_records());
     test_records.append(&mut stocktake::test_pull_upsert_records());
     test_records.append(&mut store::test_pull_upsert_records());
-    test_records.append(&mut trans_line::test_pull_upsert_records());
-    test_records.append(&mut transact::test_pull_upsert_records());
+    test_records.append(&mut invoice_line::test_pull_upsert_records());
+    test_records.append(&mut invoice::test_pull_upsert_records());
     test_records.append(&mut unit::test_pull_upsert_records());
 
     test_records
@@ -54,6 +54,11 @@ pub(crate) fn get_all_pull_delete_test_records() -> Vec<TestSyncPullRecord> {
     test_records.append(&mut report::test_pull_delete_records());
     test_records.append(&mut store::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
+    test_records.append(&mut name_store_join::test_pull_delete_records());
+    test_records.append(&mut requisition::test_pull_delete_records());
+    test_records.append(&mut requisition_line::test_pull_delete_records());
+    test_records.append(&mut invoice::test_pull_delete_records());
+    test_records.append(&mut invoice_line::test_pull_delete_records());
 
     test_records
 }
@@ -67,8 +72,8 @@ pub(crate) fn get_all_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records.append(&mut stock_line::test_push_records());
     test_records.append(&mut stocktake_line::test_push_records());
     test_records.append(&mut stocktake::test_push_records());
-    test_records.append(&mut trans_line::test_push_records());
-    test_records.append(&mut transact::test_push_records());
+    test_records.append(&mut invoice_line::test_push_records());
+    test_records.append(&mut invoice::test_push_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
 };
 use repository::NameStoreJoinRow;
 
@@ -92,4 +92,12 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         name_store_join_2_pull_record(),
         name_store_join_3_pull_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::NAME_STORE_JOIN,
+        NAME_STORE_JOIN_3.0,
+        PullDeleteRecordTable::NameStoreJoin,
+    )]
 }

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -1,7 +1,7 @@
 use super::{TestSyncPullRecord, TestSyncPushRecord};
 use crate::sync::translations::{
     requisition::{LegacyRequisitionRow, LegacyRequisitionStatus, LegacyRequisitionType},
-    LegacyTableName, PullUpsertRecord,
+    LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
 };
 use chrono::NaiveDate;
 use repository::{
@@ -296,6 +296,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         requisition_response_pull_record(),
         requisition_om_fields_pull_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::REQUISITION,
+        REQUISITION_OM_FIELDS.0,
+        PullDeleteRecordTable::Requisition,
+    )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -1,5 +1,5 @@
 use crate::sync::translations::{
-    requisition_line::LegacyRequisitionLineRow, LegacyTableName, PullUpsertRecord,
+    requisition_line::LegacyRequisitionLineRow, LegacyTableName, PullUpsertRecord, PullDeleteRecordTable,
 };
 
 use super::{TestSyncPullRecord, TestSyncPushRecord};
@@ -166,6 +166,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
         requisition_line_request_pull_record(),
         requisition_line_om_fields_pull_record(),
     ]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::REQUISITION_LINE,
+        REQUISITION_LINE_OM_FIELD.0,
+        PullDeleteRecordTable::RequisitionLine,
+    )]
 }
 
 pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -185,11 +185,11 @@ impl PullDeleteRecord {
             MasterListLine => MasterListLineRowRepository::new(con).delete(id),
             MasterListNameJoin => MasterListNameJoinRepository::new(con).delete(id),
             Report => ReportRowRepository::new(con).delete(id),
-            NameStoreJoin => todo!(),
-            Invoice => todo!(),
-            InvoiceLine => todo!(),
-            Requisition => todo!(),
-            RequisitionLine => todo!(),
+            NameStoreJoin => NameStoreJoinRepository::new(con).delete(id),
+            Invoice => InvoiceRowRepository::new(con).delete(id),
+            InvoiceLine => InvoiceLineRowRepository::new(con).delete(id),
+            Requisition => RequisitionRowRepository::new(con).delete(id),
+            RequisitionLine => RequisitionLineRowRepository::new(con).delete(id),
         }
     }
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullUpsertRecord, PushUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, PushUpsertRecord,
+    SyncTranslation,
 };
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -149,6 +150,10 @@ pub struct LegacyTransactRow {
     pub om_colour: Option<String>,
 }
 
+fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
+    sync_record.table_name == LegacyTableName::TRANSACT
+}
+
 pub(crate) struct InvoiceTranslation {}
 impl SyncTranslation for InvoiceTranslation {
     fn try_translate_pull_upsert(
@@ -156,8 +161,7 @@ impl SyncTranslation for InvoiceTranslation {
         connection: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let table_name = LegacyTableName::TRANSACT;
-        if sync_record.table_name != table_name {
+        if !match_pull_table(sync_record) {
             return Ok(None);
         }
 
@@ -215,6 +219,19 @@ impl SyncTranslation for InvoiceTranslation {
         Ok(Some(IntegrationRecords::from_upsert(
             PullUpsertRecord::Invoice(result),
         )))
+    }
+
+    fn try_translate_pull_delete(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        // TODO, check site ? (should never get delete records for this site, only transfer other half)
+        let result = match_pull_table(sync_record).then(|| {
+            IntegrationRecords::from_delete(&sync_record.record_id, PullDeleteRecordTable::Invoice)
+        });
+
+        Ok(result)
     }
 
     fn try_translate_push(
@@ -497,7 +514,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_invoice_translation() {
-        use crate::sync::test::test_data::transact as test_data;
+        use crate::sync::test::test_data::invoice as test_data;
         let translator = InvoiceTranslation {};
 
         let (_, connection, _, _) = setup_all(
@@ -509,6 +526,14 @@ mod tests {
         for record in test_data::test_pull_upsert_records() {
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            let translation_result = translator
+                .try_translate_pull_delete(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);


### PR DESCRIPTION
closes: #246 

I am not sure if name_store_join can be toggled without deleting it.
Also we should eventually add a condition to check that delete remote records are from foreign sites.
Added TODO for both of the above, and added checkbox for them in the epci

Should be pretty straight forward. I had one issue with postgres tests not passing in `pull_and_push` for delete integration, sync buffer rows are upserted with 'DELETE' action, and since they already have integartion_datetime set, those were not updated and deletes were not being integrated, fixed but made an issue to look at this in other areas: https://github.com/openmsupply/open-msupply/issues/247