### PR TITLE
Add android ID

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -54,6 +54,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414360eed71ba2d5435b185ba43ecbe281dfab5df3898286d6b7be8074372c92"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log 0.4.16",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,6 +4062,7 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-rt",
  "actix-web",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -54,21 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-cors"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414360eed71ba2d5435b185ba43ecbe281dfab5df3898286d6b7be8074372c92"
-dependencies = [
- "actix-utils",
- "actix-web",
- "derive_more",
- "futures-util",
- "log 0.4.16",
- "once_cell",
- "smallvec",
-]
-
-[[package]]
 name = "actix-files"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4062,7 +4047,6 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
- "actix-cors",
  "actix-files",
  "actix-rt",
  "actix-web",

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -93,13 +93,14 @@ pub mod android {
         port: jchar,
         files_dir: JString,
         cache_dir: JString,
-        _android_id: JString,
+        android_id: JString,
     ) -> jlong {
         android_logger::init_once(Config::default().with_min_level(Level::Trace));
 
         let (off_switch, off_switch_receiver) = oneshot::channel();
         let files_dir: String = env.get_string(files_dir).unwrap().into();
         let files_dir = PathBuf::from(&files_dir);
+        let android_id: String = env.get_string(android_id).unwrap().into();
         let db_path = files_dir.join("omsupply-database");
 
         let cache_dir: String = env.get_string(cache_dir).unwrap().into();
@@ -119,6 +120,7 @@ pub mod android {
                         debug_no_access_control: false,
                         cors_origins: vec!["http://localhost".to_string()],
                         base_dir: Some(files_dir.to_str().unwrap().to_string()),
+                        machine_uid: Some(android_id),
                     },
                     database: DatabaseSettings {
                         username: "n/a".to_string(),

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -23,7 +23,8 @@ util = { path = "../util" }
 
 machine-uid = { version = "0.2.0", optional = true }
 
-# OpenSSL is currently only used indirectly by external crates. For the Android build we need to useactix-cors = "0.6.1"
+# OpenSSL is currently only used indirectly by external crates. For the Android build we need to use actix-cors = "0.6.1"
+actix-cors = "0.6.1"
 actix-web = { version = "4.0.1", features = ["rustls"] }
 actix-files = "0.6.0"
 # the "openssl/vendored" feature to make the cross compilation work, i.e. to avoid linking against

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -21,10 +21,11 @@ repository = { path = "../repository" }
 service = { path = "../service" }
 util = { path = "../util" }
 
-actix-cors = "0.6.1"
-actix-web = { version= "4.0.1", features = ["rustls"] } 
+machine-uid = { version = "0.2.0", optional = true }
+
+# OpenSSL is currently only used indirectly by external crates. For the Android build we need to useactix-cors = "0.6.1"
+actix-web = { version = "4.0.1", features = ["rustls"] }
 actix-files = "0.6.0"
-# OpenSSL is currently only used indirectly by external crates. For the Android build we need to use
 # the "openssl/vendored" feature to make the cross compilation work, i.e. to avoid linking against
 # the openssl shared lib which is not easily available on the host platform. To enable the
 # "openssl/vendored" feature on Android (see below) the openssl crate needs to be a dependency.
@@ -39,23 +40,21 @@ rustls = "0.20.4"
 rustls-pemfile = "1.0.0"
 serde = "1.0.137"
 serde_json = "1.0.66"
-tokio = { version = "1.17.0", features = ["macros" ] }
+tokio = { version = "1.17.0", features = ["macros"] }
 thiserror = "1"
 clap = { version = "3.1.8", features = ["derive"] }
 rust-embed = "6.4.0"
 mime_guess = "2.0.4"
-local-ip-address = { version = "0.4.4",  optional = true }
+local-ip-address = { version = "0.4.4", optional = true }
 simple-dns = "0.4.6"
 simple-mdns = "0.3.9"
-machine-uid = "0.2.0"
-
 [dev-dependencies]
 actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 httpmock = "0.6"
 
 [features]
-default = ["sqlite", "dep:local-ip-address"]
+default = ["sqlite", "dep:local-ip-address", "dep:machine-uid"]
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]
 # See openssl comment regarding the "openssl/vendored" feature

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -23,10 +23,10 @@ util = { path = "../util" }
 
 machine-uid = { version = "0.2.0", optional = true }
 
-# OpenSSL is currently only used indirectly by external crates. For the Android build we need to use actix-cors = "0.6.1"
 actix-cors = "0.6.1"
 actix-web = { version = "4.0.1", features = ["rustls"] }
 actix-files = "0.6.0"
+# OpenSSL is currently only used indirectly by external crates. For the Android build we need to use actix-cors = "0.6.1"
 # the "openssl/vendored" feature to make the cross compilation work, i.e. to avoid linking against
 # the openssl shared lib which is not easily available on the host platform. To enable the
 # "openssl/vendored" feature on Android (see below) the openssl crate needs to be a dependency.

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -82,13 +82,15 @@ async fn run_stage0(
         .get_hardware_id()?
         .is_empty()
     {
-        let machine_uid = match machine_uid::get() {
-            Ok(uid) => uid,
-            Err(e) => config_settings
+        #[cfg(not(target_os = "android"))]
+        let machine_uid = machine_uid::get().expect("Failed to query OS for hardware id");
+
+        #[cfg(target_os = "android")]
+        let machine_uid = config_settings
                 .server
                 .machine_uid
                 .clone()
-                .unwrap_or("".to_string()),
+                .unwrap_or("".to_string(),
         };
 
         service_provider

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -21,7 +21,7 @@ use service::{
 
 use actix_web::{web::Data, App, HttpServer};
 use std::{
-    ops::{DerefMut, Deref},
+    ops::{Deref, DerefMut},
     sync::{Arc, RwLock},
 };
 use tokio::sync::{oneshot, Mutex};
@@ -82,9 +82,18 @@ async fn run_stage0(
         .get_hardware_id()?
         .is_empty()
     {
+        let machine_uid = match machine_uid::get() {
+            Ok(uid) => uid,
+            Err(e) => config_settings
+                .server
+                .machine_uid
+                .clone()
+                .unwrap_or("".to_string()),
+        };
+
         service_provider
             .app_data_service
-            .set_hardware_id(machine_uid::get().expect("Failed to query OS for hardware id"))?;
+            .set_hardware_id(machine_uid)?;
     }
 
     let service_provider_data = Data::new(service_provider);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -1,4 +1,6 @@
+#[cfg(not(target_os = "android"))]
 extern crate machine_uid;
+
 use crate::{
     certs::Certificates, configuration::get_or_create_token_secret, cors::cors_policy,
     serve_frontend::config_server_frontend, static_files::config_static_files,
@@ -87,11 +89,10 @@ async fn run_stage0(
 
         #[cfg(target_os = "android")]
         let machine_uid = config_settings
-                .server
-                .machine_uid
-                .clone()
-                .unwrap_or("".to_string(),
-        };
+            .server
+            .machine_uid
+            .clone()
+            .unwrap_or("".to_string());
 
         service_provider
             .app_data_service

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -22,6 +22,8 @@ pub struct ServerSettings {
     pub cors_origins: Vec<String>,
     /// Directory where the server stores its data, e.g. sqlite DB file or certs
     pub base_dir: Option<String>,
+    /// Option to set the machine id of the device for an OS that isn't supported by machine_uid
+    pub machine_uid: Option<String>,
 }
 
 impl ServerSettings {


### PR DESCRIPTION
Fixes #221 

I was hoping to just use `machine_uid::get()` and fetch from settings if that failed - but the android build wouldn't compile if `machine_uid` was included, so I've had to make it a little more specific than I'd like.

Have tested on android and the setting is updated, and makes it through to 4D:

<img width="424" alt="Screen Shot 2022-07-11 at 6 28 15 PM" src="https://user-images.githubusercontent.com/9192912/178202117-2079c9ee-8471-4048-8d6f-cdf8302b3422.png">

also ran the server locally with these changes and it still works

## Tests
- [ ] The `make android` builds successfully
- [ ] When syncing with this version, the AndroidID is sent to mSupply
