### PR TITLE
255 update existing sync integraiton tests

### DIFF
--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -34,5 +34,6 @@ rand = "0.8.5"
 
 [features]
 default = ["sqlite"]
+integration_test = []
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]

--- a/server/service/src/lib.rs
+++ b/server/service/src/lib.rs
@@ -1,3 +1,5 @@
+// json! hits recursion limit in integration test (central_server_configurations), recusion_limit attribute must be top level
+#![cfg_attr(feature = "integration_test", recursion_limit = "256")]
 use repository::RepositoryError;
 use repository::{Pagination, PaginationOption, DEFAULT_PAGINATION_LIMIT};
 use service_provider::ServiceContext;

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -53,15 +53,16 @@ impl CentralDataSynchroniser {
         &self,
         connection: &StorageConnection,
     ) -> Result<(), CentralSyncError> {
-        let cursor: u32 = CentralSyncPullCursor::new(&connection)
-            .get_cursor()
-            .unwrap_or(0);
-
         // Arbitrary batch size.
         const BATCH_SIZE: u32 = 500;
 
+        // TODO protection fron infinite loop
         loop {
             info!("Pulling central sync records...");
+            let cursor: u32 = CentralSyncPullCursor::new(&connection)
+                .get_cursor()
+                .unwrap_or(0);
+
             let sync_batch: CentralSyncBatchV5 = self
                 .sync_api_v5
                 .get_central_records(cursor, BATCH_SIZE)

--- a/server/service/src/sync/sync_api_v3.rs
+++ b/server/service/src/sync/sync_api_v3.rs
@@ -122,62 +122,6 @@ impl SyncApiV3 {
         })
     }
 
