### PR TITLE
265 Don't change sort direction when useUrlQueryParam mounts

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -27,10 +27,7 @@ export const useUrlQueryParams = ({
   useEffect(() => {
     if (!initialSortKey) return;
 
-    updateSortQuery({
-      key: initialSortKey,
-      sortBy: { key: initialSortKey, direction: 'asc' },
-    } as Column<any>);
+    updateQuery({ sort: initialSortKey})
   }, [initialSortKey]);
 
   const updateSortQuery = (column: Column<any>) => {

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -26,8 +26,10 @@ export const useUrlQueryParams = ({
 
   useEffect(() => {
     if (!initialSortKey) return;
+    // Don't want to override existing sort
+    if (!!urlQuery['sort']) return;
 
-    updateQuery({ sort: initialSortKey})
+    updateQuery({ sort: initialSortKey });
   }, [initialSortKey]);
 
   const updateSortQuery = (column: Column<any>) => {


### PR DESCRIPTION
closes: #265 

There is probably a better way to solve this, but would require a bit of refactoring, so thought to keep it simple.
