### PR TITLE
Requisition fixes

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
@@ -102,22 +102,20 @@ export const ResponseLineEditForm = ({
       Middle={
         <>
           <Typography variant="body1" fontWeight="bold">
-            {t('heading.comment')}
-          </Typography>
-          <TextArea
-            value={draftLine.comment}
-            onChange={e => update({ comment: e.target.value })}
-            InputProps={{
-              sx: { backgroundColor: theme => theme.palette.background.menu },
-            }}
-          />
-        </>
-      }
-      Right={
-        <>
-          <Typography variant="body1" fontWeight="bold">
             {t('heading.order')}
           </Typography>
+          <InputWithLabelRow
+            Input={
+              <NumericTextInput
+                width={150}
+                value={draftLine.requestedQuantity}
+                disabled
+              />
+            }
+            labelWidth="150px"
+            labelProps={{ sx: { fontWeight: 500 } }}
+            label={t('label.requested-quantity', { ns: 'distribution' })}
+          />
           <InputWithLabelRow
             Input={
               <NonNegativeIntegerInput
@@ -132,17 +130,19 @@ export const ResponseLineEditForm = ({
             labelProps={{ sx: { fontWeight: 500 } }}
             label={t('label.supply-quantity', { ns: 'distribution' })}
           />
-          <InputWithLabelRow
-            Input={
-              <NumericTextInput
-                width={150}
-                value={draftLine.requestedQuantity}
-                disabled
-              />
-            }
-            labelWidth="150px"
-            labelProps={{ sx: { fontWeight: 500 } }}
-            label={t('label.requested-quantity', { ns: 'distribution' })}
+        </>
+      }
+      Right={
+        <>
+          <Typography variant="body1" fontWeight="bold">
+            {t('heading.comment')}
+          </Typography>
+          <TextArea
+            value={draftLine.comment}
+            onChange={e => update({ comment: e.target.value })}
+            InputProps={{
+              sx: { backgroundColor: theme => theme.palette.background.menu },
+            }}
           />
         </>
       }

--- a/server/service/src/sync_processor/requisition/common.rs
+++ b/server/service/src/sync_processor/requisition/common.rs
@@ -71,6 +71,11 @@ pub fn generate_linked_requisition(
 
     let name_id = record_for_processing.source_name.id.clone();
 
+    let source_comment = match source_requisition.comment.clone() {
+        Some(comment) => format!(" ({})", comment),
+        None => String::new(),
+    };
+
     let result = RequisitionRow {
         id: uuid(),
         requisition_number: next_number(
@@ -93,7 +98,10 @@ pub fn generate_linked_requisition(
         sent_datetime: None,
         finalised_datetime: None,
         colour: None,
-        comment: None,
+        comment: Some(format!(
+            "From request requisition {}{}",
+            source_requisition.requisition_number, source_comment
+        )),
     };
 
     Ok(result)
@@ -122,7 +130,7 @@ fn generate_linked_requisition_lines(
             snapshot_datetime: source_line.requisition_line_row.snapshot_datetime,
             // Default
             supply_quantity: 0,
-            comment: None,
+            comment: source_line.requisition_line_row.comment,
         });
     }
 

--- a/server/service/src/sync_processor/requisition/common.rs
+++ b/server/service/src/sync_processor/requisition/common.rs
@@ -71,7 +71,7 @@ pub fn generate_linked_requisition(
 
     let name_id = record_for_processing.source_name.id.clone();
 
-    let source_comment = match source_requisition.comment.clone() {
+    let source_comment = match &source_requisition.comment {
         Some(comment) => format!(" ({})", comment),
         None => String::new(),
     };


### PR DESCRIPTION
Fixes #319 

- [ ] Requisition line comment is copied from the internal order line
- [ ] Requisition comment uses the same format as mSupply: `From request requisition [req #] ([internal order comment])`
- [ ] Requisition line window has the comments on the right, as per internal order
