### PR TITLE
create rows with stock lines if available

### DIFF
--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -68,10 +68,12 @@ const getColumnLookup = <T extends RecordWithId>(): Record<
     key: 'expiryDate',
     label: 'label.expiry',
     width: 100,
-    formatter: dateString =>
-      dateString
+    formatter: dateString => {
+      if (dateString === '[multiple]') return '[multiple]';
+      return dateString
         ? Formatter.expiryDate(new Date(dateString as string)) || ''
-        : '',
+        : '';
+    },
   },
 
   itemCode: {

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -8,7 +8,7 @@ import {
   ExternalNavLink,
   List,
   PowerIcon,
-  RadioIcon,
+  // RadioIcon,
   // ReportsIcon,
   SettingsIcon,
   Theme,
@@ -216,11 +216,11 @@ export const AppDrawer: React.FC = () => {
       <LowerListContainer>
         <List>
           {drawer.isOpen && <StyledDivider color="drawerDivider" />}
-          <AppNavLink
+          {/* <AppNavLink
             to={AppRoute.Sync}
             icon={<RadioIcon fontSize="small" color="primary" />}
             text={t('sync')}
-          />
+          /> */}
           <ExternalNavLink
             to={docsUrl}
             icon={<BookIcon fontSize="small" color="primary" />}

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -90,7 +90,8 @@ export const useStocktakeColumns = ({
                 ArrayUtils.ifTheSameElseDefault(lines, 'expiryDate', null) ??
                 '';
               return (
-                (expiryDate && Formatter.expiryDate(new Date(expiryDate))) || ''
+                (expiryDate && Formatter.expiryDate(new Date(expiryDate))) ||
+                '[multiple]'
               );
             } else {
               return row.expiryDate
@@ -104,7 +105,7 @@ export const useStocktakeColumns = ({
               const expiryDate = ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'expiryDate',
-                null
+                '[multiple]'
               );
               return expiryDate;
             } else {
@@ -121,7 +122,11 @@ export const useStocktakeColumns = ({
             if ('lines' in row) {
               const { lines } = row;
               return (
-                ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '') ?? ''
+                ArrayUtils.ifTheSameElseDefault(
+                  lines,
+                  'packSize',
+                  '[multiple]'
+                ) ?? ''
               );
             } else {
               return row.packSize ?? '';
@@ -130,7 +135,11 @@ export const useStocktakeColumns = ({
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ArrayUtils.ifTheSameElseDefault(lines, 'packSize', '');
+              return ArrayUtils.ifTheSameElseDefault(
+                lines,
+                'packSize',
+                '[multiple]'
+              );
             } else {
               return rowData.packSize;
             }
@@ -146,12 +155,11 @@ export const useStocktakeColumns = ({
           if ('lines' in row) {
             const { lines } = row;
             return (
-              ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'snapshotNumberOfPacks',
-                ''
-              ) ?? ''
-            );
+              lines.reduce(
+                (total, line) => total + line.snapshotNumberOfPacks,
+                0
+              ) ?? 0
+            ).toString();
           } else {
             return row.snapshotNumberOfPacks ?? '';
           }
@@ -159,11 +167,12 @@ export const useStocktakeColumns = ({
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
             const { lines } = rowData;
-            return ArrayUtils.ifTheSameElseDefault(
-              lines,
-              'snapshotNumberOfPacks',
-              ''
-            );
+            return (
+              lines.reduce(
+                (total, line) => total + line.snapshotNumberOfPacks,
+                0
+              ) ?? 0
+            ).toString();
           } else {
             return rowData.snapshotNumberOfPacks;
           }
@@ -178,12 +187,11 @@ export const useStocktakeColumns = ({
           if ('lines' in row) {
             const { lines } = row;
             return (
-              ArrayUtils.ifTheSameElseDefault(
-                lines,
-                'countedNumberOfPacks',
-                ''
-              ) ?? ''
-            );
+              lines.reduce(
+                (total, line) => total + (line.countedNumberOfPacks ?? 0),
+                0
+              ) ?? 0
+            ).toString();
           } else {
             return row.countedNumberOfPacks ?? '';
           }
@@ -191,11 +199,12 @@ export const useStocktakeColumns = ({
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
             const { lines } = rowData;
-            return ArrayUtils.ifTheSameElseDefault(
-              lines,
-              'countedNumberOfPacks',
-              ''
-            );
+            return (
+              lines.reduce(
+                (total, line) => total + (line.countedNumberOfPacks ?? 0),
+                0
+              ) ?? 0
+            ).toString();
           } else {
             return rowData.countedNumberOfPacks;
           }

--- a/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -8,6 +8,7 @@ import {
   RouteBuilder,
   useNavigate,
   useTranslation,
+  GlobalStyles,
 } from '@openmsupply-client/common';
 import { ItemRowFragment } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
@@ -40,6 +41,14 @@ export const DetailView: FC = () => {
 
   return !!data ? (
     <TableProvider createStore={createTableStore}>
+      <GlobalStyles
+        styles={{
+          '@keyframes highlight': {
+            from: { backgroundColor: 'rgba(199, 201, 217, 1)' },
+            to: { backgroundColor: 'rgba(199, 201, 217, 0)' },
+          },
+        }}
+      />
       <AppBarButtons onAddItem={() => onOpen()} />
       <Toolbar />
 

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -15,6 +15,7 @@ import {
   createTableStore,
   createQueryParamsStore,
   QueryParamsProvider,
+  useRowStyle,
 } from '@openmsupply-client/common';
 import { StocktakeLineEditForm } from './StocktakeLineEditForm';
 import { useStocktakeLineEdit } from './hooks';
@@ -51,6 +52,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const t = useTranslation(['common', 'inventory']);
   const { draftLines, update, addLine, isLoading, save, nextItem } =
     useStocktakeLineEdit(currentItem);
+  const { setRowStyle } = useRowStyle();
 
   const onNext = async () => {
     await save(draftLines);
@@ -64,6 +66,13 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const onOk = async () => {
     try {
       await save(draftLines);
+      if (item) {
+        const highlight = {
+          animation: 'highlight 1.5s',
+        };
+        const rowIds = draftLines.map(line => line.id);
+        rowIds.forEach(id => setRowStyle(id, highlight));
+      }
       onClose();
     } catch (e) {
       error(t('error.cant-save'))();

--- a/client/packages/inventory/src/Stocktake/ListView/CreateStocktakeButton.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/CreateStocktakeButton.tsx
@@ -4,7 +4,10 @@ import { PlusCircleIcon } from '@common/icons';
 import { useFormatDateTime, useTranslation } from '@common/intl';
 import { ToggleState } from '@common/hooks';
 import { useStocktake } from '../api';
-import { StockItemSelectModal } from '@openmsupply-client/system';
+import {
+  ItemWithStockLines,
+  StockItemSelectModal,
+} from '@openmsupply-client/system';
 import { useAuthContext } from '@openmsupply-client/common';
 
 export const CreateStocktakeButton: React.FC<{
@@ -15,13 +18,13 @@ export const CreateStocktakeButton: React.FC<{
   const { user } = useAuthContext();
   const { localisedDate } = useFormatDateTime();
 
-  const onChange = async (itemIds?: string[]) => {
+  const onChange = async (items?: ItemWithStockLines[]) => {
     const description = t('stocktake.description-template', {
       username: user ? user.name : 'unknown user',
       date: localisedDate(new Date()),
     });
 
-    await mutateAsync({ description, itemIds });
+    await mutateAsync({ description, items });
   };
 
   return (

--- a/client/packages/inventory/src/Stocktake/api/api.ts
+++ b/client/packages/inventory/src/Stocktake/api/api.ts
@@ -17,6 +17,7 @@ import {
   StocktakeLineFragment,
 } from './operations.generated';
 import { DraftStocktakeLine } from './../DetailView/modal/StocktakeLineEdit';
+import { StockLineFragment } from 'packages/system/src';
 
 export type ListParams = {
   first: number;
@@ -174,7 +175,11 @@ export const getStocktakeQueries = (sdk: Sdk, storeId: string) => ({
     const result = await sdk.upsertStocktakeLines(input);
     return result;
   },
-  insertStocktake: async (description: string, itemIds?: string[]) => {
+
+  insertStocktake: async (
+    description: string,
+    items?: { itemId: string; stockLines?: StockLineFragment[] }[]
+  ) => {
     const result =
       (await sdk.insertStocktake({
         input: {
@@ -185,12 +190,11 @@ export const getStocktakeQueries = (sdk: Sdk, storeId: string) => ({
     const { insertStocktake } = result;
 
     if (insertStocktake?.__typename === 'StocktakeNode') {
-      if (itemIds) {
-        const insertStocktakeLines = itemIds.map(itemId => ({
-          id: FnUtils.generateUUID(),
-          stocktakeId: insertStocktake.id,
-          itemId,
-        }));
+      if (items) {
+        const insertStocktakeLines = getInsertStocktakeLines(
+          insertStocktake.id,
+          items
+        );
         await sdk.upsertStocktakeLines({
           storeId,
           insertStocktakeLines,
@@ -207,3 +211,36 @@ export const getStocktakeQueries = (sdk: Sdk, storeId: string) => ({
     throw new Error('Could not create stocktake');
   },
 });
+
+const getInsertStocktakeLines = (
+  stocktakeId: string,
+  items: { itemId: string; stockLines?: StockLineFragment[] | undefined }[]
+) => {
+  const insertStocktakeLines = [] as InsertStocktakeLineInput[];
+
+  items.forEach(item => {
+    const { itemId, stockLines } = item;
+
+    if (stockLines) {
+      stockLines.forEach(stockLine => {
+        insertStocktakeLines.push({
+          id: FnUtils.generateUUID(),
+          stocktakeId,
+          stockLineId: stockLine.id,
+          batch: stockLine.batch,
+          countedNumberOfPacks: stockLine.availableNumberOfPacks,
+          packSize: stockLine.packSize,
+          costPricePerPack: stockLine.costPricePerPack,
+          sellPricePerPack: stockLine.sellPricePerPack,
+        });
+      });
+    } else {
+      insertStocktakeLines.push({
+        id: FnUtils.generateUUID(),
+        stocktakeId,
+        itemId,
+      });
+    }
+  });
+  return insertStocktakeLines;
+};

--- a/client/packages/inventory/src/Stocktake/api/api.ts
+++ b/client/packages/inventory/src/Stocktake/api/api.ts
@@ -176,10 +176,13 @@ export const getStocktakeQueries = (sdk: Sdk, storeId: string) => ({
     return result;
   },
 
-  insertStocktake: async (
-    description: string,
-    items?: { itemId: string; stockLines?: StockLineFragment[] }[]
-  ) => {
+  insertStocktake: async ({
+    description,
+    items,
+  }: {
+    description: string;
+    items?: { itemId: string; stockLines?: StockLineFragment[] }[];
+  }) => {
     const result =
       (await sdk.insertStocktake({
         input: {
@@ -228,9 +231,9 @@ const getInsertStocktakeLines = (
           stocktakeId,
           stockLineId: stockLine.id,
           batch: stockLine.batch,
-          countedNumberOfPacks: stockLine.availableNumberOfPacks,
-          packSize: stockLine.packSize,
           costPricePerPack: stockLine.costPricePerPack,
+          expiryDate: stockLine.expiryDate,
+          packSize: stockLine.packSize,
           sellPricePerPack: stockLine.sellPricePerPack,
         });
       });

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useInsertStocktake.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useInsertStocktake.ts
@@ -3,37 +3,17 @@ import {
   useQueryClient,
   useMutation,
 } from '@openmsupply-client/common';
-import { StockLineFragment } from '@openmsupply-client/system';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useInsertStocktake = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const api = useStocktakeApi();
-  return useMutation<
-    { __typename: 'StocktakeNode'; id: string; stocktakeNumber: number },
-    unknown,
-    {
-      description: string;
-      items: { itemId: string; stockLines?: StockLineFragment[] }[] | undefined;
+
+  return useMutation(api.insertStocktake, {
+    onSuccess: ({ stocktakeNumber }) => {
+      navigate(String(stocktakeNumber));
+      return queryClient.invalidateQueries(api.keys.base());
     },
-    unknown
-  >(
-    ({
-      description,
-      items,
-    }: {
-      description: string;
-      items?: {
-        itemId: string;
-        stockLines?: StockLineFragment[];
-      }[];
-    }) => api.insertStocktake(description, items),
-    {
-      onSuccess: ({ stocktakeNumber }) => {
-        navigate(String(stocktakeNumber));
-        return queryClient.invalidateQueries(api.keys.base());
-      },
-    }
-  );
+  });
 };

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useInsertStocktake.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useInsertStocktake.ts
@@ -3,6 +3,7 @@ import {
   useQueryClient,
   useMutation,
 } from '@openmsupply-client/common';
+import { StockLineFragment } from '@openmsupply-client/system';
 import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useInsertStocktake = () => {
@@ -12,11 +13,22 @@ export const useInsertStocktake = () => {
   return useMutation<
     { __typename: 'StocktakeNode'; id: string; stocktakeNumber: number },
     unknown,
-    { description: string; itemIds: string[] | undefined },
+    {
+      description: string;
+      items: { itemId: string; stockLines?: StockLineFragment[] }[] | undefined;
+    },
     unknown
   >(
-    ({ description, itemIds }: { description: string; itemIds?: string[] }) =>
-      api.insertStocktake(description, itemIds),
+    ({
+      description,
+      items,
+    }: {
+      description: string;
+      items?: {
+        itemId: string;
+        stockLines?: StockLineFragment[];
+      }[];
+    }) => api.insertStocktake(description, items),
     {
       onSuccess: ({ stocktakeNumber }) => {
         navigate(String(stocktakeNumber));

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -73,6 +73,29 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
 
       throw new Error('Could not fetch items');
     },
+    stockItemsWithStockLines: async ({
+      first,
+      offset,
+      sortBy,
+      filterBy,
+    }: ListParams<ItemRowFragment>) => {
+      const result = await sdk.itemsWithStockLines({
+        first,
+        offset,
+        key: itemParsers.toSortField(sortBy),
+        desc: sortBy.isDesc,
+        storeId,
+        filter: { ...filterBy, type: { equalTo: ItemNodeType.Stock } },
+      });
+
+      const { items } = result;
+
+      if (result?.items?.__typename === 'ItemConnector') {
+        return items;
+      }
+
+      throw new Error('Could not fetch items');
+    },
     list: async ({
       first,
       offset,

--- a/client/packages/system/src/Item/api/hooks/index.ts
+++ b/client/packages/system/src/Item/api/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './useItems';
 export * from './useStockLines';
 export * from './useItemApi';
 export * from './useStockItemsWithStats';
+export * from './useStockItemsWithStockLines';
 export * from './useServiceItems';
 export * from './useStockItems';
 export * from './useDefaultServiceItem';

--- a/client/packages/system/src/Item/api/hooks/useStockItemsWithStockLines/index.ts
+++ b/client/packages/system/src/Item/api/hooks/useStockItemsWithStockLines/index.ts
@@ -1,0 +1,1 @@
+export * from './useStockItemsWithStockLines';

--- a/client/packages/system/src/Item/api/hooks/useStockItemsWithStockLines/useStockItemsWithStockLines.tsx
+++ b/client/packages/system/src/Item/api/hooks/useStockItemsWithStockLines/useStockItemsWithStockLines.tsx
@@ -1,7 +1,7 @@
 import { ItemNodeType, useQuery } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
-export const useStockItemsWithStats = () => {
+export const useStockItemsWithStockLines = () => {
   const queryParams = {
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
     offset: 0,
@@ -9,7 +9,8 @@ export const useStockItemsWithStats = () => {
     filterBy: { type: { equalTo: ItemNodeType.Stock } },
   };
   const api = useItemApi();
+
   return useQuery(api.keys.paramList(queryParams), () =>
-    api.get.stockItemsWithStats(queryParams)
+    api.get.stockItemsWithStockLines(queryParams)
   );
 };


### PR DESCRIPTION
Fixes #243 
and https://github.com/openmsupply/open-msupply-internal/issues/7

Creates stocktake lines for each available stock line, if there are any for the items selected.
Sets the counted quantity to be the available quantity, as does mSupply.

Have also tweaked the grouping display, so that it shows `[multiple]` a little more, and adds the quantities ( even though this is dodgy, given pack sizes )

## Testing

- [ ] Create a stocktake for an item with stock: should show the available quantity in the stocktake
- [ ] Include an item with no stock: should behave as it does now
- [ ] Include an item with multiple stock lines: should create multiple
- [ ] The counted qty should be same as available qty