### PR TITLE
250 name is customer and supplier to reflect in name store join

### DIFF
--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -198,9 +198,9 @@ impl<'a> SyncBufferRepository<'a> {
     }
 }
 
-type BoxedStocktakeQuery = IntoBoxed<'static, sync_buffer::table, DBType>;
+type BoxedSyncBufferQuery = IntoBoxed<'static, sync_buffer::table, DBType>;
 
-fn create_filtered_query<'a>(filter: Option<SyncBufferFilter>) -> BoxedStocktakeQuery {
+fn create_filtered_query<'a>(filter: Option<SyncBufferFilter>) -> BoxedSyncBufferQuery {
     let mut query = sync_buffer_dsl::sync_buffer.into_boxed();
 
     if let Some(f) = filter {

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -109,6 +109,19 @@ pub struct MockData {
     pub sync_buffer_rows: Vec<SyncBufferRow>,
 }
 
+impl MockData {
+    pub async fn insert(&self, connection: &StorageConnection) {
+        insert_mock_data(
+            connection,
+            MockDataInserts::all(),
+            MockDataCollection {
+                data: vec![("".to_string(), self.clone())],
+            },
+        )
+        .await;
+    }
+}
+
 #[derive(Default)]
 pub struct MockDataInserts {
     pub user_accounts: bool,

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -10,7 +10,7 @@ use crate::sync::{
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
 use util::{init_logger, LogLevel};
 
-use super::test_data::get_all_pull_delete_test_records;
+use super::{insert_all_extra_data, test_data::get_all_pull_delete_test_records};
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
@@ -21,6 +21,7 @@ async fn test_sync_pull_and_push() {
 
     // Test Pull Upsert
     let test_records = get_all_pull_upsert_test_records();
+    insert_all_extra_data(&test_records, &connection).await;
     let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
     SyncBufferRowRepository::new(&connection)
@@ -53,6 +54,7 @@ async fn test_sync_pull_and_push() {
 
     // Test Pull Delete
     let test_records = get_all_pull_delete_test_records();
+    insert_all_extra_data(&test_records, &connection).await;
     let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
     SyncBufferRowRepository::new(&connection)

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod number;
 pub(crate) mod report;
 pub(crate) mod requisition;
 pub(crate) mod requisition_line;
+pub(crate) mod special;
 pub(crate) mod stock_line;
 pub(crate) mod stocktake;
 pub(crate) mod stocktake_line;
@@ -39,6 +40,7 @@ pub(crate) fn get_all_pull_upsert_test_records() -> Vec<TestSyncPullRecord> {
     test_records.append(&mut invoice_line::test_pull_upsert_records());
     test_records.append(&mut invoice::test_pull_upsert_records());
     test_records.append(&mut unit::test_pull_upsert_records());
+    test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/number.rs
+++ b/server/service/src/sync/test/test_data/number.rs
@@ -144,6 +144,7 @@ fn number_purchase_order_pull_record() -> TestSyncPullRecord {
             r.record_id = PURCHASE_ORDER.0.to_string();
             r.data = PURCHASE_ORDER.1.to_string();
         }),
+        extra_data: None,
     }
 }
 

--- a/server/service/src/sync/test/test_data/special/mod.rs
+++ b/server/service/src/sync/test/test_data/special/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod name_to_name_store_join;

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -1,0 +1,180 @@
+use repository::{mock::MockData, NameRow, NameStoreJoinRow, StoreRow, SyncBufferRow};
+use util::{inline_edit, inline_init};
+
+use crate::sync::{
+    test::TestSyncPullRecord,
+    translations::{IntegrationRecords, LegacyTableName, PullUpsertRecord},
+};
+
+const NAME_1: (&'static str, &'static str) = (
+    "BEB2D69692C44B32B24BEBD5020BCD14",
+    r#"{
+        "ID": "BEB2D69692C44B32B24BEBD5020BCD14",
+        "supplier": false,
+        "customer": true,
+        "name": "General",
+        "fax": "",
+        "phone": "",
+        "bill_address1": "",
+        "bill_address2": "",
+        "charge code": "GEN",
+        "margin": 0,
+        "comment": "",
+        "currency_ID": "72C3E81AEF1F460686C31B1A1151E8C0",
+        "country": "",
+        "freightfac": 0,
+        "email": "",
+        "custom1": "",
+        "code": "GEN",
+        "last": "",
+        "first": "",
+        "title": "",
+        "female": false,
+        "date_of_birth": "0000-00-00",
+        "overpayment": 0,
+        "group_ID": "",
+        "hold": false,
+        "ship_address1": "",
+        "ship_address2": "",
+        "url": "",
+        "barcode": "",
+        "postal_address1": "",
+        "postal_address2": "",
+        "category1_ID": "",
+        "region_ID": "",
+        "type": "store",
+        "price_category": "",
+        "flag": "",
+        "manufacturer": false,
+        "print_invoice_alphabetical": false,
+        "custom2": "",
+        "custom3": "",
+        "default_order_days": 0,
+        "connection_type": 0,
+        "PATIENT_PHOTO": "data:image/png;base64,",
+        "NEXT_OF_KIN_ID": "",
+        "POBOX": "",
+        "ZIP": 0,
+        "middle": "",
+        "preferred": false,
+        "Blood_Group": "",
+        "marital_status": "",
+        "Benchmark": false,
+        "next_of_kin_relative": "",
+        "mother_id": "",
+        "postal_address3": "",
+        "postal_address4": "",
+        "bill_address3": "",
+        "bill_address4": "",
+        "ship_address3": "",
+        "ship_address4": "",
+        "ethnicity_ID": "",
+        "occupation_ID": "",
+        "religion_ID": "",
+        "national_health_number": "",
+        "Master_RTM_Supplier_Code": 0,
+        "ordering_method": "",
+        "donor": false,
+        "latitude": 0,
+        "longitude": 0,
+        "Master_RTM_Supplier_name": "",
+        "category2_ID": "",
+        "category3_ID": "",
+        "category4_ID": "",
+        "category5_ID": "",
+        "category6_ID": "",
+        "bill_address5": "",
+        "bill_postal_zip_code": "",
+        "postal_address5": "",
+        "postal_zip_code": "",
+        "ship_address5": "",
+        "ship_postal_zip_code": "",
+        "supplying_store_id": "",
+        "license_number": "",
+        "license_expiry": "0000-00-00",
+        "has_current_license": false,
+        "custom_data": null,
+        "maximum_credit": 0,
+        "nationality_ID": "",
+        "created_date": "0000-00-00",
+        "integration_ID": "",
+        "isDeceased": false,
+        "is_deleted": false
+    }"#,
+);
+
+pub fn name1() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = NAME_1.0.to_string();
+    })
+}
+
+pub fn name2() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = "609F9BAB7313424CB05A3B3D26F4E6FA".to_string();
+    })
+}
+
+pub fn store() -> StoreRow {
+    inline_init(|r: &mut StoreRow| {
+        r.id = "8576512519B44CCF840E191BABA89596".to_string();
+        r.name_id = name2().id;
+    })
+}
+
+pub fn name_store_join1() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: "name_to_name_store_join1".to_string(),
+        name_id: NAME_1.0.to_string(),
+        store_id: store().id,
+        name_is_customer: false,
+        name_is_supplier: true,
+    }
+}
+
+pub fn name_store_join2() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: "name_to_name_store_join2".to_string(),
+        name_id: NAME_1.0.to_string(),
+        store_id: store().id,
+        name_is_customer: false,
+        name_is_supplier: false,
+    }
+}
+
+pub fn name_store_join3() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: "name_to_name_store_join3".to_string(),
+        name_id: name2().id,
+        store_id: store().id,
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+    vec![TestSyncPullRecord {
+        translated_record: Some(IntegrationRecords::from_upserts(vec![
+            PullUpsertRecord::NameStoreJoin(inline_edit(&name_store_join1(), |mut r| {
+                r.name_is_customer = true;
+                r.name_is_supplier = false;
+                r
+            })),
+            PullUpsertRecord::NameStoreJoin(inline_edit(&name_store_join2(), |mut r| {
+                r.name_is_customer = true;
+                r.name_is_supplier = false;
+                r
+            })),
+        ])),
+        sync_buffer_row: inline_init(|r: &mut SyncBufferRow| {
+            r.table_name = LegacyTableName::NAME.to_owned();
+            r.record_id = NAME_1.0.to_owned();
+            r.data = NAME_1.1.to_owned();
+        }),
+        extra_data: Some(inline_init(|r: &mut MockData| {
+            r.stores = vec![store()];
+            r.names = vec![name1(), name2()];
+            r.name_store_joins = vec![name_store_join1(), name_store_join2(), name_store_join3()]
+        })),
+    }]
+}