-    pub async fn get_initial_dump(
-        &self,
-        from_site: u32,
-        to_site: u32,
-    ) -> anyhow::Result<serde_json::Value> {
-        let query = [("from_site", from_site), ("to_site", to_site)];
-
-        let response = self
-            .client
-            .get(self.server_url.join("/sync/v3/initial_dump")?)
-            .basic_auth(
-                &self.credentials.username,
-                Some(&self.credentials.password_sha256),
-            )
-            .query(&query)
-            .headers(self.extra_headers.clone())
-            .send()
-            .await?
-            .error_for_status()?;
-
-        let response = response.json().await?;
-        let response = validate_response(response)?;
-        Ok(response)
-    }
-
-    pub async fn get_queued_records(
-        &self,
-        from_site: u32,
-        to_site: u32,
-        limit: u32,
-    ) -> anyhow::Result<Vec<RemoteGetRecordV3>> {
-        let query = [
-            ("from_site", from_site),
-            ("to_site", to_site),
-            ("limit", limit),
-        ];
-
-        let response = self
-            .client
-            .get(self.server_url.join("/sync/v3/queued_records")?)
-            .basic_auth(
-                &self.credentials.username,
-                Some(&self.credentials.password_sha256),
-            )
-            .query(&query)
-            .headers(self.extra_headers.clone())
-            .send()
-            .await?
-            .error_for_status()?;
-
-        let response = response.json().await?;
-        let response = validate_response(response)?;
-        let response = serde_json::from_value(response)?;
-        Ok(response)
-    }
-
     pub async fn post_queued_records(
         &self,
         from_site: u32,

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -1,0 +1,242 @@
+use std::env;
+
+use rand::{thread_rng, Rng};
+use reqwest::{Client, Url};
+use serde_json::json;
+use util::{hash::sha256, uuid::uuid};
+
+use crate::sync::{settings::SyncSettings, SyncApiV5, SyncConnectionError, SyncCredentials};
+
+impl SyncApiV5 {
+    pub(crate) async fn upsert_central_records(
+        &self,
+        value: &serde_json::Value,
+    ) -> Result<(), SyncConnectionError> {
+        self.create_post("/sync/v5/test/upsert", value)?
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(())
+    }
+}
+
+pub(crate) struct ConfigureCentralServer {
+    api: SyncApiV5,
+    new_site_password: String,
+    server_url: String,
+}
+
+pub(crate) struct CreateSyncSiteResult {
+    pub(crate) new_site_properties: NewSiteProperties,
+    pub(crate) sync_settings: SyncSettings,
+}
+
+impl ConfigureCentralServer {
+    // SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test sync_integration_test --features integration_test
+    // OR in VSCODE settings if using rust analyzer:
+    // "rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass", "NEW_SITE_PASSWORD": "pass"}
+    // "rust-analyzer.cargo.features": ["integration_test"]
+    pub(crate) fn from_env() -> ConfigureCentralServer {
+        let password =
+            env::var("SYNC_SITE_PASSWORD").expect("SYNC_SITE_PASSWORD env variable missing");
+        let new_site_password =
+            env::var("NEW_SITE_PASSWORD").expect("NEW_SITE_PASSWORD env variable missing");
+        let site_name = env::var("SYNC_SITE_NAME").expect("SYNC_SITE_NAME env variable missing");
+        let url = env::var("SYNC_URL").expect("SYNC_URL env variable missing");
+
+        ConfigureCentralServer {
+            api: SyncApiV5::new(
+                Url::parse(&url).unwrap(),
+                SyncCredentials {
+                    username: site_name,
+                    password_sha256: sha256(&password),
+                },
+                Client::new(),
+                "",
+            ),
+            server_url: url,
+            new_site_password,
+        }
+    }
+
+    pub(crate) async fn create_sync_site_with_extra_data<F>(
+        &self,
+        // Before site is inserted and linked to store
+        pre_site_creation_data: F,
+    ) -> anyhow::Result<CreateSyncSiteResult>
+    where
+        F: Fn(&NewSiteProperties) -> serde_json::Value,
+    {
+        let new_site_properties = NewSiteProperties::new(&self.new_site_password);
+        self.api
+            .upsert_central_records(&new_site_properties.preliminary_data())
+            .await?;
+        self.api
+            .upsert_central_records(&pre_site_creation_data(&new_site_properties))
+            .await?;
+
+        self.api
+            .upsert_central_records(&new_site_properties.site_data())
+            .await?;
+
+        Ok(CreateSyncSiteResult {
+            sync_settings: SyncSettings {
+                url: self.server_url.clone(),
+                username: new_site_properties.site_id_as_string(),
+                password_sha256: new_site_properties.password_sha256.clone(),
+                interval_sec: 10000000,
+                central_server_site_id: 1,
+                site_id: new_site_properties.site_id as u32,
+            },
+            new_site_properties,
+        })
+    }
+}
+
+pub(crate) struct NewSiteProperties {
+    pub(crate) store_id: String,
+    pub(crate) name_id: String,
+    pref_id: String,
+    site_uuid: String,
+    site_id: u16,
+    password_sha256: String,
+}
+
+impl NewSiteProperties {
+    fn new(password: &str) -> NewSiteProperties {
+        NewSiteProperties {
+            store_id: uuid(),
+            name_id: uuid(),
+            pref_id: uuid(),
+            // TODO max that can be used ?
+            site_id: thread_rng().gen::<u16>(),
+            site_uuid: uuid(),
+            password_sha256: sha256(password),
+        }
+    }
+    fn site_id_as_string(&self) -> String {
+        format!("{}", self.site_id)
+    }
+
+    // Data for creating site was deduced by doing diff of central data by running below code before and after creating store and site
+    // re-saving export each time for clean diff and doing a temp commit (or can save to multiple files and do --no-index git diff)
+    //
+    // var $content : Text
+    // For each ($tableName; ds)
+    // $recordInTable:=ds[$tableName].all()
+    // For each ($record; $recordInTable)
+    //     $content:=$content+$tableName+JSON Stringify($record.toObject(); *)
+    // End for each
+    // End for each
+    // $file:=File("/Users/Drei/Documents/repos/work/msupply/out.txt")
+    // $file.create()
+    // $file.setText($content; Document with CR)
+
+    // Data without site
+    fn preliminary_data(&self) -> serde_json::Value {
+        json!(
+        {
+            "name": [
+                {
+                    "ID": self.name_id,
+                    "name": self.name_id
+                }
+            ],
+            "store": [
+                {
+                    "ID":  self.store_id,
+                    "name":  self.store_id,
+                    "code":  self.store_id,
+                    "name_ID":  self.name_id,
+                    "sync_id_remote_site": 0,
+                    "store_mode": "store"
+                }
+            ],
+            "pref": [
+                {
+                    "item": "store_preferences",
+                    "user_ID": "",
+                    "ID": self.pref_id,
+                    "network_ID": "",
+                    "store_ID":  self.store_id,
+                    "data": {
+                        "sort_batches_by_VVM_not_expiry": false,
+                        "new_patients_visible_in_this_store_only": true,
+                        "new_names_visible_in_this_store_only": true,
+                        "can_enter_total_distribution_quantities": false,
+                        "round_up_distribute_quantities": false,
+                        "can_pack_items_into_multiple_boxes": false,
+                        "can_issue_in_foreign_currency": false,
+                        "edit_sell_price_on_customer_invoice_lines": false,
+                        "purchase_order_must_be_authorised": false,
+                        "finalise_customer_invoices_automatically": false,
+                        "customer_invoices_must_be_authorised": false,
+                        "customer_invoice_authorisation_needed_only_if_over_budget": false,
+                        "confirm_customer_invoices_automatically": false,
+                        "supplier_invoices_must_be_authorised": false,
+                        "confirm_supplier_invoices_automatically": false,
+                        "goods_received_lines_must_be_authorised": false,
+                        "must_enter_locations_on_goods_received": false,
+                        "can_specify_manufacturer": false,
+                        "show_item_unit_column_while_issuing": false,
+                        "log_editing_transacts": false,
+                        "default_item_packsize_to_one": true,
+                        "shouldAuthoriseResponseRequisition": false,
+                        "includeRequisitionsInSuppliersRemoteAuthorisationProcesses": false,
+                        "canLinkRequistionToSupplierInvoice": false,
+                        "responseRequisitionAutoFillSupplyQuantity": false,
+                        "useExtraFieldsForRequisitions": false,
+                        "CommentFieldToBeShownOnSupplierInvoiceLines": false,
+                        "UseEDDPlaceholderLinesOnSupplierInvoice": false,
+                        "consolidateBatches": false,
+                        "editPrescribedQuantityOnPrescription": false,
+                        "chooseDiagnosisOnPrescription": false,
+                        "useConsumptionAndStockFromCustomersForInternalOrders": false,
+                        "monthlyConsumptionEnforceLookBackPeriod": false,
+                        "usesVaccineModule": false,
+                        "usesDashboardModule": false,
+                        "usesCashRegisterModule": false,
+                        "usesPaymentModule": false,
+                        "usesPatientTypes": false,
+                        "usesHideSnapshotColumn": false,
+                        "good_receipt_finalise_next_action": "supplier_invoice_on_hold",
+                        "stock_transfer_supplier_invoice_is_on_hold": true,
+                        "monthlyConsumptionLookBackPeriod": "0",
+                        "monthsLeadTime": "0",
+                        "usesDispensaryModule": false,
+                        "monthsOverstock": 6 as u32,
+                        "monthsUnderstock": 3 as u32,
+                        "monthsItemsExpire": 3 as u32,
+                    }
+                }
+            ]
+        })
+    }
+
+    // Data with site (relies on preliminary data already inserted)
+    fn site_data(&self) -> serde_json::Value {
+        json!(
+        {
+            "site": [
+                {
+                    "ID":  self.site_uuid,
+                    "site_ID": self.site_id,
+                    "name":  self.site_id_as_string(),
+                    "password":  self.password_sha256,
+                    "code": self.site_id_as_string()
+                }
+            ],
+            "store": [
+                {
+                    "ID":  self.store_id,
+                    "name":  self.store_id,
+                    "code":  self.store_id,
+                    "name_ID":  self.name_id,
+                    "sync_id_remote_site":  self.site_id,
+                    "store_mode": "store"
+                }
+            ]
+        })
+    }
+}

--- a/server/service/src/sync/test/integration/location.rs
+++ b/server/service/src/sync/test/integration/location.rs
@@ -1,11 +1,19 @@
 use repository::{LocationRow, LocationRowRepository, StorageConnection};
 use util::{inline_edit, uuid::uuid};
 
-use super::remote_sync_integration_test::SyncRecordTester;
+use super::{
+    central_server_configurations::NewSiteProperties,
+    remote_sync_integration_test::SyncRecordTester,
+};
 
 pub struct LocationSyncRecordTester {}
 impl SyncRecordTester<Vec<LocationRow>> for LocationSyncRecordTester {
-    fn insert(&self, connection: &StorageConnection, store_id: &str) -> Vec<LocationRow> {
+    fn insert(
+        &self,
+        connection: &StorageConnection,
+        new_site_properties: &NewSiteProperties,
+    ) -> Vec<LocationRow> {
+        let store_id = &new_site_properties.store_id;
         let rows = vec![LocationRow {
             id: uuid(),
             name: "LoationName".to_string(),
@@ -20,7 +28,12 @@ impl SyncRecordTester<Vec<LocationRow>> for LocationSyncRecordTester {
         rows
     }
 
-    fn mutate(&self, connection: &StorageConnection, rows: &Vec<LocationRow>) -> Vec<LocationRow> {
+    fn mutate(
+        &self,
+        connection: &StorageConnection,
+        _: &NewSiteProperties,
+        rows: &Vec<LocationRow>,
+    ) -> Vec<LocationRow> {
         let repo = LocationRowRepository::new(&connection);
         let rows = rows
             .iter()

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -1,3 +1,4 @@
+mod central_server_configurations;
 mod invoice;
 mod location;
 mod number;

--- a/server/service/src/sync/test/integration/number.rs
+++ b/server/service/src/sync/test/integration/number.rs
@@ -1,11 +1,19 @@
 use repository::{NumberRow, NumberRowRepository, NumberRowType, StorageConnection};
 use util::{inline_edit, uuid::uuid};
 
-use super::remote_sync_integration_test::{gen_i64, SyncRecordTester};
+use super::{
+    central_server_configurations::NewSiteProperties,
+    remote_sync_integration_test::{gen_i64, SyncRecordTester},
+};
 
 pub struct NumberSyncRecordTester {}
 impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
-    fn insert(&self, connection: &StorageConnection, store_id: &str) -> Vec<NumberRow> {
+    fn insert(
+        &self,
+        connection: &StorageConnection,
+        new_site_properties: &NewSiteProperties,
+    ) -> Vec<NumberRow> {
+        let store_id = &new_site_properties.store_id;
         let number_repo = NumberRowRepository::new(&connection);
 
         let mut row_0 = number_repo
@@ -81,7 +89,12 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
         rows
     }
 
-    fn mutate(&self, connection: &StorageConnection, rows: &Vec<NumberRow>) -> Vec<NumberRow> {
+    fn mutate(
+        &self,
+        connection: &StorageConnection,
+        _: &NewSiteProperties,
+        rows: &Vec<NumberRow>,
+    ) -> Vec<NumberRow> {
         let number_repo = NumberRowRepository::new(&connection);
         let rows = rows
             .iter()

--- a/server/service/src/sync/test/integration/stock_line.rs
+++ b/server/service/src/sync/test/integration/stock_line.rs
@@ -5,11 +5,19 @@ use repository::{
 };
 use util::{inline_edit, uuid::uuid};
 
-use super::remote_sync_integration_test::SyncRecordTester;
+use super::{
+    central_server_configurations::NewSiteProperties,
+    remote_sync_integration_test::SyncRecordTester,
+};
 
 pub struct StockLineRecordTester {}
 impl SyncRecordTester<Vec<StockLineRow>> for StockLineRecordTester {
-    fn insert(&self, connection: &StorageConnection, store_id: &str) -> Vec<StockLineRow> {
+    fn insert(
+        &self,
+        connection: &StorageConnection,
+        new_site_properties: &NewSiteProperties,
+    ) -> Vec<StockLineRow> {
+        let store_id = &new_site_properties.store_id;
         // create test location
         let location = LocationRow {
             id: uuid(),
@@ -51,6 +59,7 @@ impl SyncRecordTester<Vec<StockLineRow>> for StockLineRecordTester {
     fn mutate(
         &self,
         connection: &StorageConnection,
+        _: &NewSiteProperties,
         rows: &Vec<StockLineRow>,
     ) -> Vec<StockLineRow> {
         let repo = StockLineRowRepository::new(&connection);

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -1,4 +1,5 @@
-// mod integration;
+#[cfg(feature = "integration_test")]
+mod integration;
 mod pull_and_push;
 pub(crate) mod test_data;
 


### PR DESCRIPTION
closes #255

some of these changes feel a bit dirty, but I think it might be ok for tests for now.

requires this central branch: https://github.com/sussol/msupply/compare/feature/sync-v5...feature/sync-v5-test-temp (will be PRed).

Should be able to run integration test with rust analyzer or from command line, as per comment (need a datafile with a sync site, should work on empty data files with a sync site).
```
    // SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test sync_integration_test --features integration_test
    // OR in VSCODE settings if using rust analyzer:
    // "rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass", "NEW_SITE_PASSWORD": "pass"}
    // "rust-analyzer.cargo.features": ["integration_test"]
```

I also added a bit more info to errors, Clemens already done something similar to status, but I had an issue with status be fine but error showing in xml form. Also i remember approving PR for sync api relocation to api directory, I shouldn't have approved it, we've discussed partitioning by functionality vs characteristics, and i think we've agreed: by functionality.

The changers in individual test record implementations are:
* Central data is added to server (item, extra name and store)
* Not querying for any remote data, upserting it (we have store_id of new site, so using that to make sure this data syncs)

Sometime have Server Unavailable when running all tests at once, made a not to look into it, I think Rust is too fast for 4d : / hehe

please see issue for more details
