### PR TITLE
Only mount CreatePatientModal when it suppose to be shown

### DIFF
--- a/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
@@ -53,7 +53,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
         </LoadingButton>
       </Grid>
 
-      <CreatePatientModal open={open} setOpen={setOpen} />
+      {open ? <CreatePatientModal onClose={() => setOpen(false)} /> : null}
     </AppBarButtonsPortal>
   );
 };

--- a/client/packages/system/src/Patient/hooks/useCreatePatientStore.ts
+++ b/client/packages/system/src/Patient/hooks/useCreatePatientStore.ts
@@ -28,7 +28,15 @@ export const useCreatePatientStore = create<CreateNewPatientState>(set => ({
       patient: update,
     })),
   updatePatient: patch =>
-    set(state => ({
-      patient: { ...(state.patient as CreateNewPatient), ...patch },
-    })),
+    set(state => {
+      if (!state.patient) {
+        console.error(
+          'useCreatePatientStore: updatePatient() can only be used after a patient is set using setNewPatient()'
+        );
+        return state;
+      }
+      return {
+        patient: { ...state.patient, ...patch },
+      };
+    }),
 }));


### PR DESCRIPTION
This avoids doing unnecessary API calls and getting into an inconsistent
state.

Also add a safety check to not get into an invalid patient state. (This fix somehow solved it but I had another case where update was called without setting the patient first which resulted navigating to an undefined value -> crash...)

#280 