### PR TITLE
Create postgres database if it doesn't exist

### DIFF
--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -1,6 +1,7 @@
 use crate::db_diesel::{DBBackendConnection, StorageConnectionManager};
 use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, ManageConnection, Pool};
+use log::info;
 use serde;
 
 //WAIT up to 5 SECONDS for lock in SQLITE (https://www.sqlite.org/c3ref/busy_timeout.html)
@@ -112,51 +113,43 @@ pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageCon
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
 
+    // Check the database connection, and attempt to create the database if required
     // Note: the build() call isn't failing when you have an incorrect server or database name
-    // which is why the connect() call is made
-    match connection_manager.connect() {
-        Ok(_conn) => {
-            // the min_idle is a workaround to get pg running reliably on windows.
-            // if you don't require it any more, swap the pool creation lines out for this one:
-            // let pool = Pool::new(connection_manager).expect("Failed to connect to database");
-            let pool = Pool::builder()
-                .min_idle(Some(0))
-                .build(connection_manager)
-                .expect("Failed to connect to database");
-            StorageConnectionManager::new(pool)
-        }
-        Err(e) => {
-            if e.to_string().contains(
-                format!("database \"{}\" does not exist", &settings.database_name).as_str(),
-            ) {
-                let root_connection_manager = ConnectionManager::<DBBackendConnection>::new(
-                    &settings.connection_string_without_db(),
-                );
+    // so we need to explicitly call connect() to test the connection
+    if let Err(e) = connection_manager.connect() {
+        if e.to_string()
+            .contains(format!("database \"{}\" does not exist", &settings.database_name).as_str())
+        {
+            info!(
+                "Database {} does not exist. Attempting to create it.",
+                &settings.database_name
+            );
+            let root_connection_manager = ConnectionManager::<DBBackendConnection>::new(
+                &settings.connection_string_without_db(),
+            );
 
-                match root_connection_manager.connect() {
-                    Ok(root_connection) => {
-                        root_connection
-                            .batch_execute(&format!(
-                                "CREATE DATABASE \"{}\";",
-                                &settings.database_name
-                            ))
-                            .expect("Failed to create database");
-
-                        let pool = Pool::builder()
-                            .min_idle(Some(0))
-                            .build(connection_manager)
-                            .expect("Failed to connect to database");
-                        StorageConnectionManager::new(pool)
-                    }
-                    Err(e) => {
-                        panic!("Failed to connect to postgres root: {}", e);
-                    }
+            match root_connection_manager.connect() {
+                Ok(root_connection) => {
+                    root_connection
+                        .batch_execute(&format!("CREATE DATABASE \"{}\";", &settings.database_name))
+                        .expect("Failed to create database");
                 }
-            } else {
-                panic!("Failed to connect to database: {}", e);
+                Err(e) => {
+                    panic!("Failed to connect to postgres root: {}", e);
+                }
             }
+        } else {
+            panic!("Failed to connect to database: {}", e);
         }
     }
+    // the min_idle is a workaround to get pg running reliably on windows.
+    // if you don't require it any more, swap the pool creation lines out for this one:
+    // let pool = Pool::new(connection_manager).expect("Failed to connect to database");
+    let pool = Pool::builder()
+        .min_idle(Some(0))
+        .build(connection_manager)
+        .expect("Failed to connect to database");
+    StorageConnectionManager::new(pool)
 }
 
 // feature sqlite

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -112,8 +112,13 @@ pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageCon
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
 
+    // Note: the build() call isn't failing when you have an incorrect server or database name
+    // which is why the connect() call is made
     match connection_manager.connect() {
         Ok(_conn) => {
+            // the min_idle is a workaround to get pg running reliably on windows.
+            // if you don't require it any more, swap the pool creation lines out for this one:
+            // let pool = Pool::new(connection_manager).expect("Failed to connect to database");
             let pool = Pool::builder()
                 .min_idle(Some(0))
                 .build(connection_manager)


### PR DESCRIPTION
Fixes #222 

Along the way, I made it easier for those who are setting up postgres. If you specify a database which doesn't exist, but credentials which can create, then the server will create the database for you. Just as good as sqlite now!

Have also added in Clemens' temporary fix, since I am already patching demo and AV to use this.. postgres doesn't run on windows without it.

## Tests
- [ ] Run with `--features postgres` with an invalid database host name: should show error in console and quit
- [ ] Run with `--features postgres` with an invalid database name: should create db for you, and run as normal
- [ ] Run with `--features postgres` with a valid database name: should run as normal
- [ ] Run with `--features postgres` with an invalid database name: and a user without db create permission: should raise error and quit

Note: test[4] fails with `FATAL:  database "[username]" does not exist` which isn't accurate. not concerned enough to look further into that one