### PR TITLE
Misc Ux issues

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import { useUrlQuery } from './useUrlQuery';
-import { Column } from '@openmsupply-client/common';
+import { Column, useLocalStorage } from '@openmsupply-client/common';
 import { FilterController } from '../useQueryParams';
 
 // This hook uses the state of the url query parameters (from useUrlQuery hook)
 // to provide query parameters and update methods to tables.
 
-const RECORDS_PER_PAGE = 20;
+export const DEFAULT_RECORDS_PER_PAGE = 20;
 
 interface UrlQueryParams {
   filterKey?: string;
@@ -23,6 +23,11 @@ export const useUrlQueryParams = ({
   // if this is parsed as numeric, the query param changes filter=0300 to filter=300
   // which then does not match against codes, as the filter is usually a 'startsWith'
   const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['filter'] });
+  const [storedRowsPerPage] = useLocalStorage(
+    '/pagination/rowsperpage',
+    DEFAULT_RECORDS_PER_PAGE
+  );
+  const rowsPerPage = storedRowsPerPage || DEFAULT_RECORDS_PER_PAGE;
 
   useEffect(() => {
     if (!initialSortKey) return;
@@ -69,8 +74,8 @@ export const useUrlQueryParams = ({
   };
   const queryParams = {
     page: urlQuery.page ? urlQuery.page - 1 : 0,
-    offset: urlQuery.page ? (urlQuery.page - 1) * RECORDS_PER_PAGE : 0,
-    first: RECORDS_PER_PAGE,
+    offset: urlQuery.page ? (urlQuery.page - 1) * rowsPerPage : 0,
+    first: rowsPerPage,
     sortBy: {
       key: urlQuery.sort ?? initialSortKey,
       direction: urlQuery.dir ?? 'asc',

--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQueryParams.ts
@@ -27,7 +27,7 @@ export const useUrlQueryParams = ({
     '/pagination/rowsperpage',
     DEFAULT_RECORDS_PER_PAGE
   );
-  const rowsPerPage = storedRowsPerPage || DEFAULT_RECORDS_PER_PAGE;
+  const rowsPerPage = storedRowsPerPage ?? DEFAULT_RECORDS_PER_PAGE;
 
   useEffect(() => {
     if (!initialSort) return;

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -138,6 +138,7 @@
   "label.remaining-to-supply": "Remaining",
   "label.requested-quantity": "Requested",
   "label.requisition": "Requisition",
+  "label.rows-per-page": "Rows per page:",
   "label.select": "Select",
   "label.select-all": "Select all",
   "label.selected": "Selected",

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -22,6 +22,7 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/mru/credentials': AuthenticationCredentials;
   '/auth/error': AuthError | undefined;
+  '/pagination/rowsperpage': number;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/client/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react';
-import { Box, Typography, Pagination } from '@mui/material';
+import { Box, Typography, Pagination, TablePagination } from '@mui/material';
 import { useTableStore } from '../../context';
 import { useTranslation } from '@common/intl';
+import { useLocalStorage } from 'packages/common/src/localStorage';
+import { DEFAULT_RECORDS_PER_PAGE } from '@common/hooks';
 
 interface PaginationRowProps {
   offset: number;
@@ -19,12 +21,19 @@ export const PaginationRow: FC<PaginationRowProps> = ({
   onChange,
 }) => {
   const { numberSelected } = useTableStore();
+  const [, setRowsPerPage] = useLocalStorage(
+    '/pagination/rowsperpage',
+    DEFAULT_RECORDS_PER_PAGE
+  );
 
   // Offset is zero indexed, but should display one indexed for
   // users.
   const xToY = `${offset + 1}-${Math.min(first + offset, total)}`;
 
-  const onChangePage = (_: React.ChangeEvent<unknown>, value: number) => {
+  const onChangePage = (
+    _: React.ChangeEvent<unknown> | React.MouseEvent<HTMLButtonElement> | null,
+    value: number
+  ) => {
     // The type here is broken and `value` can be `null`!
 
     const isValidPage = !!value;
@@ -33,6 +42,13 @@ export const PaginationRow: FC<PaginationRowProps> = ({
       const zeroIndexedPageNumber = value - 1;
       onChange(zeroIndexedPageNumber);
     }
+  };
+
+  const onChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    onChangePage(event, 0);
   };
 
   const t = useTranslation('common');
@@ -72,6 +88,20 @@ export const PaginationRow: FC<PaginationRowProps> = ({
             )}
           </Box>
 
+          <TablePagination
+            size="small"
+            component="div"
+            page={page}
+            onPageChange={onChangePage}
+            rowsPerPage={first}
+            onRowsPerPageChange={onChangeRowsPerPage}
+            count={total}
+            rowsPerPageOptions={[20, 50, 100, 500]}
+            nextIconButtonProps={{ style: { display: 'none' } }}
+            backIconButtonProps={{ style: { display: 'none' } }}
+            labelDisplayedRows={() => null}
+            labelRowsPerPage={t('label.rows-per-page')}
+          />
           <Pagination
             size="small"
             page={displayPage}

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -15,6 +15,7 @@ import {
   Theme,
   useTheme,
   useTableStore,
+  CellProps,
 } from '@openmsupply-client/common';
 import { getLocationInputColumn } from '@openmsupply-client/system';
 import { DraftStocktakeLine } from './utils';
@@ -80,6 +81,13 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
   const theme = useTheme();
   useDisableStocktakeRows(batches);
 
+  const PackSizeCell = (props: CellProps<DraftStocktakeLine>) => (
+    <PositiveNumberInputCell
+      {...props}
+      isDisabled={!!props.rowData.stockLine}
+    />
+  );
+
   const columns = useColumns<DraftStocktakeLine>([
     getCountThisLineColumn(update, theme),
     getBatchColumn(update, theme),
@@ -93,7 +101,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
       key: 'packSize',
       label: 'label.pack-size',
       width: 125,
-      Cell: PositiveNumberInputCell,
+      Cell: PackSizeCell,
       setter: patch => update({ ...patch, countThisLine: true }),
     },
     {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -33,6 +33,7 @@ export const InboundLineEditForm: FC<InboundLineEditProps> = ({
         <Grid item flex={1}>
           <StockItemSearchInput
             autoFocus={!item}
+            openOnFocus={!item}
             disabled={disabled}
             currentItemId={item?.id}
             onChange={newItem => newItem && onChangeItem(newItem)}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -63,6 +63,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
         <Grid item flex={1}>
           <StockItemSearchInput
             autoFocus={!item}
+            openOnFocus={!item}
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -95,6 +95,7 @@ export const RequestLineEditForm = ({
         <>
           <StockItemSearchInput
             autoFocus={!item}
+            openOnFocus={!item}
             width={300}
             disabled={disabled}
             currentItemId={item?.id}

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useToggle,
   useFormatNumber,
@@ -47,6 +47,7 @@ interface StockItemSearchInputProps {
   extraFilter?: (item: ItemRowWithStatsFragment) => boolean;
   width?: number;
   autoFocus?: boolean;
+  openOnFocus?: boolean;
 }
 
 export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
@@ -56,6 +57,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   extraFilter,
   width,
   autoFocus = false,
+  openOnFocus,
 }) => {
   const { data, isLoading } = useStockItemsWithStats();
   const t = useTranslation('common');
@@ -67,6 +69,14 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   const options = extraFilter
     ? data?.nodes?.filter(extraFilter) ?? []
     : data?.nodes ?? [];
+
+  useEffect(() => {
+    // using the Autocomplete openOnFocus prop, the popper is incorrectly positioned
+    // when used within a Dialog. This is a workaround to fix the popper position.
+    if (openOnFocus) {
+      setTimeout(() => selectControl.toggleOn(), 300);
+    }
+  }, []);
 
   return (
     <Autocomplete
@@ -85,6 +95,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
       width={width ? `${width}px` : '100%'}
       popperMinWidth={width}
       isOptionEqualToValue={(option, value) => option?.id === value?.id}
+      open={selectControl.isOn}
     />
   );
 };


### PR DESCRIPTION
Fixes #302 

Some minor fixes, bundled together in one PR.

The pagination is a bit of a quick and dirty - am saving to localStorage for that one, on the understanding that you'd want to retain the option set. If the value is in the URL then it won't be retained for you. Have also set that as a general option - so it will apply to all paginated data tables 🤷 

The stocktake change is fairly sensible, I think.
Likewise the outbound placeholder row changes.

Then there's the auto-open of the item autocomplete when creating inbound, outbound and internal orders. This is something that we've tried before - and the issue is that the Popper displays incorrectly positioned. I've worked around that by making the open state controlled ( which it partly was anyway ) and delaying the open by 300ms. 