### PR TITLE
291 change default sort for list of invoices, requisitions and stocktake

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -10,13 +10,13 @@ const RECORDS_PER_PAGE = 20;
 
 interface UrlQueryParams {
   filterKey?: string;
-  initialSortKey?: string;
+  initialSort?: string | { sort: string; dir: 'desc' | 'asc' };
   filterCondition?: string;
 }
 
 export const useUrlQueryParams = ({
   filterKey,
-  initialSortKey,
+  initialSort,
   filterCondition = 'like',
 }: UrlQueryParams = {}) => {
   // do not coerce the filter parameter if the user enters a numeric value
@@ -25,10 +25,17 @@ export const useUrlQueryParams = ({
   const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['filter'] });
 
   useEffect(() => {
-    if (!initialSortKey) return;
+    if (!initialSort) return;
 
-    updateQuery({ sort: initialSortKey})
-  }, [initialSortKey]);
+    // Don't want to override existing sort
+    if (!!urlQuery['sort']) return;
+
+    if (typeof initialSort === 'object') {
+      updateQuery(initialSort);
+    } else {
+      updateQuery({ sort: initialSort });
+    }
+  }, [initialSort]);
 
   const updateSortQuery = (column: Column<any>) => {
     const currentSort = urlQuery['sort'];
@@ -70,7 +77,7 @@ export const useUrlQueryParams = ({
     offset: urlQuery.page ? (urlQuery.page - 1) * RECORDS_PER_PAGE : 0,
     first: RECORDS_PER_PAGE,
     sortBy: {
-      key: urlQuery.sort ?? initialSortKey,
+      key: urlQuery.sort ?? initialSort,
       direction: urlQuery.dir ?? 'asc',
       isDesc: urlQuery.dir === 'desc',
     },

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -10,7 +10,7 @@ const RECORDS_PER_PAGE = 20;
 
 interface UrlQueryParams {
   filterKey?: string;
-  initialSort?: string | { sort: string; dir: 'desc' | 'asc' };
+  initialSort?: { key: string; dir: 'desc' | 'asc' };
   filterCondition?: string;
 }
 
@@ -30,11 +30,8 @@ export const useUrlQueryParams = ({
     // Don't want to override existing sort
     if (!!urlQuery['sort']) return;
 
-    if (typeof initialSort === 'object') {
-      updateQuery(initialSort);
-    } else {
-      updateQuery({ sort: initialSort });
-    }
+    const { key: sort, dir } = initialSort;
+    updateQuery({ sort, dir });
   }, [initialSort]);
 
   const updateSortQuery = (column: Column<any>) => {

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakes.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakes.ts
@@ -3,7 +3,7 @@ import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useStocktakes = () => {
   const { queryParams } = useUrlQueryParams({
-    initialSortKey: 'createdDatetime',
+    initialSort: { sort: 'createdDatetime', dir: 'desc' },
     filterKey: 'status',
     filterCondition: 'equalTo',
   });

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakes.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakes.ts
@@ -3,7 +3,7 @@ import { useStocktakeApi } from '../utils/useStocktakeApi';
 
 export const useStocktakes = () => {
   const { queryParams } = useUrlQueryParams({
-    initialSort: { sort: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
     filterKey: 'status',
     filterCondition: 'equalTo',
   });

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -8,7 +8,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  } = useUrlQueryParams({ initialSort: 'itemName' });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
   const columns = useStocktakeColumns({

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -8,7 +8,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSort: 'itemName' });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'desc' } });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
   const columns = useStocktakeColumns({

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInbounds.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInbounds.ts
@@ -4,7 +4,7 @@ import { useInboundApi } from '../utils/useInboundApi';
 export const useInbounds = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSort: { sort: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const api = useInboundApi();
 

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInbounds.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInbounds.ts
@@ -4,7 +4,7 @@ import { useInboundApi } from '../utils/useInboundApi';
 export const useInbounds = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSortKey: 'otherPartyName',
+    initialSort: { sort: 'createdDatetime', dir: 'desc' },
   });
   const api = useInboundApi();
 

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
@@ -4,7 +4,7 @@ import { useOutboundApi } from './../utils/useOutboundApi';
 export const useOutbounds = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSortKey: 'otherPartyName',
+    initialSort: { sort: 'createdDatetime', dir: 'desc' },
   });
   const api = useOutboundApi();
 

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
@@ -4,7 +4,7 @@ import { useOutboundApi } from './../utils/useOutboundApi';
 export const useOutbounds = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSort: { sort: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const api = useOutboundApi();
 

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundRows.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundRows.ts
@@ -8,7 +8,7 @@ export const useOutboundRows = (isGrouped = true) => {
   const {
     queryParams: { sortBy },
     updateSortQuery: onChangeSortBy,
-  } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  } = useUrlQueryParams({ initialSort: 'itemName' });
   const { data: lines } = useOutboundLines();
   const { data: items } = useOutboundItems();
   const columns = useOutboundColumns({

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundRows.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/line/useOutboundRows.ts
@@ -8,7 +8,7 @@ export const useOutboundRows = (isGrouped = true) => {
   const {
     queryParams: { sortBy },
     updateSortQuery: onChangeSortBy,
-  } = useUrlQueryParams({ initialSort: 'itemName' });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const { data: lines } = useOutboundLines();
   const { data: items } = useOutboundItems();
   const columns = useOutboundColumns({

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useRequests.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useRequests.ts
@@ -4,7 +4,7 @@ import { useRequestApi } from '../utils/useRequestApi';
 export const useRequests = (options?: { enabled: boolean }) => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSort: { sort: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const api = useRequestApi();
 

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useRequests.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/document/useRequests.ts
@@ -4,7 +4,7 @@ import { useRequestApi } from '../utils/useRequestApi';
 export const useRequests = (options?: { enabled: boolean }) => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'otherPartyName',
-    initialSortKey: 'otherPartyName',
+    initialSort: { sort: 'createdDatetime', dir: 'desc' },
   });
   const api = useRequestApi();
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -11,7 +11,7 @@ export const useResponseColumns = () => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSort: 'itemName' });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const columns = useColumns<ResponseLineFragment>(
     [
       getCommentPopoverColumn(),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -11,7 +11,7 @@ export const useResponseColumns = () => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  } = useUrlQueryParams({ initialSort: 'itemName' });
   const columns = useColumns<ResponseLineFragment>(
     [
       getCommentPopoverColumn(),

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useResponses.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useResponses.ts
@@ -4,7 +4,7 @@ import { useResponseApi } from '../utils/useResponseApi';
 export const useResponses = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'comment',
-    initialSortKey: 'otherPartyName',
+    initialSort: { sort: 'createdDatetime', dir: 'desc' },
   });
   const api = useResponseApi();
 

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useResponses.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/document/useResponses.ts
@@ -4,7 +4,7 @@ import { useResponseApi } from '../utils/useResponseApi';
 export const useResponses = () => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'comment',
-    initialSort: { sort: 'createdDatetime', dir: 'desc' },
+    initialSort: { key: 'createdDatetime', dir: 'desc' },
   });
   const api = useResponseApi();
 

--- a/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
+++ b/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
@@ -2,7 +2,7 @@ import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
 export const useItems = () => {
-  const { queryParams } = useUrlQueryParams({ initialSortKey: 'name' });
+  const { queryParams } = useUrlQueryParams({ initialSort: 'name' });
   const api = useItemApi();
 
   return {

--- a/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
+++ b/client/packages/system/src/Item/api/hooks/useItems/useItems.ts
@@ -2,7 +2,9 @@ import { useQuery, useUrlQueryParams } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
 export const useItems = () => {
-  const { queryParams } = useUrlQueryParams({ initialSort: 'name' });
+  const { queryParams } = useUrlQueryParams({
+    initialSort: { key: 'name', dir: 'asc' },
+  });
   const api = useItemApi();
 
   return {

--- a/client/packages/system/src/Location/api/hooks/document/useLocations.ts
+++ b/client/packages/system/src/Location/api/hooks/document/useLocations.ts
@@ -3,7 +3,7 @@ import { useLocationApi } from '../utils/useLocationApi';
 
 export const useLocations = () => {
   const api = useLocationApi();
-  const { queryParams } = useUrlQueryParams({ initialSortKey: 'name' });
+  const { queryParams } = useUrlQueryParams({ initialSort: 'name' });
   const result = useQuery(api.keys.paramList(queryParams), () =>
     api.get.list(queryParams)
   );

--- a/client/packages/system/src/Location/api/hooks/document/useLocations.ts
+++ b/client/packages/system/src/Location/api/hooks/document/useLocations.ts
@@ -3,7 +3,9 @@ import { useLocationApi } from '../utils/useLocationApi';
 
 export const useLocations = () => {
   const api = useLocationApi();
-  const { queryParams } = useUrlQueryParams({ initialSort: 'name' });
+  const { queryParams } = useUrlQueryParams({
+    initialSort: { key: 'name', dir: 'asc' },
+  });
   const result = useQuery(api.keys.paramList(queryParams), () =>
     api.get.list(queryParams)
   );

--- a/client/packages/system/src/MasterList/DetailView/columns.ts
+++ b/client/packages/system/src/MasterList/DetailView/columns.ts
@@ -5,7 +5,7 @@ export const useMasterListColumns = () => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSort: 'itemName' });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const columns = useColumns<MasterListLineFragment>(
     [
       [

--- a/client/packages/system/src/MasterList/DetailView/columns.ts
+++ b/client/packages/system/src/MasterList/DetailView/columns.ts
@@ -5,7 +5,7 @@ export const useMasterListColumns = () => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  } = useUrlQueryParams({ initialSort: 'itemName' });
   const columns = useColumns<MasterListLineFragment>(
     [
       [

--- a/client/packages/system/src/MasterList/api/hooks/document/useMasterLists.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/useMasterLists.ts
@@ -4,7 +4,7 @@ import { useMasterListApi } from '../utils/useMasterListApi';
 export const useMasterLists = ({ enabled } = { enabled: true }) => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'name',
-    initialSortKey: 'name',
+    initialSort: 'name',
   });
   const api = useMasterListApi();
 

--- a/client/packages/system/src/MasterList/api/hooks/document/useMasterLists.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/useMasterLists.ts
@@ -4,7 +4,7 @@ import { useMasterListApi } from '../utils/useMasterListApi';
 export const useMasterLists = ({ enabled } = { enabled: true }) => {
   const { queryParams } = useUrlQueryParams({
     filterKey: 'name',
-    initialSort: 'name',
+    initialSort: { key: 'name', dir: 'asc' } 
   });
   const api = useMasterListApi();
 

--- a/client/packages/system/src/Name/api/hooks/document/useNames.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useNames.ts
@@ -3,7 +3,7 @@ import { useNameApi } from '../utils/useNameApi';
 
 export const useNames = (type: 'customer' | 'supplier') => {
   const { queryParams } = useUrlQueryParams({
-    initialSortKey: 'name',
+    initialSort: 'name',
   });
   const api = useNameApi();
   return {

--- a/client/packages/system/src/Name/api/hooks/document/useNames.ts
+++ b/client/packages/system/src/Name/api/hooks/document/useNames.ts
@@ -3,7 +3,7 @@ import { useNameApi } from '../utils/useNameApi';
 
 export const useNames = (type: 'customer' | 'supplier') => {
   const { queryParams } = useUrlQueryParams({
-    initialSort: 'name',
+    initialSort: { key: 'name', dir: 'asc' },
   });
   const api = useNameApi();
   return {

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,7 +21,7 @@ const StockListComponent: FC = () => {
     updatePaginationQuery,
     updateSortQuery,
     queryParams: { sortBy, page, first, offset },
-  } = useUrlQueryParams({ initialSort: 'itemName' });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
   const filterString = String(urlQuery.filter ?? '');

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -21,7 +21,7 @@ const StockListComponent: FC = () => {
     updatePaginationQuery,
     updateSortQuery,
     queryParams: { sortBy, page, first, offset },
-  } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  } = useUrlQueryParams({ initialSort: 'itemName' });
   const pagination = { page, first, offset };
   const t = useTranslation('inventory');
   const filterString = String(urlQuery.filter ?? '');

--- a/client/packages/system/src/Stock/api/hooks/document/useStockLines.ts
+++ b/client/packages/system/src/Stock/api/hooks/document/useStockLines.ts
@@ -3,7 +3,7 @@ import { useStockApi } from '../utils/useStockApi';
 
 export const useStockLines = () => {
   const api = useStockApi();
-  const { queryParams } = useUrlQueryParams({ initialSortKey: 'itemName' });
+  const { queryParams } = useUrlQueryParams({ initialSort: 'itemName' });
   return {
     ...useQuery(['stock', 'list', api.storeId, queryParams], () =>
       api.get.list(queryParams)

--- a/client/packages/system/src/Stock/api/hooks/document/useStockLines.ts
+++ b/client/packages/system/src/Stock/api/hooks/document/useStockLines.ts
@@ -3,7 +3,9 @@ import { useStockApi } from '../utils/useStockApi';
 
 export const useStockLines = () => {
   const api = useStockApi();
-  const { queryParams } = useUrlQueryParams({ initialSort: 'itemName' });
+  const { queryParams } = useUrlQueryParams({
+    initialSort: { key: 'itemName', dir: 'asc' },
+  });
   return {
     ...useQuery(['stock', 'list', api.storeId, queryParams], () =>
       api.get.list(queryParams)


### PR DESCRIPTION
closes: #291 

Had to change initialSorKey to initialSort (since we need to also specify direction to be descending for createdDatetime).

### Tests

- [ ] Opening lists for shipments, requisition and stocktakes should sort by createdDatetime in descending order
- [ ] Changing direction of sort and doing full reload of the page should result in last sort order retained
- [ ] Changing sort column and reload of the page should result in last sort order retained
- [ ] Above but after navigation to a page (pagination), should retain pagination after full reload

By full reload I just mean refreshing the page (or even better copying url and pasting it in another tab)