### PR TITLE
Hide columns

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -177,5 +177,6 @@
   "placeholder.search-by-name": "Search by name",
   "placeholder.search-by-name-or-code": "Search by name or code",
   "success": "Success!",
-  "success.sync-settings": "Sync settings updated successfully!"
+  "success.sync-settings": "Sync settings updated successfully!",
+  "table.show-columns": "Show / hide columns"
 }

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -22,6 +22,7 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/mru/credentials': AuthenticationCredentials;
   '/auth/error': AuthError | undefined;
+  '/columns/hidden': Record<string, string[]> | undefined;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/client/packages/common/src/ui/icons/Columns.tsx
+++ b/client/packages/common/src/ui/icons/Columns.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+export const ColumnsIcon = (props: SvgIconProps): JSX.Element => {
+  return (
+    <SvgIcon {...props} viewBox="0 0 24 24">
+      <path d="M5.33,20H4c-1.1,0-2-0.9-2-2V6c0-1.1,0.9-2,2-2h1.33c1.1,0,2,0.9,2,2v12C7.33,19.1,6.44,20,5.33,20z M22,18V6 c0-1.1-0.9-2-2-2h-1.33c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2H20C21.11,20,22,19.1,22,18z M14.67,18V6c0-1.1-0.9-2-2-2h-1.33 c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2h1.33C13.77,20,14.67,19.1,14.67,18z" />
+    </SvgIcon>
+  );
+};

--- a/client/packages/common/src/ui/icons/Columns.tsx
+++ b/client/packages/common/src/ui/icons/Columns.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
-export const ColumnsIcon = (props: SvgIconProps): JSX.Element => {
-  return (
-    <SvgIcon {...props} viewBox="0 0 24 24">
-      <path d="M5.33,20H4c-1.1,0-2-0.9-2-2V6c0-1.1,0.9-2,2-2h1.33c1.1,0,2,0.9,2,2v12C7.33,19.1,6.44,20,5.33,20z M22,18V6 c0-1.1-0.9-2-2-2h-1.33c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2H20C21.11,20,22,19.1,22,18z M14.67,18V6c0-1.1-0.9-2-2-2h-1.33 c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2h1.33C13.77,20,14.67,19.1,14.67,18z" />
-    </SvgIcon>
-  );
-};
+export const ColumnsIcon = (props: SvgIconProps): JSX.Element => (
+  <SvgIcon {...props} viewBox="0 0 24 24">
+    <path d="M5.33,20H4c-1.1,0-2-0.9-2-2V6c0-1.1,0.9-2,2-2h1.33c1.1,0,2,0.9,2,2v12C7.33,19.1,6.44,20,5.33,20z M22,18V6 c0-1.1-0.9-2-2-2h-1.33c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2H20C21.11,20,22,19.1,22,18z M14.67,18V6c0-1.1-0.9-2-2-2h-1.33 c-1.1,0-2,0.9-2,2v12c0,1.1,0.9,2,2,2h1.33C13.77,20,14.67,19.1,14.67,18z" />
+  </SvgIcon>
+);

--- a/client/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/client/packages/common/src/ui/icons/Icon.stories.tsx
@@ -17,6 +17,7 @@ import { ChevronsDownIcon } from './ChevronsDown';
 import { CircleIcon } from './Circle';
 import { ClockIcon } from './Clock';
 import { CloseIcon } from './Close';
+import { ColumnsIcon } from './Columns';
 import { CopyIcon } from './Copy';
 import { CustomersIcon } from './Customers';
 import { DashboardIcon } from './Dashboard';
@@ -93,6 +94,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <CircleIcon {...args} />, name: 'Circle' },
     { icon: <ClockIcon {...args} />, name: 'Clock' },
     { icon: <CloseIcon {...args} />, name: 'Close' },
+    { icon: <ColumnsIcon {...args} />, name: 'Columns' },
     { icon: <CopyIcon {...args} />, name: 'Copy' },
     { icon: <CustomersIcon {...args} />, name: 'Customers' },
     { icon: <DashboardIcon {...args} />, name: 'Dashboard' },

--- a/client/packages/common/src/ui/icons/index.ts
+++ b/client/packages/common/src/ui/icons/index.ts
@@ -13,6 +13,7 @@ export { ChevronsDownIcon } from './ChevronsDown';
 export { CircleIcon } from './Circle';
 export { ClockIcon } from './Clock';
 export { CloseIcon } from './Close';
