### PR TITLE
Stocktake show lines

### DIFF
--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -6,6 +6,7 @@ import { AuthError } from '../authentication/AuthContext';
 export type GroupByItem = {
   outboundShipment?: boolean;
   inboundShipment?: boolean;
+  stocktake?: boolean;
 };
 type AuthenticationCredentials = {
   store?: UserStoreNodeFragment | undefined;

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import {
   Paper,
@@ -7,6 +7,7 @@ import {
   createFilterOptions,
   CreateFilterOptionsConfig,
   FilterOptionsState,
+  Fade,
 } from '@mui/material';
 import { AutocompleteOnChange, AutocompleteOptionRenderer } from './types';
 import { BasicTextInput } from '../TextInput';
@@ -59,6 +60,7 @@ export const AutocompleteList = <T,>({
   disableClearable,
   getOptionDisabled,
 }: AutocompleteListProps<T>): JSX.Element => {
+  const listboxRef = useRef<HTMLUListElement>(null);
   const createdFilterOptions = createFilterOptions(filterOptionConfig);
   const optionRenderer = optionKey
     ? getDefaultOptionRenderer<T>(optionKey)
@@ -72,6 +74,20 @@ export const AutocompleteList = <T,>({
     mappedOptions = options;
   }
 
+  const handleChange: AutocompleteOnChange<T | T[]> = (
+    event,
+    value,
+    reason,
+    details
+  ) => {
+    onChange?.(event, value, reason, details);
+    const scrollPos = listboxRef.current?.scrollTop || 0;
+    window.setTimeout(
+      () => listboxRef.current?.scrollTo({ top: scrollPos }),
+      100
+    );
+  };
+
   return (
     <MuiAutocomplete
       disableClearable={disableClearable}
@@ -79,7 +95,7 @@ export const AutocompleteList = <T,>({
       loading={loading}
       loadingText={loadingText}
       noOptionsText={noOptionsText}
-      onChange={onChange}
+      onChange={handleChange}
       sx={{
         '& .MuiAutocomplete-listbox': {
           minHeight: height ? `${height}` : 'auto',
@@ -97,12 +113,18 @@ export const AutocompleteList = <T,>({
       forcePopupIcon={false}
       options={mappedOptions}
       renderOption={optionRenderer}
-      ListboxProps={{
-        style: {
-          height: height ? `${height}` : 'auto',
-          maxHeight: height ? `${height}` : 'auto',
-        },
-      }}
+      ListboxComponent={props => (
+        <Fade in={true}>
+          <ul
+            {...props}
+            ref={listboxRef}
+            style={{
+              height: height ? `${height}` : 'auto',
+              maxHeight: height ? `${height}` : 'auto',
+            }}
+          />
+        </Fade>
+      )}
       PaperComponent={props => (
         <Paper
           sx={{

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteList.tsx
@@ -1,13 +1,11 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import {
-  Paper,
   Autocomplete as MuiAutocomplete,
   AutocompleteRenderInputParams,
   createFilterOptions,
   CreateFilterOptionsConfig,
   FilterOptionsState,
-  Fade,
 } from '@mui/material';
 import { AutocompleteOnChange, AutocompleteOptionRenderer } from './types';
 import { BasicTextInput } from '../TextInput';
@@ -60,7 +58,6 @@ export const AutocompleteList = <T,>({
   disableClearable,
   getOptionDisabled,
 }: AutocompleteListProps<T>): JSX.Element => {
-  const listboxRef = useRef<HTMLUListElement>(null);
   const createdFilterOptions = createFilterOptions(filterOptionConfig);
   const optionRenderer = optionKey
     ? getDefaultOptionRenderer<T>(optionKey)
@@ -74,20 +71,6 @@ export const AutocompleteList = <T,>({
     mappedOptions = options;
   }
 
-  const handleChange: AutocompleteOnChange<T | T[]> = (
-    event,
-    value,
-    reason,
-    details
-  ) => {
-    onChange?.(event, value, reason, details);
-    const scrollPos = listboxRef.current?.scrollTop || 0;
-    window.setTimeout(
-      () => listboxRef.current?.scrollTo({ top: scrollPos }),
-      100
-    );
-  };
-
   return (
     <MuiAutocomplete
       disableClearable={disableClearable}
@@ -95,7 +78,7 @@ export const AutocompleteList = <T,>({
       loading={loading}
       loadingText={loadingText}
       noOptionsText={noOptionsText}
-      onChange={handleChange}
+      onChange={onChange}
       sx={{
         '& .MuiAutocomplete-listbox': {
           minHeight: height ? `${height}` : 'auto',
@@ -113,28 +96,14 @@ export const AutocompleteList = <T,>({
       forcePopupIcon={false}
       options={mappedOptions}
       renderOption={optionRenderer}
-      ListboxComponent={props => (
-        <Fade in={true}>
-          <ul
-            {...props}
-            ref={listboxRef}
-            style={{
-              height: height ? `${height}` : 'auto',
-              maxHeight: height ? `${height}` : 'auto',
-            }}
-          />
-        </Fade>
-      )}
-      PaperComponent={props => (
-        <Paper
-          sx={{
+      componentsProps={{
+        paper: {
+          sx: {
             backgroundColor: theme => theme.palette.background.toolbar,
             minHeight: height ? `${height}` : 'auto',
-          }}
-        >
-          {props.children}
-        </Paper>
-      )}
+          },
+        },
+      }}
       disableCloseOnSelect={disableCloseOnSelect}
       multiple={multiple}
       getOptionLabel={getOptionLabel}

--- a/client/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/EnabledCheckboxCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/EnabledCheckboxCell.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CellProps } from '../../../columns';
+import { RecordWithId } from '@common/types';
+import { CheckboxCell } from './CheckboxCell';
+
+export const EnabledCheckboxCell = <T extends RecordWithId>({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isDisabled,
+  ...props
+}: CellProps<T>): React.ReactElement<CellProps<T>> => (
+  <CheckboxCell {...props} />
+);

--- a/client/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/index.ts
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/index.ts
@@ -1,1 +1,2 @@
 export * from './CheckboxCell';
+export * from './EnabledCheckboxCell';

--- a/client/packages/common/src/ui/layout/tables/context/hooks/useIsGrouped.ts
+++ b/client/packages/common/src/ui/layout/tables/context/hooks/useIsGrouped.ts
@@ -15,6 +15,7 @@ export const useIsGrouped = (key: keyof GroupByItem): IsGroupedControl => {
   const [groupByItem, setGroupByItem] = useLocalStorage('/groupbyitem', {
     outboundShipment: false,
     inboundShipment: false,
+    stocktake: true,
   });
 
   const toggleIsGrouped = useCallback(() => {

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -93,7 +93,7 @@ export const ContentArea: FC<ContentAreaProps> = ({
   onRowClick,
 }) => {
   const t = useTranslation('inventory');
-  const { isGrouped, toggleIsGrouped } = useIsGrouped('inboundShipment');
+  const { isGrouped, toggleIsGrouped } = useIsGrouped('stocktake');
   const { rows, onChangeSortBy, sortBy } = useStocktake.line.rows(isGrouped);
   const columns = useStocktakeColumns({ onChangeSortBy, sortBy });
   const isDisabled = useStocktake.utils.isDisabled();

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -79,9 +79,10 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
     }
   };
 
-  const hasValidBatches = draftLines.some(
-    line => line.countThisLine && line.countedNumberOfPacks !== undefined
-  );
+  const hasValidBatches = draftLines.length > 0;
+  // .some(
+  //   line => line.countThisLine && line.countedNumberOfPacks !== undefined
+  // );
 
   return (
     <TableProvider


### PR DESCRIPTION
Fixes #200 

Disables the row, while displaying the details of each column.
Have also chucked in these ones:
- When selecting items as part of stocktake creation, the list scrolls to the top (thanks @clemens-msupply for spotting that!)
- The groupBy should default to true (that's for @adamdewey)


## Testing
- [ ] All rows in a stocktake should be visible, though disabled if 'not counted'
- [ ] Clicking on an item in the stocktake creation window won't result in the list scrolling to the top
- [ ] Group by will default to 'on'