### PR TITLE
Increase name query limit

### DIFF
--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -37,6 +37,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         desc: !!sortBy?.isDesc,
         storeId,
         filter: { isSupplier: true, isStore: true },
+        first: 1000,
       });
 
       return result?.names;
@@ -49,6 +50,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         desc: !!sortBy?.isDesc,
         storeId,
         filter: { isSupplier: true },
+        first: 1000,
       });
 
       return result?.names;
@@ -61,6 +63,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         desc: !!sortBy?.isDesc,
         storeId,
         filter: { isCustomer: true },
+        first: 1000,
       });
 
       return result?.names;


### PR DESCRIPTION
Fixes #273 

Rather than update `DEFAULT_PAGINATION_LIMIT` in `filter_sort_pagination` I've pushed the implementation to the client and specified a greater limit.