+export { ColumnsIcon } from './Columns';
 export { CopyIcon } from './Copy';
 export { CustomersIcon } from './Customers';
 export { DashboardIcon } from './Dashboard';

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -20,11 +20,12 @@ import { useTranslation } from '@common/intl';
 import { useTableStore } from './context';
 
 export const DataTableComponent = <T extends RecordWithId>({
+  key,
   ExpandContent,
   columns,
   data = [],
   dense = false,
-  hiddenColumnKey,
+  enableColumnSelection,
   isDisabled = false,
   isError = false,
   isLoading = false,
@@ -131,11 +132,11 @@ export const DataTableComponent = <T extends RecordWithId>({
                 key={String(column.key)}
               />
             ))}
-            {!!hiddenColumnKey && (
+            {!!enableColumnSelection && (
               <ColumnPicker
                 columns={columns}
                 onChange={setDisplayColumns}
-                columnKey={hiddenColumnKey}
+                tableKey={key}
               />
             )}
           </HeaderRow>

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -36,6 +36,7 @@ export const DataTableComponent = <T extends RecordWithId>({
   const t = useTranslation('common');
   const { setRows, setDisabledRows, setFocus } = useTableStore();
   const [clickFocusedRow, setClickFocusedRow] = useState(false);
+  const [displayColumns, setDisplayColumns] = useState(columns);
   useRegisterActions([
     {
       id: 'table:focus-down',
@@ -122,14 +123,14 @@ export const DataTableComponent = <T extends RecordWithId>({
           }}
         >
           <HeaderRow dense={dense}>
-            {columns.map(column => (
+            {displayColumns.map(column => (
               <HeaderCell
                 dense={dense}
                 column={column}
                 key={String(column.key)}
               />
             ))}
-            <ColumnPicker columns={columns} />
+            <ColumnPicker columns={columns} onChange={setDisplayColumns} />
           </HeaderRow>
         </TableHead>
         <TableBody>
@@ -139,7 +140,7 @@ export const DataTableComponent = <T extends RecordWithId>({
               rows={data}
               ExpandContent={ExpandContent}
               rowIndex={idx}
-              columns={columns}
+              columns={displayColumns}
               onClick={onRowClick ? onRowClick : undefined}
               rowData={row}
               rowKey={String(idx)}

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -14,7 +14,7 @@ import { BasicSpinner, useRegisterActions } from '@openmsupply-client/common';
 import { TableProps } from './types';
 import { DataRow } from './components/DataRow/DataRow';
 import { PaginationRow } from './columns/PaginationRow';
-import { HeaderCell, HeaderRow } from './components/Header';
+import { ColumnPicker, HeaderCell, HeaderRow } from './components/Header';
 import { RecordWithId } from '@common/types';
 import { useTranslation } from '@common/intl';
 import { useTableStore } from './context';
@@ -129,6 +129,7 @@ export const DataTableComponent = <T extends RecordWithId>({
                 key={String(column.key)}
               />
             ))}
+            <ColumnPicker columns={columns} />
           </HeaderRow>
         </TableHead>
         <TableBody>

--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -24,6 +24,7 @@ export const DataTableComponent = <T extends RecordWithId>({
   columns,
   data = [],
   dense = false,
+  hiddenColumnKey,
   isDisabled = false,
   isError = false,
   isLoading = false,
@@ -130,7 +131,13 @@ export const DataTableComponent = <T extends RecordWithId>({
                 key={String(column.key)}
               />
             ))}
-            <ColumnPicker columns={columns} onChange={setDisplayColumns} />
+            {!!hiddenColumnKey && (
+              <ColumnPicker
+                columns={columns}
+                onChange={setDisplayColumns}
+                columnKey={hiddenColumnKey}
+              />
+            )}
           </HeaderRow>
         </TableHead>
         <TableBody>

--- a/client/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
@@ -42,7 +42,7 @@ export const MiniTable = <T extends RecordWithId>({
             createQueryParamsStore<T>({ initialSortBy: { key: 'name' } })
           }
         >
-          <DataTable dense columns={columns} data={rows} />
+          <DataTable dense columns={columns} data={rows} key="mini-table" />
         </TableProvider>
       </Box>
     </Box>

--- a/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  IconButton,
+  Tooltip,
+  Popover,
+  Stack,
+  Typography,
+  FormControlLabel,
+} from '@mui/material';
+import {
+  Checkbox,
+  Column,
+  ColumnsIcon,
+  RecordWithId,
+} from '@openmsupply-client/common';
+import { LocaleKey, useTranslation } from '@common/intl';
+
+export interface ColumnPickerProps<T extends RecordWithId> {
+  columns: Column<T>[];
+}
+
+export const ColumnPicker = <T extends RecordWithId>({
+  columns,
+}: ColumnPickerProps<T>) => {
+  const t = useTranslation('common');
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+  const columnList = columns
+    .filter(column => !!column.label)
+    .map(column => ({
+      enabled: true,
+      label: column.label,
+      key: column.key,
+    }));
+
+  return (
+    <>
+      <Tooltip title={t('table.show-columns')}>
+        <IconButton onClick={handleClick} aria-describedby={id}>
+          <ColumnsIcon sx={{ color: 'secondary.main' }} />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'center',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        <Stack spacing={1} padding={2}>
+          <Typography style={{ fontWeight: 700 }}>
+            {t('table.show-columns')}
+          </Typography>
+          {columnList.map(column => (
+            <FormControlLabel
+              key={String(column.key)}
+              control={<Checkbox checked={column.enabled} />}
+              label={t(column.label as LocaleKey)}
+            />
+          ))}
+        </Stack>
+      </Popover>
+    </>
+  );
+};

--- a/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Header/ColumnPicker.tsx
@@ -17,18 +17,19 @@ import {
 import { LocaleKey, useTranslation } from '@common/intl';
 
 interface ColumnPickerProps<T extends RecordWithId> {
-  columnKey: string;
   columns: Column<T>[];
+  tableKey: string;
   onChange: (columns: Column<T>[]) => void;
 }
 
 export const ColumnPicker = <T extends RecordWithId>({
-  columnKey,
+  tableKey,
   columns,
   onChange,
 }: ColumnPickerProps<T>) => {
   const t = useTranslation('common');
-  const [hiddenColumns, setHiddenColumns] = useLocalStorage('/columns/hidden');
+  const [hiddenColumnsConfig, setHiddenColumnsConfig] =
+    useLocalStorage('/columns/hidden');
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null
   );
@@ -36,8 +37,7 @@ export const ColumnPicker = <T extends RecordWithId>({
   const open = Boolean(anchorEl);
   const id = open ? 'simple-popover' : undefined;
 
-  const getHiddenColumns = () =>
-    hiddenColumns ? hiddenColumns[columnKey] ?? [] : [];
+  const getHiddenColumns = () => hiddenColumnsConfig?.[tableKey] ?? [];
 
   const isVisible = (column: Column<T>) =>
     !getHiddenColumns()?.includes(String(column.key));
@@ -56,10 +56,13 @@ export const ColumnPicker = <T extends RecordWithId>({
       ? [...hidden, String(column.key)]
       : hidden.filter(key => key !== column.key);
 
-    setHiddenColumns({ ...hiddenColumns, [columnKey]: updatedColumns });
+    setHiddenColumnsConfig({
+      ...hiddenColumnsConfig,
+      [tableKey]: updatedColumns,
+    });
   };
 
-  useEffect(() => onChange(columns.filter(isVisible)), [hiddenColumns]);
+  useEffect(() => onChange(columns.filter(isVisible)), [hiddenColumnsConfig]);
 
   return (
     <>

--- a/client/packages/common/src/ui/layout/tables/components/Header/index.ts
+++ b/client/packages/common/src/ui/layout/tables/components/Header/index.ts
@@ -1,1 +1,2 @@
+export * from './ColumnPicker';
 export * from './Header';

--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -20,6 +20,8 @@ export interface TableProps<T extends RecordWithId> {
   data?: T[];
   dense?: boolean;
   ExpandContent?: FC<{ rowData: T }>;
+  // specify a key to enable the option to hide columns
+  hiddenColumnKey?: string;
   isDisabled?: boolean;
   isError?: boolean;
   isLoading?: boolean;

--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -20,8 +20,8 @@ export interface TableProps<T extends RecordWithId> {
   data?: T[];
   dense?: boolean;
   ExpandContent?: FC<{ rowData: T }>;
-  // specify a key to enable the option to hide columns
-  hiddenColumnKey?: string;
+  enableColumnSelection?: boolean;
+  key: string;
   isDisabled?: boolean;
   isError?: boolean;
   isLoading?: boolean;

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -117,6 +117,7 @@ export const ContentArea: FC<ContentAreaProps> = ({
         ExpandContent={Expando}
         columns={columns}
         data={rows}
+        key="stocktake-detail"
         noDataElement={
           <NothingHere
             body={t('error.no-stocktake-items')}

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -114,6 +114,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
 
   return (
     <DataTable
+      key="stocktake-batch"
       isDisabled={isDisabled}
       columns={columns}
       data={batches}
@@ -153,6 +154,7 @@ export const PricingTable: FC<StocktakeLineEditTableProps> = ({
 
   return (
     <DataTable
+      key="stocktake-pricing"
       isDisabled={isDisabled}
       columns={columns}
       data={batches}
@@ -183,6 +185,7 @@ export const LocationTable: FC<StocktakeLineEditTableProps> = ({
 
   return (
     <DataTable
+      key="stocktake-location"
       isDisabled={isDisabled}
       columns={columns}
       data={batches}

--- a/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -68,6 +68,7 @@ export const StocktakeListView: FC = () => {
       <AppBarButtons sortBy={sortBy} modalController={modalController} />
 
       <DataTable
+        key="stocktake-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
@@ -55,6 +55,7 @@ export const ContentArea: FC<ContentAreaProps> = React.memo(
           ExpandContent={Expando}
           columns={columns}
           data={rows}
+          hiddenColumnKey="inbound-detail"
           noDataElement={
             <NothingHere
               body={t('error.no-inbound-items')}

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
@@ -51,11 +51,12 @@ export const ContentArea: FC<ContentAreaProps> = React.memo(
           </Box>
         )}
         <DataTable
+          key="inbound-detail"
           onRowClick={onRowClick}
           ExpandContent={Expando}
           columns={columns}
           data={rows}
-          hiddenColumnKey="inbound-detail"
+          enableColumnSelection
           noDataElement={
             <NothingHere
               body={t('error.no-inbound-items')}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -85,6 +85,7 @@ export const QuantityTableComponent: FC<TableProps> = ({
 
   return (
     <DataTable
+      key="inbound-line-quantity"
       isDisabled={isDisabled}
       columns={columns}
       data={lines}
@@ -132,6 +133,7 @@ export const PricingTableComponent: FC<TableProps> = ({
 
   return (
     <DataTable
+      key="inbound-line-pricing"
       isDisabled={isDisabled}
       columns={columns}
       data={lines}
@@ -167,7 +169,13 @@ export const LocationTableComponent: FC<TableProps> = ({
         })
       }
     >
-      <DataTable columns={columns} data={lines} dense isDisabled={isDisabled} />
+      <DataTable
+        key="inbound-line-location"
+        columns={columns}
+        data={lines}
+        dense
+        isDisabled={isDisabled}
+      />
     </QueryParamsProvider>
   );
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
@@ -81,6 +81,7 @@ const InboundServiceLineEditComponent = ({
             })}
           >
             <DataTable
+              key="inbound-detail-service-line"
               columns={columns}
               data={lines.filter(({ isDeleted }) => !isDeleted)}
               dense

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -74,6 +74,7 @@ export const InboundListView: FC = () => {
       <AppBarButtons sortBy={sortBy} modalController={modalController} />
 
       <DataTable
+        key="inbound-line-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -135,11 +135,12 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
         </Box>
       )}
       <DataTable
+        key="outbound-detail"
         onRowClick={onRowClick}
         ExpandContent={Expand}
         columns={columns}
         data={rows}
-        hiddenColumnKey="outbound-detail"
+        enableColumnSelection
         noDataElement={
           <NothingHere
             body={t('error.no-outbound-items')}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -139,6 +139,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
         ExpandContent={Expand}
         columns={columns}
         data={rows}
+        hiddenColumnKey="outbound-detail"
         noDataElement={
           <NothingHere
             body={t('error.no-outbound-items')}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -95,7 +95,12 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
         }}
       >
         {!!orderedRows.length && (
-          <DataTable columns={columns} data={orderedRows} dense />
+          <DataTable
+            key="outbound-line-edit"
+            columns={columns}
+            data={orderedRows}
+            dense
+          />
         )}
         {placeholderRow ? (
           <PlaceholderRow line={placeholderRow} onChange={onChange} />

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
@@ -80,6 +80,7 @@ const OutboundServiceLineEditComponent = ({
             })}
           >
             <DataTable
+              key="outbound-service-line"
               columns={columns}
               data={lines.filter(({ isDeleted }) => !isDeleted)}
               dense

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -83,6 +83,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
       <AppBarButtons sortBy={sortBy} modalController={modalController} />
 
       <DataTable
+        key="outbound-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
@@ -20,6 +20,7 @@ export const ContentArea = ({ onAddItem, onRowClick }: ContentAreaProps) => {
 
   return (
     <DataTable
+      key="internal-order-detail"
       onRowClick={onRowClick}
       columns={columns}
       data={lines}

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -78,6 +78,7 @@ export const RequestRequisitionListView: FC = () => {
       <AppBarButtons sortBy={sortBy} modalController={modalController} />
 
       <DataTable
+        key="internal-order-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ContentArea.tsx
@@ -11,6 +11,7 @@ export const ContentArea = ({ onRowClick }: ContentAreaProps) => {
 
   return (
     <DataTable
+      key="requisition-detail"
       onRowClick={onRowClick}
       columns={columns}
       data={lines}

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -67,6 +67,7 @@ export const ResponseRequisitionListView: FC = () => {
       <AppBarButtons sortBy={sortBy} />
 
       <DataTable
+        key="requisition-list"
         pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/MasterLists.tsx
@@ -23,7 +23,9 @@ const MasterListsTable = () => {
 
   if (isLoading) return <BasicSpinner />;
 
-  return <DataTable data={data?.nodes} columns={columns} />;
+  return (
+    <DataTable key="master-list-detail" data={data?.nodes} columns={columns} />
+  );
 };
 
 export const MasterListsTab = () => (

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -33,6 +33,7 @@ const ItemListComponent: FC = () => {
 
   return (
     <DataTable
+      key="item-list"
       pagination={{ ...pagination, total: data?.totalCount }}
       onChangePage={updatePaginationQuery}
       columns={columns}

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -49,6 +49,7 @@ const LocationListComponent: FC = () => {
       <Toolbar data={locations} filter={filter} />
       <AppBarButtons onCreate={() => onOpen()} sortBy={sortBy} />
       <DataTable
+        key="location-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
+++ b/client/packages/system/src/MasterList/DetailView/ContentArea.tsx
@@ -7,6 +7,7 @@ export const ContentArea = () => {
   const { lines, columns } = useMasterList.line.rows();
   return (
     <DataTable
+      key="master-list-detail"
       columns={columns}
       data={lines}
       noDataMessage={t('error.no-items')}

--- a/client/packages/system/src/MasterList/ListView/ListView.tsx
+++ b/client/packages/system/src/MasterList/ListView/ListView.tsx
@@ -39,6 +39,7 @@ const MasterListComponent: FC = () => {
       <Toolbar filter={filter} />
       <AppBarButtons sortBy={sortBy} />
       <DataTable
+        key="master-list-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -47,6 +47,7 @@ const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
   return (
     <>
       <DataTable
+        key="name-list"
         pagination={{ ...pagination, total: data?.totalCount }}
         onChangePage={updatePaginationQuery}
         columns={columns}

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -63,6 +63,7 @@ const StockListComponent: FC = () => {
         filterString={urlQuery.filter ?? ''}
       />
       <DataTable
+        key="stock-list"
         pagination={{ ...pagination, total: filteredSortedData.length }}
         columns={columns}
         data={filteredSortedData.slice(


### PR DESCRIPTION
Fixes #275 

Allows hiding columns - with the option saved locally in the browser local storage, making the setting browser specific rather than per user, strictly speaking.

Added to the detail view of shipments ( inbound & outbound ) only at this stage.
The icon changes colour, to indicate whether the filter is active or not.

Here's the process in action:

https://user-images.githubusercontent.com/9192912/177681860-352f9d20-e8f5-495b-81c4-cb09e136d91c.mp4

which results in a localstorage item of `@openmsupply-client/columns/hidden` which has the shape:

```
{ 
    "outbound-detail": ["lineTotal", "sellPricePerUnit", "unitQuantity"] 
}
```


