### PR TITLE
274 Trim unallocated lines with zero quantity

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -158,7 +158,8 @@ const useStatusChangePlaceholderCheck = () => {
   const hasPlaceholder = useMemo(
     () =>
       !!lines?.some(
-        ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
+        ({ type, numberOfPacks }) =>
+          type === InvoiceLineNodeType.UnallocatedStock && numberOfPacks > 0
       ),
     [lines]
   );

--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -50,6 +50,14 @@ impl EqualFilter<i32> {
             not_equal_all: None,
         }
     }
+    pub fn not_equal_to_i32(value: i32) -> Self {
+        EqualFilter {
+            equal_to: None,
+            not_equal_to: Some(value),
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
 }
 
 impl EqualFilter<String> {

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -55,6 +55,7 @@ pub struct InvoiceLineFilter {
     pub r#type: Option<EqualFilter<InvoiceLineRowType>>,
     pub location_id: Option<EqualFilter<String>>,
     pub requisition_id: Option<EqualFilter<String>>,
+    pub number_of_packs: Option<EqualFilter<i32>>,
 }
 
 impl InvoiceLineFilter {
@@ -66,6 +67,7 @@ impl InvoiceLineFilter {
             item_id: None,
             location_id: None,
             requisition_id: None,
+            number_of_packs: None,
         }
     }
 
@@ -96,6 +98,11 @@ impl InvoiceLineFilter {
 
     pub fn requisition_id(mut self, filter: EqualFilter<String>) -> Self {
         self.requisition_id = Some(filter);
+        self
+    }
+
+    pub fn number_of_packs(mut self, filter: EqualFilter<i32>) -> Self {
+        self.number_of_packs = Some(filter);
         self
     }
 }
@@ -170,12 +177,23 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
         .into_boxed();
 
     if let Some(f) = filter {
-        apply_equal_filter!(query, f.id, invoice_line_dsl::id);
-        apply_equal_filter!(query, f.requisition_id, invoice_dsl::requisition_id);
-        apply_equal_filter!(query, f.invoice_id, invoice_line_dsl::invoice_id);
-        apply_equal_filter!(query, f.location_id, invoice_line_dsl::location_id);
-        apply_equal_filter!(query, f.item_id, invoice_line_dsl::item_id);
-        apply_equal_filter!(query, f.r#type, invoice_line_dsl::type_);
+        let InvoiceLineFilter {
+            id,
+            invoice_id,
+            item_id,
+            r#type,
+            location_id,
+            requisition_id,
+            number_of_packs,
+        } = f;
+
+        apply_equal_filter!(query, id, invoice_line_dsl::id);
+        apply_equal_filter!(query, requisition_id, invoice_dsl::requisition_id);
+        apply_equal_filter!(query, invoice_id, invoice_line_dsl::invoice_id);
+        apply_equal_filter!(query, location_id, invoice_line_dsl::location_id);
+        apply_equal_filter!(query, item_id, invoice_line_dsl::item_id);
+        apply_equal_filter!(query, r#type, invoice_line_dsl::type_);
+        apply_equal_filter!(query, number_of_packs, invoice_line_dsl::number_of_packs);
     }
 
     query

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use repository::Name;
+use repository::{EqualFilter, InvoiceLineFilter, InvoiceLineRepository, Name, RepositoryError};
 use repository::{
     InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus,
     StockLineRow, StockLineRowRepository, StorageConnection,
@@ -8,7 +8,13 @@ use repository::{
 
 use super::{UpdateOutboundShipment, UpdateOutboundShipmentError, UpdateOutboundShipmentStatus};
 
-pub fn generate(
+pub(crate) struct GenerateResult {
+    pub(crate) batches_to_update: Option<Vec<StockLineRow>>,
+    pub(crate) update_invoice: InvoiceRow,
+    pub(crate) unallocated_lines_to_trim: Option<Vec<InvoiceLineRow>>,
+}
+
+pub(crate) fn generate(
     existing_invoice: InvoiceRow,
     other_party_option: Option<Name>,
     UpdateOutboundShipment {
@@ -22,7 +28,7 @@ pub fn generate(
         transport_reference: input_transport_reference,
     }: UpdateOutboundShipment,
     connection: &StorageConnection,
-) -> Result<(Option<Vec<StockLineRow>>, InvoiceRow), UpdateOutboundShipmentError> {
+) -> Result<GenerateResult, UpdateOutboundShipmentError> {
     let should_create_batches = should_update_batches(&existing_invoice, &input_status);
     let mut update_invoice = existing_invoice;
 
@@ -36,7 +42,7 @@ pub fn generate(
     update_invoice.transport_reference =
         input_transport_reference.or(update_invoice.transport_reference);
 
-    if let Some(status) = input_status {
+    if let Some(status) = input_status.clone() {
         update_invoice.status = status.full_status().into()
     }
 
@@ -45,17 +51,24 @@ pub fn generate(
         update_invoice.name_id = other_party.name_row.id;
     }
 
-    if !should_create_batches {
-        Ok((None, update_invoice))
+    let batches_to_update = if should_create_batches {
+        Some(generate_batches(&update_invoice.id, connection)?)
     } else {
-        Ok((
-            Some(generate_batches(&update_invoice.id, connection)?),
-            update_invoice,
-        ))
-    }
+        None
+    };
+
+    Ok(GenerateResult {
+        batches_to_update,
+        unallocated_lines_to_trim: unallocated_lines_to_trim(
+            connection,
+            &update_invoice,
+            &input_status,
+        )?,
+        update_invoice,
+    })
 }
 
-pub fn should_update_batches(
+fn should_update_batches(
     invoice: &InvoiceRow,
     status: &Option<UpdateOutboundShipmentStatus>,
 ) -> bool {
@@ -68,6 +81,42 @@ pub fn should_update_batches(
     } else {
         false
     }
+}
+
+// If status changed to allocated and above, remove unallocated lines
+fn unallocated_lines_to_trim(
+    connection: &StorageConnection,
+    invoice: &InvoiceRow,
+    status: &Option<UpdateOutboundShipmentStatus>,
+) -> Result<Option<Vec<InvoiceLineRow>>, RepositoryError> {
+    if invoice.status != InvoiceRowStatus::New {
+        return Ok(None);
+    }
+
+    let new_invoice_status = match UpdateOutboundShipmentStatus::full_status_option(status) {
+        Some(new_invoice_status) => new_invoice_status,
+        None => return Ok(None),
+    };
+
+    if new_invoice_status == InvoiceRowStatus::New {
+        return Ok(None);
+    }
+
+    // If new invoice status in not new and previous invoice stauts is new
+    // add all unallocated lines to be deleted
+
+    let lines = InvoiceLineRepository::new(connection).query_by_filter(
+        InvoiceLineFilter::new()
+            .invoice_id(EqualFilter::equal_to(&invoice.id))
+            .r#type(InvoiceLineRowType::UnallocatedStock.equal_to()),
+    )?;
+
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    let invoice_line_rows = lines.into_iter().map(|l| l.invoice_line_row).collect();
+    return Ok(Some(invoice_line_rows));
 }
 
 fn set_new_status_datetime(
@@ -99,7 +148,7 @@ fn set_new_status_datetime(
 }
 
 // Returns a list of stock lines that need to be updated
-pub fn generate_batches(
+fn generate_batches(
     id: &str,
     connection: &StorageConnection,
 ) -> Result<Vec<StockLineRow>, UpdateOutboundShipmentError> {

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -103,7 +103,7 @@ fn unallocated_lines_to_trim(
         return Ok(None);
     }
 
-    // If new invoice status in not new and previous invoice status is new
+    // If new invoice status is not new and previous invoice status is new
     // add all unallocated lines to be deleted
 
     let lines = InvoiceLineRepository::new(connection).query_by_filter(

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -89,6 +89,7 @@ fn unallocated_lines_to_trim(
     invoice: &InvoiceRow,
     status: &Option<UpdateOutboundShipmentStatus>,
 ) -> Result<Option<Vec<InvoiceLineRow>>, RepositoryError> {
+    // Status sequence for outbound shipment: New, Allocated, Picked, Shipped
     if invoice.status != InvoiceRowStatus::New {
         return Ok(None);
     }
@@ -102,7 +103,7 @@ fn unallocated_lines_to_trim(
         return Ok(None);
     }
 
-    // If new invoice status in not new and previous invoice stauts is new
+    // If new invoice status in not new and previous invoice status is new
     // add all unallocated lines to be deleted
 
     let lines = InvoiceLineRepository::new(connection).query_by_filter(

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -30,7 +30,7 @@ pub(crate) fn generate(
     connection: &StorageConnection,
 ) -> Result<GenerateResult, UpdateOutboundShipmentError> {
     let should_create_batches = should_update_batches(&existing_invoice, &input_status);
-    let mut update_invoice = existing_invoice;
+    let mut update_invoice = existing_invoice.clone();
 
     set_new_status_datetime(&mut update_invoice, &input_status);
 
@@ -61,7 +61,7 @@ pub(crate) fn generate(
         batches_to_update,
         unallocated_lines_to_trim: unallocated_lines_to_trim(
             connection,
-            &update_invoice,
+            &existing_invoice,
             &input_status,
         )?,
         update_invoice,

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -319,6 +319,11 @@ mod test {
         let result = service.update_outbound_shipment(&context, &mock_store_a().id, update);
 
         assert!(matches!(result, Ok(_)), "Not Ok(_) {:#?}", result);
+
+        assert_eq!(
+            InvoiceLineRowRepository::new(&connection).find_one_by_id_option(&invoice_line().id),
+            Ok(None)
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use repository::{
-    Invoice, InvoiceLine, InvoiceRowRepository, InvoiceRowStatus, LogRow, LogType, RepositoryError,
-    StockLineRowRepository, TransactionError,
+    Invoice, InvoiceLine, InvoiceLineRowRepository, InvoiceRowRepository, InvoiceRowStatus, LogRow,
+    LogType, RepositoryError, StockLineRowRepository, TransactionError,
 };
 
 pub mod generate;
@@ -11,6 +11,7 @@ use generate::generate;
 use util::uuid::uuid;
 use validate::validate;
 
+use crate::invoice::outbound_shipment::update::generate::GenerateResult;
 use crate::invoice::query::get_invoice;
 use crate::log::log_entry;
 use crate::service_provider::ServiceContext;
@@ -40,6 +41,7 @@ pub enum UpdateOutboundShipmentError {
     InvoiceDoesNotExists,
     InvoiceIsNotEditable,
     NotAnOutboundShipment,
+    // Error applies to unallocated lines with above zero quantity
     CanOnlyChangeToAllocatedWhenNoUnallocatedLines(Vec<InvoiceLine>),
     // Name validation
     OtherPartyNotACustomer,
@@ -63,14 +65,24 @@ pub fn update_outbound_shipment(
         .connection
         .transaction_sync(|connection| {
             let (invoice, other_party_option) = validate(connection, store_id, &patch)?;
-            let (stock_lines_option, update_invoice) =
-                generate(invoice, other_party_option, patch.clone(), connection)?;
+            let GenerateResult {
+                batches_to_update,
+                update_invoice,
+                unallocated_lines_to_trim,
+            } = generate(invoice, other_party_option, patch.clone(), connection)?;
 
             InvoiceRowRepository::new(connection).upsert_one(&update_invoice)?;
-            if let Some(stock_lines) = stock_lines_option {
+            if let Some(stock_lines) = batches_to_update {
                 let repository = StockLineRowRepository::new(connection);
                 for stock_line in stock_lines {
                     repository.upsert_one(&stock_line)?;
+                }
+            }
+
+            if let Some(lines) = unallocated_lines_to_trim {
+                let repository = InvoiceLineRowRepository::new(connection);
+                for line in lines {
+                    repository.delete(&line.id)?;
                 }
             }
 
@@ -161,14 +173,21 @@ impl UpdateOutboundShipment {
 #[cfg(test)]
 mod test {
     use repository::{
-        mock::{mock_name_a, mock_outbound_shipment_a, mock_store_a, MockData, MockDataInserts},
+        mock::{
+            mock_item_a, mock_name_a, mock_outbound_shipment_a, mock_store_a, MockData,
+            MockDataInserts,
+        },
         test_db::setup_all_with_data,
-        InvoiceRow, InvoiceRowRepository, InvoiceRowType, NameRow, NameStoreJoinRow,
+        InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineRowType, InvoiceRow,
+        InvoiceRowRepository, InvoiceRowType, NameRow, NameStoreJoinRow,
     };
     use util::{inline_edit, inline_init};
 
     use crate::{
-        invoice::outbound_shipment::UpdateOutboundShipment, service_provider::ServiceProvider,
+        invoice::outbound_shipment::{
+            update::UpdateOutboundShipmentStatus, UpdateOutboundShipment,
+        },
+        service_provider::ServiceProvider,
     };
 
     use super::UpdateOutboundShipmentError;
@@ -250,6 +269,56 @@ mod test {
         );
 
         // TODO add not Other error (only other party related atm)
+    }
+
+    #[actix_rt::test]
+    async fn update_outbound_shipment_success_trim_unallocated_line() {
+        fn invoice() -> InvoiceRow {
+            inline_init(|r: &mut InvoiceRow| {
+                r.id = "invoice".to_string();
+                r.name_id = mock_name_a().id;
+                r.store_id = mock_store_a().id;
+                r.r#type = InvoiceRowType::OutboundShipment;
+            })
+        }
+
+        fn invoice_line() -> InvoiceLineRow {
+            inline_init(|r: &mut InvoiceLineRow| {
+                r.id = "invoice_line".to_string();
+                r.invoice_id = invoice().id;
+                r.item_id = mock_item_a().id;
+                r.r#type = InvoiceLineRowType::UnallocatedStock;
+                r.pack_size = 1;
+                r.number_of_packs = 0;
+            })
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_outbound_shipment_success_trim_unallocated_line",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.invoices = vec![invoice()];
+                r.invoice_lines = vec![invoice_line()];
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            InvoiceLineRowRepository::new(&connection).find_one_by_id_option(&invoice_line().id),
+            Ok(Some(invoice_line()))
+        );
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider.context().unwrap();
+        let service = service_provider.invoice_service;
+
+        let update = inline_init(|r: &mut UpdateOutboundShipment| {
+            r.id = invoice().id;
+            r.status = Some(UpdateOutboundShipmentStatus::Picked);
+        });
+        let result = service.update_outbound_shipment(&context, &mock_store_a().id, update);
+
+        assert!(matches!(result, Ok(_)), "Not Ok(_) {:#?}", result);
     }
 
     #[actix_rt::test]

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -56,6 +56,8 @@ fn check_invoice_exists(
     Ok(result?)
 }
 
+// If status is beinged changed to allocated and above, return error if there are
+// unallocated lines with quantity above 0, zero quantity unallocated lines will be deleted
 fn check_can_change_status_to_allocated(
     connection: &StorageConnection,
     invoice_row: &InvoiceRow,
@@ -74,12 +76,8 @@ fn check_can_change_status_to_allocated(
         let unallocated_lines = repository.query_by_filter(
             InvoiceLineFilter::new()
                 .invoice_id(EqualFilter::equal_to(&invoice_row.id))
-                .r#type(EqualFilter {
-                    equal_to: Some(InvoiceLineRowType::UnallocatedStock),
-                    not_equal_to: None,
-                    equal_any: None,
-                    not_equal_all: None,
-                }),
+                .r#type(InvoiceLineRowType::UnallocatedStock.equal_to())
+                .number_of_packs(EqualFilter::not_equal_to_i32(0)),
         )?;
 
         if unallocated_lines.len() > 0 {

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -56,7 +56,7 @@ fn check_invoice_exists(
     Ok(result?)
 }
 
-// If status is beinged changed to allocated and above, return error if there are
+// If status is changed to allocated and above, return error if there are
 // unallocated lines with quantity above 0, zero quantity unallocated lines will be deleted
 fn check_can_change_status_to_allocated(
     connection: &StorageConnection,

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -67,6 +67,7 @@ fn check_can_change_status_to_allocated(
         return Ok(());
     };
 
+    // Status sequence for outbound shipment: New, Allocated, Picked, Shipped
     if let Some(new_status) = status_option {
         if new_status == InvoiceRowStatus::New {
             return Ok(());


### PR DESCRIPTION
closes #274 

* Existing check for unallocated lines when status of outbound shipment is changed 'above' new (allocated +), would only check for unallocated lines with non zero quantity
* Zero quantity unallocated lines are trimmed when status changed to to allocated +
* Update useStatusChangePlaceholderCheck to allow placeholder with numberOfPacks === 0


### Tests

- [ ] Create outbound shipment from master list
- [ ] Allocate some lines an leave some unallocated lines as zero
- [ ] Try to change status (lines should be trimmed)

- [ ] Try the same but have unallocated lines with above zero quantity, should see warning