### PR TITLE
266 os placeholder rows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmsupply-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "start-local": "lerna run --scope @openmsupply-client/* --parallel start-local",

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -13,6 +13,7 @@ import { DraftOutboundLine } from '../../../types';
 import { PackSizeController, useOutboundLineEditRows } from './hooks';
 import { useOutbound } from '../../api';
 import { useOutboundLineEditColumns } from './columns';
+import { shouldUpdatePlaceholder } from './utils';
 
 export interface OutboundLineEditTableProps {
   onChange: (key: string, value: number, packSize: number) => void;
@@ -67,11 +68,20 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
   packSizeController,
   rows,
 }) => {
-  const columns = useOutboundLineEditColumns({ onChange });
   const { orderedRows, placeholderRow } = useOutboundLineEditRows(
     rows,
     packSizeController
   );
+  const onEditStockLine = (key: string, value: number, packSize: number) => {
+    onChange(key, value, packSize);
+    if (placeholderRow && shouldUpdatePlaceholder(value, placeholderRow))
+      // if a stock line has been allocated
+      // and the placeholder row is a generated one with a zero value,
+      // this allows removal of the placeholder row
+      placeholderRow.isUpdated = true;
+  };
+
+  const columns = useOutboundLineEditColumns({ onChange: onEditStockLine });
 
   return (
     <Box style={{ width: '100%' }}>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
@@ -131,6 +131,10 @@ export const allocateQuantities =
 
       if (!placeholder) throw new Error('No placeholder within item editing');
 
+      // stock has been allocated, and the auto generated placeholder is no longer required
+      if (shouldUpdatePlaceholder(newValue, placeholder))
+        placeholder.isUpdated = true;
+
       newDraftOutboundLines[placeholderIdx] = {
         ...placeholder,
         numberOfPacks: placeholder.numberOfPacks + toAllocate,
@@ -253,3 +257,8 @@ const reduceBatchAllocation = ({
     });
   return Math.abs(toAllocate);
 };
+
+export const shouldUpdatePlaceholder = (
+  quantity: number,
+  placeholder: DraftOutboundLine
+) => quantity > 0 && placeholder.numberOfPacks === 0 && !placeholder.isCreated;


### PR DESCRIPTION
Fixes #266 

Patch release to fix the outbound placeholder row issue.

Setting the `isUpdated` flag on placeholder rows that have `isCreated` false (i.e. are sent by the server) and have a value of `0` - when a quantity is allocated to a stock line row.

This then will send a delete request for that unallocated row, when the allocated row is inserted or updated.