### PR TITLE
Internal order fixes

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -7,7 +7,11 @@ type DialogButtonVariant = 'cancel' | 'next' | 'ok';
 
 interface DialogButtonProps {
   disabled?: boolean;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>
+  ) => void;
   variant: DialogButtonVariant;
   autoFocus?: boolean;
 }
@@ -60,6 +64,11 @@ export const DialogButton: React.FC<DialogButtonProps> = ({
       variant={buttonVariant}
       label={t(labelKey)}
       tabIndex={variant === 'cancel' ? 1 : 0}
+      onKeyDown={e => {
+        if (e.key === 'Enter') {
+          onClick(e);
+        }
+      }}
       sx={
         disabled
           ? {

--- a/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -59,6 +59,7 @@ export const DialogButton: React.FC<DialogButtonProps> = ({
       Icon={icon}
       variant={buttonVariant}
       label={t(labelKey)}
+      tabIndex={variant === 'cancel' ? 1 : 0}
       sx={
         disabled
           ? {

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
@@ -42,7 +42,7 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
       case 'consumption':
         const label = props.payload.isHistoric
           ? t('label.consumption')
-          : t('label.amc');
+          : t('label.projected');
         return [value, label];
       case 'averageMonthlyConsumption':
         return [value, t('label.moving-average')];
@@ -98,7 +98,7 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
                   color: theme.palette.gray.main,
                 },
                 {
-                  value: t('label.amc'),
+                  value: t('label.projected'),
                   type: 'rect',
                   id: '2',
                   color: theme.palette.primary.light,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -53,15 +53,19 @@ export const RequestLineEdit = ({
   };
 
   const onCancel = () => {
-    deletePreviousLine();
+    if (mode === ModalMode.Create) {
+      deletePreviousLine();
+    }
     onClose();
   };
 
   useEffect(() => {
+    // isCreated is true when the line exists only locally i.e. not saved to server
     if (!!draft?.isCreated) {
       save();
+    } else {
+      if (!!draft?.id) setPreviousItemLineId(draft.id);
     }
-    if (!!draft?.id) setPreviousItemLineId(draft.id);
   }, [draft]);
 
   return (

--- a/client/packages/requisitions/src/RequestRequisition/api/api.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/api.ts
@@ -153,6 +153,23 @@ export const getRequestQueries = (sdk: Sdk, storeId: string) => ({
       throw new Error('Unable to load chart data');
     },
   },
+  deleteLine: async (requestLineId: string) => {
+    const ids = [{ id: requestLineId }];
+    const result = await sdk.deleteRequestLines({ ids, storeId });
+
+    if (result.batchRequestRequisition.deleteRequestRequisitionLines) {
+      const failedLines =
+        result.batchRequestRequisition.deleteRequestRequisitionLines.filter(
+          line =>
+            line.response.__typename === 'DeleteRequestRequisitionLineError'
+        );
+      if (failedLines.length === 0) {
+        return result.batchRequestRequisition.deleteRequestRequisitionLines;
+      }
+    }
+
+    throw new Error('Could not delete requisition lines!');
+  },
   deleteLines: async (requestLines: RequestLineFragment[]) => {
     const ids = requestLines.map(requestParser.toDeleteLine);
     const result = await sdk.deleteRequestLines({ ids, storeId });

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/index.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/index.ts
@@ -27,6 +27,7 @@ export const useRequest = {
   line: {
     chartData: Lines.useRequestLineChartData,
     delete: Lines.useDeleteRequestLines,
+    deleteLine: Lines.useDeleteRequestLine,
     list: Lines.useRequestLines,
     save: Lines.useSaveRequestLines,
   },

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/index.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/index.ts
@@ -1,9 +1,11 @@
+import { useDeleteRequestLine } from './useDeleteRequestLine';
 import { useDeleteRequestLines } from './useDeleteRequestLines';
 import { useRequestLineChartData } from './useRequestLineChartData';
 import { useRequestLines } from './useRequestLines';
 import { useSaveRequestLines } from './useSaveRequestLines';
 
 export const Lines = {
+  useDeleteRequestLine,
   useDeleteRequestLines,
   useRequestLineChartData,
   useRequestLines,

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useDeleteRequestLine.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useDeleteRequestLine.ts
@@ -1,0 +1,15 @@
+import { useQueryClient, useMutation } from '@openmsupply-client/common';
+import { useRequestNumber } from '../document/useRequest';
+import { useRequestApi } from '../utils/useRequestApi';
+
+export const useDeleteRequestLine = () => {
+  const api = useRequestApi();
+  const requestNumber = useRequestNumber();
+
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation(api.deleteLine, {
+    onSettled: () =>
+      queryClient.invalidateQueries(api.keys.detail(requestNumber)),
+  });
+  return mutate;
+};

--- a/client/packages/system/src/Item/api/api.ts
+++ b/client/packages/system/src/Item/api/api.ts
@@ -62,7 +62,11 @@ export const getItemQueries = (sdk: Sdk, storeId: string) => ({
         key: itemParsers.toSortField(sortBy),
         isDesc: sortBy.isDesc,
         storeId,
-        filter: { ...filterBy, type: { equalTo: ItemNodeType.Stock } },
+        filter: {
+          ...filterBy,
+          type: { equalTo: ItemNodeType.Stock },
+          isVisible: true,
+        },
       });
 
       const { items } = result;

--- a/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
+++ b/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
@@ -1,4 +1,4 @@
-import { ItemNodeType, useQuery } from '@openmsupply-client/common';
+import { useQuery } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
 export const useStockItemsWithStats = () => {
@@ -6,7 +6,6 @@ export const useStockItemsWithStats = () => {
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
     offset: 0,
     first: 1000, // TODO: remove arbitrary limit
-    filterBy: { type: { equalTo: ItemNodeType.Stock } },
   };
   const api = useItemApi();
   return useQuery(api.keys.paramList(queryParams), () =>

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -75,7 +75,7 @@ pub fn get_requisition_line_chart(
         item_id,
         available_stock_on_hand,
         average_monthly_consumption,
-        suggested_quantity,
+        requested_quantity,
         ..
     } = requisition_line.requisition_line_row;
 
@@ -103,7 +103,7 @@ pub fn get_requisition_line_chart(
         *requisition_line_datetime,
         available_stock_on_hand as u32,
         *expected_delivery_date,
-        suggested_quantity as u32,
+        requested_quantity as u32,
         average_monthly_consumption as f64,
         stock_evolution_options,
     )?;

--- a/server/service/src/requisition_line/chart/stock_evolution.rs
+++ b/server/service/src/requisition_line/chart/stock_evolution.rs
@@ -39,7 +39,7 @@ pub fn get_stock_evolution_for_item(
     reference_datetime: NaiveDateTime,
     reference_stock_on_hand: u32,
     expected_delivery_date: NaiveDate,
-    suggested_quantity: u32,
+    requested_quantity: u32,
     average_monthly_consumption: f64,
     options: StockEvolutionOptions,
 ) -> Result<StockEvolutionResult, RepositoryError> {
@@ -65,7 +65,7 @@ pub fn get_stock_evolution_for_item(
         projected_stock: calculate_projected_stock_evolution(
             reference_stock_on_hand,
             average_monthly_consumption,
-            suggested_quantity,
+            requested_quantity,
             expected_delivery_date,
             points.projected_points,
         ),
@@ -166,7 +166,7 @@ fn calculate_historic_stock_evolution(
 fn calculate_projected_stock_evolution(
     reference_stock_on_hand: u32,
     average_monthly_consumption: f64,
-    suggested_quantity: u32,
+    requested_quantity: u32,
     expected_delivery_date: NaiveDate,
     projected_points: Vec<NaiveDate>,
 ) -> Vec<StockEvolution> {
@@ -175,7 +175,7 @@ fn calculate_projected_stock_evolution(
     let mut running_stock_on_hand = reference_stock_on_hand as f64;
     for reference_date in projected_points.into_iter() {
         if reference_date == expected_delivery_date {
-            running_stock_on_hand += suggested_quantity as f64;
+            running_stock_on_hand += requested_quantity as f64;
         }
         running_stock_on_hand -= average_daily_consumption;
 


### PR DESCRIPTION
Fixes #317 

- [ ] Update tab order to deprioritise cancel
- [ ] Creating the stock lines on item selection in order to show charts 
- [ ] Delete request line for previous item when changing item - but only when creating a request line
- [ ] Delete request line when cancelling a create dialog
- [ ] `Stock Evolution` chart is now using requested quantity not suggested quantity
- [ ] `Consumption History` chart has the 'AMC' relabelled to 'Projected' Not sure what else to do for this request 🤷 
- [ ] Dialog buttons now fire the `onClick` when pressing space or enter

The other item, of "Print > does not seem to be working" required a database migration on the demo server.