### PR TITLE
sql_function! macro to allow lowercase comparison for usernames.

### DIFF
--- a/server/repository/src/db_diesel/user_row.rs
+++ b/server/repository/src/db_diesel/user_row.rs
@@ -1,6 +1,6 @@
 use super::{user_row::user_account::dsl as user_account_dsl, StorageConnection, User};
 
-use crate::repository_error::RepositoryError;
+use crate::{lower, repository_error::RepositoryError};
 
 use diesel::prelude::*;
 
@@ -58,14 +58,10 @@ impl<'a> UserAccountRowRepository<'a> {
         &self,
         username: &str,
     ) -> Result<Option<UserAccountRow>, RepositoryError> {
-        #[cfg(feature = "postgres")]
         let result: Result<UserAccountRow, diesel::result::Error> = user_account_dsl::user_account
-            .filter(user_account_dsl::username.ilike(username))
+            .filter(lower(user_account_dsl::username).eq(lower(username)))
             .first(&self.connection.connection);
-        #[cfg(not(feature = "postgres"))]
-        let result: Result<UserAccountRow, diesel::result::Error> = user_account_dsl::user_account
-            .filter(user_account_dsl::username.like(username))
-            .first(&self.connection.connection);
+
         match result {
             Ok(row) => Ok(Some(row)),
             Err(err) => match err {

--- a/server/repository/src/lib.rs
+++ b/server/repository/src/lib.rs
@@ -14,8 +14,11 @@ pub mod test_db;
 pub use self::db_diesel::*;
 pub use self::repository_error::RepositoryError;
 pub use database_settings::get_storage_connection_manager;
+use diesel::sql_types::Text;
 
 mod tests;
+
+sql_function!(fn lower(x: Text) -> Text);
 
 #[cfg(feature = "postgres")]
 embed_migrations!("./migrations/postgres");

--- a/server/service/src/user_account.rs
+++ b/server/service/src/user_account.rs
@@ -227,6 +227,11 @@ mod user_account_test {
         // should be able to verify correct username and password
         service.verify_password(username, password).unwrap();
 
+        // should be able to verify with uppercase(username) and correct password
+        service
+            .verify_password(&username.to_uppercase(), password)
+            .unwrap();
+
         // should fail to verify wrong password
         let err = service.verify_password(username, "wrong").unwrap_err();
         assert!(matches!(err, VerifyPasswordError::InvalidCredentials));


### PR DESCRIPTION
Closes (Yet Again) #175 

The case insensitive like approach (previously implemented) allows a user to login with partial username using an sql wildcard match (if central server is not available). E.g. `adm%` instead of `admin`. They still need to provide the correct password, but you could try things like a%,b%...z% with a list of common passwords hoping to login as someone.

**Note: Tests are failing on this branch but seems to be log related not my changes...**

Login tested in sqlite locally with no central server