--- a/server/service/src/sync/test/test_data/store.rs
+++ b/server/service/src/sync/test/test_data/store.rs
@@ -116,6 +116,7 @@ fn store_2() -> TestSyncPullRecord {
             r.record_id = STORE_2.0.to_owned();
             r.data = STORE_2.1.to_owned();
         }),
+        extra_data: None,
     }
 }
 
@@ -172,6 +173,7 @@ fn store_3() -> TestSyncPullRecord {
             r.record_id = STORE_3.0.to_owned();
             r.data = STORE_3.1.to_owned();
         }),
+        extra_data: None,
     }
 }
 
@@ -228,6 +230,7 @@ fn store_4() -> TestSyncPullRecord {
             r.record_id = STORE_4.0.to_owned();
             r.data = STORE_4.1.to_owned();
         }),
+        extra_data: None,
     }
 }
 

--- a/server/service/src/sync/translations/special/mod.rs
+++ b/server/service/src/sync/translations/special/mod.rs
@@ -1,0 +1,2 @@
+mod name_to_name_store_join;
+pub(crate) use name_to_name_store_join::*;

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -1,0 +1,84 @@
+use repository::{
+    EqualFilter, NameStoreJoinFilter, NameStoreJoinRepository, StorageConnection, SyncBufferRow,
+};
+
+use serde::Deserialize;
+
+use crate::sync::translations::{
+    IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation,
+};
+
+#[allow(non_snake_case)]
+#[derive(Deserialize)]
+pub struct PartialLegacyNameRow {
+    pub ID: String,
+    #[serde(rename = "customer")]
+    pub name_is_customer: bool,
+    #[serde(rename = "supplier")]
+    pub name_is_supplier: bool,
+}
+
+// In omSupply, is_customer and is_supplier relationship between store and name is stored
+// in name_store_join, in mSupply it's stored on name. This translator updates all name_store_joins
+// for name when name is pulled (setting is_customer and is_supplier appropriatly)
+// NOTE Translator should be removed when central server configures these properties on name_store_join
+pub(crate) struct NameToNameStoreJoinTranslation {}
+impl SyncTranslation for NameToNameStoreJoinTranslation {
+    fn try_translate_pull_upsert(
+        &self,
+        connection: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        if sync_record.table_name != LegacyTableName::NAME {
+            return Ok(None);
+        }
+
+        let data = serde_json::from_str::<PartialLegacyNameRow>(&sync_record.data)?;
+
+        let name_store_joins = NameStoreJoinRepository::new(connection)
+            .query_by_filter(NameStoreJoinFilter::new().name_id(EqualFilter::equal_to(&data.ID)))?;
+
+        if name_store_joins.len() == 0 {
+            return Ok(None);
+        }
+
+        let upserts: Vec<PullUpsertRecord> = name_store_joins
+            .into_iter()
+            .map(|mut r| {
+                r.name_is_customer = data.name_is_customer;
+                r.name_is_supplier = data.name_is_supplier;
+                PullUpsertRecord::NameStoreJoin(r)
+            })
+            .collect();
+
+        Ok(Some(IntegrationRecords::from_upserts(upserts)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_name_to_name_store_join_translation() {
+        use crate::sync::test::test_data::special::name_to_name_store_join as test_data;
+        let translator = NameToNameStoreJoinTranslation {};
+
+        let (_, connection, _, _) = setup_all(
+            "test_name_to_name_store_join_translation",
+            MockDataInserts::none().names(),
+        )
+        .await;
+
+        for record in test_data::test_pull_upsert_records() {
+            record.insert_extra_data(&connection).await;
+
+            let translation_result = translator
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}


### PR DESCRIPTION
closes: #250 

I think this is where Visitor pattern shines, it's only benefit as far as I can see (dynamically loading visitors, which we don't really use in sync), enforcing certain interface for developers to use, fragment complex operation into seperate steps (which would mean in this case, don't exist on the first match of translation). I could have added this to name translation, but I think it just make the method more crowded, and since this translation operation will eventually be removed it's better to do it in its own step. Thus had to modify integration slightly to allow all translators to try and translate.

Also added extra_data to sync pull test object.

Quite please that translation visitor interface makes this quite easy and clean