### PR TITLE
Disable doc tests for crates that don't use them

### DIFF
--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 path = "src/cli.rs"

--- a/server/graphql/Cargo.toml
+++ b/server/graphql/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "./lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/batch_mutations/Cargo.toml
+++ b/server/graphql/batch_mutations/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/core/Cargo.toml
+++ b/server/graphql/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/general/Cargo.toml
+++ b/server/graphql/general/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/invoice/Cargo.toml
+++ b/server/graphql/invoice/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/invoice_line/Cargo.toml
+++ b/server/graphql/invoice_line/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/location/Cargo.toml
+++ b/server/graphql/location/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/reports/Cargo.toml
+++ b/server/graphql/reports/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/requisition/Cargo.toml
+++ b/server/graphql/requisition/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/requisition_line/Cargo.toml
+++ b/server/graphql/requisition_line/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/stocktake/Cargo.toml
+++ b/server/graphql/stocktake/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/stocktake_line/Cargo.toml
+++ b/server/graphql/stocktake_line/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/graphql/types/Cargo.toml
+++ b/server/graphql/types/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/report_builder/Cargo.toml
+++ b/server/report_builder/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 path = "src/cli.rs"

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "remote_server"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 path = "src/main.rs"

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 repository = { path = "../repository" }


### PR DESCRIPTION
Closes #303 
Doc tests slow down testing when not used.
This change improves test time by around 15s with `--features=memory`