### PR TITLE
327 central sync integration test

### DIFF
--- a/server/service/src/sync/test/integration/central/master_list.rs
+++ b/server/service/src/sync/test/integration/central/master_list.rs
@@ -1,0 +1,119 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+};
+use repository::{MasterListLineRow, MasterListNameJoinRow, MasterListRow};
+
+use serde_json::json;
+use util::uuid::uuid;
+
+pub(crate) struct MasterListTester;
+
+impl SyncRecordTester for MasterListTester {
+    fn test_step_data(&self, new_site_properties: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let master_list_row1 = MasterListRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            description: "".to_string(),
+        };
+        let master_list_json1 = json!({
+            "ID": master_list_row1.id,
+            "description":  master_list_row1.name,
+            "code": master_list_row1.code,
+        });
+
+        let master_list_name_join_row1 = MasterListNameJoinRow {
+            id: uuid(),
+            master_list_id: master_list_row1.id.clone(),
+            name_id: new_site_properties.name_id.clone(),
+        };
+        let master_list_name_join_json1 = json!({
+            "ID": master_list_name_join_row1.id,
+            "list_master_ID":  master_list_name_join_row1.master_list_id,
+            "name_ID": master_list_name_join_row1.name_id,
+        });
+
+        let master_list_row2 = MasterListRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            description: uuid(),
+        };
+        let master_list_json2 = json!({
+            "ID": master_list_row2.id,
+            "description":  master_list_row2.name,
+            "code": master_list_row2.code,
+            "note": master_list_row2.description
+        });
+
+        let master_list_name_join_row2 = MasterListNameJoinRow {
+            id: uuid(),
+            master_list_id: master_list_row2.id.clone(),
+            name_id: new_site_properties.name_id.clone(),
+        };
+        let master_list_name_join_json2 = json!({
+            "ID": master_list_name_join_row2.id,
+            "list_master_ID":  master_list_name_join_row2.master_list_id,
+            "name_ID": master_list_name_join_row2.name_id,
+        });
+
+        let item_id = uuid();
+        let master_list_line_row = MasterListLineRow {
+            id: uuid(),
+            item_id: item_id.clone(),
+            master_list_id: master_list_row1.id.clone(),
+        };
+        let master_list_line_json = json!({
+            "ID": master_list_line_row.id,
+            "item_master_ID": master_list_line_row.master_list_id,
+            "item_ID":  master_list_line_row.item_id,
+        });
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "list_master": [master_list_json1,master_list_json2],
+                "list_master_name_join": [master_list_name_join_json1,master_list_name_join_json2],
+                "list_master_line": [master_list_line_json],
+                "item": [{"ID": item_id, "type_of": "general"}]
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::MasterList(master_list_row1.clone()),
+                PullUpsertRecord::MasterList(master_list_row2),
+                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row1.clone()),
+                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row2),
+                PullUpsertRecord::MasterListLine(master_list_line_row.clone()),
+            ]),
+        });
+
+        // STEP 2 - deletes
+        result.push(TestStepData {
+            central_upsert: json!({}),
+            central_delete: json!({
+                "list_master_line": [master_list_line_row.id],
+                "list_master": [master_list_row1.id],
+                "list_master_name_join": [master_list_name_join_row1.id]
+            }),
+            integration_records: IntegrationRecords::from_deletes(vec![
+                PullDeleteRecord {
+                    id: master_list_row1.id,
+                    table: PullDeleteRecordTable::MasterList,
+                },
+                PullDeleteRecord {
+                    id: master_list_line_row.id,
+                    table: PullDeleteRecordTable::MasterListLine,
+                },
+                PullDeleteRecord {
+                    id: master_list_name_join_row1.id,
+                    table: PullDeleteRecordTable::MasterListNameJoin,
+                },
+            ]),
+        });
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/central/mod.rs
+++ b/server/service/src/sync/test/integration/central/mod.rs
@@ -1,0 +1,101 @@
+mod master_list;
+mod name_and_store_and_name_store_join;
+mod report;
+mod test;
+mod unit_and_item;
+
+use util::uuid::uuid;
+
+use super::{central_server_configurations::ConfigureCentralServer, SyncRecordTester};
+use crate::sync::test::{
+    check_records_against_database,
+    integration::{central_server_configurations::CreateSyncSiteResult, init_db, random_timeout},
+};
+
+fn small_uuid() -> String {
+    uuid().split("-").next().unwrap().to_string()
+}
+
+/// Updates central server with data specified from each step of tester
+/// Synchronises after each step and checks against step data
+///
+/// Do update for each step and re-initialise and check against the step data
+
+async fn test_central_sync_record(identifier: &str, tester: &dyn SyncRecordTester) {
+    // util::init_logger(util::LogLevel::Warn);
+    random_timeout().await;
+    // Without re-initialisation
+    println!("test_central_sync_record_{}_init", identifier);
+
+    let central_server_configurations = ConfigureCentralServer::from_env();
+    let CreateSyncSiteResult {
+        new_site_properties,
+        sync_settings,
+    } = central_server_configurations
+        .create_sync_site()
+        .await
+        .expect("Problem creating sync site");
+
+    let (connection, synchroniser) = init_db(&sync_settings, &identifier).await;
+
+    let steps_data = tester.test_step_data(&new_site_properties);
+
+    for (index, step_data) in steps_data.into_iter().enumerate() {
+        println!("test_central_sync_record_{}_step{}", identifier, index + 1);
+
+        // println!(
+        //     "upsert {}",
+        //     serde_json::to_string_pretty(&step_data.central_upsert).unwrap()
+        // );
+
+        central_server_configurations
+            .upsert_records(step_data.central_upsert)
+            .await
+            .expect("Problem inserting central data");
+
+        central_server_configurations
+            .delete_records(step_data.central_delete)
+            .await
+            .expect("Problem deleting central data");
+
+        synchroniser.sync().await.unwrap();
+        check_records_against_database(&connection, step_data.integration_records).await;
+    }
+
+    // With re-initialisation
+    let identifier = format!("with_reinitialisation_{}", identifier);
+    println!("test_central_sync_record_{}_init", identifier);
+
+    let central_server_configurations = ConfigureCentralServer::from_env();
+    let CreateSyncSiteResult {
+        new_site_properties,
+        sync_settings,
+    } = central_server_configurations
+        .create_sync_site()
+        .await
+        .expect("Problem creating sync site");
+
+    let steps_data = tester.test_step_data(&new_site_properties);
+    for (index, step_data) in steps_data.into_iter().enumerate() {
+        println!("test_central_sync_record_{}_step{}", identifier, index + 1);
+
+        // println!(
+        //     "upsert {}",
+        //     serde_json::to_string_pretty(&step_data.central_upsert).unwrap()
+        // );
+
+        central_server_configurations
+            .upsert_records(step_data.central_upsert)
+            .await
+            .expect("Problem inserting central data");
+
+        central_server_configurations
+            .delete_records(step_data.central_delete)
+            .await
+            .expect("Problem deleting central data");
+
+        let (connection, _) = init_db(&sync_settings, &identifier).await;
+        synchroniser.sync().await.unwrap();
+        check_records_against_database(&connection, step_data.integration_records).await;
+    }
+}

--- a/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
@@ -1,0 +1,187 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+};
+use chrono::NaiveDate;
+use repository::{NameRow, NameStoreJoinRow, NameType, StoreRow};
+
+use serde_json::json;
+use util::{inline_init, merge_json, uuid::uuid};
+
+use super::small_uuid;
+
+pub(crate) struct NameAndStoreAndNameStoreJoinTester;
+
+impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
+    fn test_step_data(&self, new_site_properties: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let name_row1 = NameRow {
+            id: uuid(),
+            name: uuid(),
+            code: small_uuid(),
+            r#type: NameType::Facility,
+            is_customer: true,
+            is_supplier: true,
+            supplying_store_id: None,
+            first_name: Some(uuid()),
+            last_name: Some(uuid()),
+            gender: None,
+            date_of_birth: Some(NaiveDate::from_ymd(1998, 07, 29)),
+            phone: Some(small_uuid()),
+            charge_code: Some(small_uuid()),
+            comment: Some(uuid()),
+            country: Some(small_uuid()),
+            address1: Some(uuid()),
+            address2: Some(uuid()),
+            email: Some(uuid()),
+            website: Some(uuid()),
+            is_manufacturer: true,
+            is_donor: true,
+            on_hold: true,
+            created_datetime: Some(NaiveDate::from_ymd(2022, 05, 22).and_hms(0, 0, 0)),
+        };
+        let name_json1 = json!({
+            "ID": name_row1.id,
+            "name":  name_row1.name,
+            "code": name_row1.code,
+            "type": "facility",
+            "customer": true,
+            "supplier": true,
+            "first": name_row1.first_name.as_ref().unwrap(),
+            "last": name_row1.last_name.as_ref().unwrap(),
+            "date_of_birth": "1998-07-29",
+            "phone": name_row1.phone.as_ref().unwrap(),
+            "charge code": name_row1.charge_code.as_ref().unwrap(),
+            "comment": name_row1.comment.as_ref().unwrap(),
+            "country": name_row1.country.as_ref().unwrap(),
+            "bill_address1": name_row1.address1.as_ref().unwrap(),
+            "bill_address2": name_row1.address2.as_ref().unwrap(),
+            "email":  name_row1.email.as_ref().unwrap(),
+            "url":  name_row1.website.as_ref().unwrap(),
+            "manufacturer": true,
+            "donor": true,
+            "hold": true,
+            "created_date": "2022-05-22"
+        });
+
+        let name_row2 = inline_init(|r: &mut NameRow| {
+            r.id = uuid();
+            r.r#type = NameType::Facility;
+            r.is_customer = true;
+            r.is_supplier = false;
+        });
+        let mut name_json2 = json!({
+            "ID": name_row2.id,
+            "type": "facility",
+            "customer": true,
+            "supplier": false,
+        });
+
+        let store_row = StoreRow {
+            id: uuid(),
+            name_id: name_row1.id.clone(),
+            code: small_uuid(),
+            site_id: new_site_properties.site_id as i32,
+        };
+        let store_json = json!({
+            "ID": store_row.id,
+            "code": store_row.code,
+            "name_ID": store_row.name_id,
+            "sync_id_remote_site": store_row.site_id,
+            "store_mode": "store"
+        });
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "name": [name_json1,name_json2.clone()],
+                "store": [store_json]
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::Name(name_row1),
+                PullUpsertRecord::Name(name_row2.clone()),
+                PullUpsertRecord::Store(store_row.clone()),
+            ]),
+        });
+        // STEP 2 name store joins need to be inserted after store (for them to be inserted in sync queue)
+        let mut name_store_join_row1 = NameStoreJoinRow {
+            id: uuid(),
+            name_id: name_row2.id.clone(),
+            store_id: new_site_properties.store_id.clone(),
+            name_is_customer: true,
+            name_is_supplier: false,
+        };
+        let name_store_join_json1 = json!({
+            "ID": name_store_join_row1.id,
+            "name_ID": name_store_join_row1.name_id,
+            "store_ID": name_store_join_row1.store_id
+
+        });
+
+        let mut name_store_join_row2 = NameStoreJoinRow {
+            id: uuid(),
+            name_id: name_row2.id.clone(),
+            store_id: store_row.id.clone(),
+            name_is_customer: true,
+            name_is_supplier: false,
+        };
+        let name_store_join_json2 = json!({
+            "ID": name_store_join_row2.id,
+            "name_ID": name_store_join_row2.name_id,
+            "store_ID": name_store_join_row2.store_id
+
+        });
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "name_store_join": [name_store_join_json1,name_store_join_json2 ],
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::NameStoreJoin(name_store_join_row1.clone()),
+                PullUpsertRecord::NameStoreJoin(name_store_join_row2.clone()),
+            ]),
+        });
+        // STEP 3 update name and make sure name_store_joins update
+        merge_json(
+            &mut name_json2,
+            &json!({
+                "customer": false,
+                "supplier": true,
+            }),
+        );
+
+        name_store_join_row1.name_is_customer = false;
+        name_store_join_row2.name_is_customer = false;
+
+        name_store_join_row1.name_is_supplier = true;
+        name_store_join_row2.name_is_supplier = true;
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "name": [name_json2],
+
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::NameStoreJoin(name_store_join_row1.clone()),
+                PullUpsertRecord::NameStoreJoin(name_store_join_row2),
+            ]),
+        });
+
+        // STEP 4 - deletes
+        // TODO should we check for name and store deletes ?
+        result.push(TestStepData {
+            central_upsert: json!({}),
+            central_delete: json!({ "name_store_join": [name_store_join_row1.id] }),
+            integration_records: IntegrationRecords::from_deletes(vec![PullDeleteRecord {
+                id: name_store_join_row1.id,
+                table: PullDeleteRecordTable::NameStoreJoin,
+            }]),
+        });
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/central/report.rs
+++ b/server/service/src/sync/test/integration/central/report.rs
@@ -1,0 +1,89 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+};
+use repository::{ReportContext, ReportRow, ReportType};
+use serde_json::json;
+use util::{inline_init, uuid::uuid};
+
+pub(crate) struct ReportTester;
+
+impl SyncRecordTester for ReportTester {
+    fn test_step_data(&self, _: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let report_row1 = ReportRow {
+            id: uuid(),
+            name: uuid(),
+            r#type: ReportType::OmSupply,
+            template: "".to_string(),
+            context: ReportContext::InboundShipment,
+            comment: Some(uuid()),
+        };
+        let report_json1 = json!({
+            "ID": report_row1.id,
+            "report_name":  report_row1.name,
+            "editor": "omsupply",
+            "context": "Supplier Invoice",
+            "Comment": report_row1.comment.as_ref().unwrap()
+        });
+
+        let report_row2 = inline_init(|r: &mut ReportRow| {
+            r.id = uuid();
+            r.context = ReportContext::OutboundShipment
+        });
+        let report_json2 = json!({
+            "ID": report_row2.id,
+            "editor": "omsupply",
+            "context": "Customer Invoice",
+        });
+
+        let report_row3 = inline_init(|r: &mut ReportRow| {
+            r.id = uuid();
+            r.context = ReportContext::Requisition
+        });
+        let report_json3 = json!({
+            "ID": report_row3.id,
+            "editor": "omsupply",
+            "context": "Requisition",
+        });
+
+        let report_row4 = inline_init(|r: &mut ReportRow| {
+            r.id = uuid();
+            r.context = ReportContext::Stocktake
+        });
+        let report_json4 = json!({
+            "ID": report_row4.id,
+            "editor": "omsupply",
+            "context": "Stock Take",
+        });
+
+        // TODO Resource ? There is not translations for it
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "report": [report_json1,report_json2,report_json3,report_json4],
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::Report(report_row1.clone()),
+                PullUpsertRecord::Report(report_row2),
+                PullUpsertRecord::Report(report_row3),
+                PullUpsertRecord::Report(report_row4),
+            ]),
+        });
+
+        // STEP 2 - deletes
+        result.push(TestStepData {
+            central_upsert: json!({}),
+            central_delete: json!({ "report": [report_row1.id] }),
+            integration_records: IntegrationRecords::from_deletes(vec![PullDeleteRecord {
+                id: report_row1.id,
+                table: PullDeleteRecordTable::Report,
+            }]),
+        });
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/central/test.rs
+++ b/server/service/src/sync/test/integration/central/test.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod tests {
+    use crate::sync::test::integration::central::{
+        master_list::MasterListTester,
+        name_and_store_and_name_store_join::NameAndStoreAndNameStoreJoinTester,
+        report::ReportTester, test_central_sync_record, unit_and_item::UnitAndItemTester,
+    };
+
+    #[actix_rt::test]
+    async fn integration_sync_central_unit_and_item() {
+        test_central_sync_record("unit_and_item", &UnitAndItemTester).await;
+    }
+
+    #[actix_rt::test]
+    async fn integration_sync_central_name_and_store_and_name_store_join() {
+        // util::init_logger(util::LogLevel::Warn);
+        test_central_sync_record(
+            "name_and_store_and_name_store_join",
+            &NameAndStoreAndNameStoreJoinTester,
+        )
+        .await;
+    }
+
+    #[actix_rt::test]
+    async fn integration_sync_central_master_list() {
+        // util::init_logger(util::LogLevel::Warn);
+        test_central_sync_record("master_list", &MasterListTester).await;
+    }
+
+    #[actix_rt::test]
+    async fn integration_sync_central_report() {
+        // util::init_logger(util::LogLevel::Warn);
+        test_central_sync_record("report", &ReportTester).await;
+    }
+}

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -96,7 +96,10 @@ impl SyncRecordTester for UnitAndItemTester {
         item_row3.legacy_record = serde_json::to_string(&item_json3).unwrap();
 
         result.push(TestStepData {
-            central_upsert:   json!({ "item": [item_json1,item_json2,item_json3], "unit": [unit_json1, unit_json2] }),
+            central_upsert: json!({
+                "item": [item_json1, item_json2, item_json3],
+                "unit": [unit_json1, unit_json2]
+            }),
             central_delete: json!({}),
             integration_records: IntegrationRecords::from_upserts(vec![
                 PullUpsertRecord::Unit(unit_row1.clone()),

--- a/server/service/src/sync/test/integration/central/unit_and_item.rs
+++ b/server/service/src/sync/test/integration/central/unit_and_item.rs
@@ -1,0 +1,133 @@
+use crate::sync::{
+    test::{
+        integration::{
+            central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+        },
+        test_data::item::test_pull_upsert_records,
+    },
+    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
+};
+use repository::{ItemRow, ItemRowType, UnitRow};
+
+use serde_json::json;
+use util::{merge_json, uuid::uuid};
+
+pub(crate) struct UnitAndItemTester;
+
+impl SyncRecordTester for UnitAndItemTester {
+    fn test_step_data(&self, _: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let unit_row1 = UnitRow {
+            id: uuid(),
+            name: uuid(),
+            description: None,
+            index: 1,
+        };
+        let unit_json1 = json!({
+            "ID": unit_row1.id,
+            "units":  unit_row1.name,
+            "comment": "",
+            "order_number": 1 as u32
+        });
+
+        let unit_row2 = UnitRow {
+            id: uuid(),
+            name: uuid(),
+            description: Some("test description".to_string()),
+            index: 2,
+        };
+        let unit_json2 = json!({
+            "ID": unit_row2.id,
+            "units":  unit_row2.name,
+            "comment": "test description",
+            "order_number": 2 as u32
+        });
+
+        let mut item_row1 = ItemRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            unit_id: None,
+            r#type: ItemRowType::NonStock,
+            legacy_record: "".to_string(),
+        };
+        let item_json1 = extend_base(json!({
+            "ID": item_row1.id,
+            "item_name": item_row1.name,
+            "code": item_row1.code,
+            "type_of": "non_stock",
+            "unit_ID": ""
+        }));
+        item_row1.legacy_record = serde_json::to_string(&item_json1).unwrap();
+
+        let mut item_row2 = ItemRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            unit_id: Some(unit_row1.id.clone()),
+            r#type: ItemRowType::Stock,
+            legacy_record: "".to_string(),
+        };
+        let item_json2 = extend_base(json!({
+            "ID": item_row2.id,
+            "item_name": item_row2.name,
+            "code": item_row2.code,
+            "type_of": "general",
+            "unit_ID": unit_row1.id,
+        }));
+        item_row2.legacy_record = serde_json::to_string(&item_json2).unwrap();
+
+        let mut item_row3 = ItemRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            unit_id: None,
+            r#type: ItemRowType::Service,
+            legacy_record: "".to_string(),
+        };
+        let item_json3 = extend_base(json!({
+            "ID": item_row3.id,
+            "item_name": item_row3.name,
+            "code": item_row3.code,
+            "type_of": "service",
+            "unit_ID": "",
+        }));
+        item_row3.legacy_record = serde_json::to_string(&item_json3).unwrap();
+
+        result.push(TestStepData {
+            central_upsert:   json!({ "item": [item_json1,item_json2,item_json3], "unit": [unit_json1, unit_json2] }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::Unit(unit_row1.clone()),
+                PullUpsertRecord::Unit(unit_row2),
+                PullUpsertRecord::Item(item_row1),
+                PullUpsertRecord::Item(item_row2.clone()),
+                PullUpsertRecord::Item(item_row3),
+            ]),
+        });
+        // STEP 2 - deletes
+        result.push(TestStepData {
+            central_upsert: json!({}),
+            central_delete: json!({ "item": [item_row2.id], "unit": [unit_row1.id] }),
+            integration_records: IntegrationRecords::from_deletes(vec![
+                PullDeleteRecord {
+                    id: unit_row1.id,
+                    table: PullDeleteRecordTable::Unit,
+                },
+                PullDeleteRecord {
+                    id: item_row2.id,
+                    table: PullDeleteRecordTable::Item,
+                },
+            ]),
+        });
+        result
+    }
+}
+
+fn extend_base(value: serde_json::Value) -> serde_json::Value {
+    let mut base =
+        serde_json::from_str(&test_pull_upsert_records()[0].sync_buffer_row.data).unwrap();
+    merge_json(&mut base, &value);
+    base
+}

--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use std::{io::Error, path::PathBuf};
+
+    use actix_web::web::Data;
+    use repository::{mock::MockDataInserts, test_db::setup_all, StorageConnectionManager};
+    use reqwest::StatusCode;
+    use serde_json::json;
+    use util::assert_matches;
+
+    use crate::{
+        app_data::{AppData, AppDataServiceTrait},
+        service_provider::ServiceProvider,
+        sync::{
+            api::{SyncApiError, SyncErrorV5},
+            central_data_synchroniser::CentralSyncError,
+            settings::SyncSettings,
+            synchroniser::Synchroniser,
+            test::integration::central_server_configurations::{
+                ConfigureCentralServer, CreateSyncSiteResult,
+            },
+        },
+    };
+
+    fn get_synchroniser_with_hardware_id(
+        connection_manager: &StorageConnectionManager,
+        settings: &SyncSettings,
+        hardware_id: &str,
+    ) -> Synchroniser {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        struct TestService1(String);
+        impl AppDataServiceTrait for TestService1 {
+            fn get_app_data_directory(&self) -> Result<PathBuf, Error> {
+                todo!()
+            }
+            fn get_app_data_file(&self) -> Result<PathBuf, Error> {
+                todo!()
+            }
+            fn load_from_file(&self) -> Result<AppData, Error> {
+                todo!()
+            }
+            fn get_hardware_id(&self) -> Result<String, Error> {
+                Ok(self.0.clone())
+            }
+            fn set_hardware_id(&self, _: String) -> Result<(), Error> {
+                todo!()
+            }
+        }
+        service_provider.app_data_service = Box::new(TestService1(hardware_id.to_string()));
+
+        Synchroniser::new(settings.clone(), Data::new(service_provider)).unwrap()
+    }
+    #[actix_rt::test]
+    async fn sync_integration_test_parsed_error() {
+        let CreateSyncSiteResult { sync_settings, .. } = ConfigureCentralServer::from_env()
+            .create_sync_site()
+            .await
+            .expect("Problem creating sync site");
+
+        let (_, _, connection_manager, _) = setup_all(
+            "sync_integration_test_parsed_error",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let synchroniser =
+            get_synchroniser_with_hardware_id(&connection_manager, &sync_settings, "id1");
+        synchroniser.sync().await.unwrap();
+
+        // Change hardware id
+        let synchroniser =
+            get_synchroniser_with_hardware_id(&connection_manager, &sync_settings, "id2");
+
+        let error = match synchroniser.sync().await {
+            Ok(_) => panic!("Should result in error"),
+            Err(e) => e,
+        };
+
+        assert_matches!(
+            error.downcast_ref::<CentralSyncError>(),
+            Some(CentralSyncError::PullError(SyncApiError::MappedError {
+                source: SyncErrorV5::ParsedError { .. },
+                status: StatusCode::UNAUTHORIZED,
+            }))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn sync_integration_not_parsed_error() {
+        let central_config = ConfigureCentralServer::from_env();
+
+        // Should result in an error in non standard format
+        let error = match central_config
+            .upsert_records(json!({
+                "this_one_does_not_exist": [{"should_error":  true}]
+            }))
+            .await
+        {
+            Ok(_) => panic!("Should result in error"),
+            Err(e) => e,
+        };
+
+        assert_matches!(
+            error.downcast_ref::<SyncApiError>(),
+            Some(SyncApiError::MappedError {
+                source: SyncErrorV5::FullText(_),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            })
+        );
+    }
+}

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -1,8 +1,58 @@
+mod central;
 mod central_server_configurations;
-mod invoice;
-mod location;
-mod number;
-mod remote_sync_integration_test;
-mod requisition;
-mod stock_line;
-mod stocktake;
+mod errors;
+mod remote;
+
+use std::time::Duration;
+
+use crate::{
+    service_provider::ServiceProvider,
+    sync::{
+        settings::SyncSettings,
+        synchroniser::Synchroniser,
+        translations::{IntegrationRecords, PullDeleteRecord},
+    },
+};
+use actix_web::web::Data;
+use rand::{thread_rng, Rng};
+use repository::{mock::MockDataInserts, test_db::setup_all, StorageConnection};
+
+use self::central_server_configurations::NewSiteProperties;
+
+async fn init_db(sync_settings: &SyncSettings, step: &str) -> (StorageConnection, Synchroniser) {
+    let (_, connection, connection_manager, _) = setup_all(
+        &format!("sync_integration_{}_tests", step),
+        MockDataInserts::none(),
+    )
+    .await;
+
+    let service_provider = Data::new(ServiceProvider::new(connection_manager.clone(), "app_data"));
+    let synchroniser = Synchroniser::new(sync_settings.clone(), service_provider).unwrap();
+
+    (connection, synchroniser)
+}
+
+struct TestStepData {
+    central_upsert: serde_json::Value,
+    central_delete: serde_json::Value,
+    integration_records: IntegrationRecords,
+}
+
+impl IntegrationRecords {
+    fn from_deletes(rows: Vec<PullDeleteRecord>) -> IntegrationRecords {
+        IntegrationRecords {
+            upserts: Vec::new(),
+            deletes: rows,
+        }
+    }
+}
+
+trait SyncRecordTester {
+    /// Get central data upsert and integration records
+    fn test_step_data(&self, new_site_properties: &NewSiteProperties) -> Vec<TestStepData>;
+}
+
+async fn random_timeout() {
+    let duration = Duration::from_millis(thread_rng().gen_range(10..1000));
+    tokio::time::sleep(duration).await;
+}

--- a/server/service/src/sync/test/test_data/item.rs
+++ b/server/service/src/sync/test/test_data/item.rs
@@ -1,6 +1,8 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullUpsertRecord, PullDeleteRecordTable},
+    translations::{
+        item::ordered_simple_json, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord,
+    },
 };
 use repository::{ItemRow, ItemRowType};
 
@@ -12,7 +14,7 @@ const ITEM_1: (&'static str, &'static str) = (
     "start_of_year_date": "0000-00-00",
     "manufacture_method": "",
     "default_pack_size": 1,
-    "dose_picture": "[object Picture]",
+    "dose_picture": "data:image/png;base64,",
     "atc_category": "",
     "medication_purpose": "",
     "instructions": "",
@@ -91,7 +93,7 @@ const ITEM_2: (&'static str, &'static str) = (
     "start_of_year_date": "0000-00-00",
     "manufacture_method": "",
     "default_pack_size": 1,
-    "dose_picture": "[object Picture]",
+    "dose_picture": "data:image/png;base64,",
     "atc_category": "",
     "medication_purpose": "",
     "instructions": "",
@@ -166,26 +168,26 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         TestSyncPullRecord::new_pull_upsert(
             LegacyTableName::ITEM,
-            ITEM_1,
+            (ITEM_1.0, &ordered_simple_json(ITEM_1.1).unwrap()),
             PullUpsertRecord::Item(ItemRow {
                 id: ITEM_1.0.to_owned(),
                 name: "Non stock items".to_owned(),
                 code: "NSI".to_owned(),
                 unit_id: None,
                 r#type: ItemRowType::NonStock,
-                legacy_record: ITEM_1.1.to_owned(),
+                legacy_record: ordered_simple_json(ITEM_1.1).unwrap(),
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
             LegacyTableName::ITEM,
-            ITEM_2,
+            (ITEM_2.0, &ordered_simple_json(ITEM_2.1).unwrap()),
             PullUpsertRecord::Item(ItemRow {
                 id: ITEM_2.0.to_owned(),
                 name: "Non stock items 2".to_owned(),
                 code: "NSI".to_owned(),
                 unit_id: Some("A02C91EB6C77400BA783C4CD7C565F29".to_owned()),
                 r#type: ItemRowType::Stock,
-                legacy_record: ITEM_2.1.to_owned(),
+                legacy_record: ordered_simple_json(ITEM_2.1).unwrap(),
             }),
         ),
     ]

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -35,6 +35,11 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
     sync_record.table_name == LegacyTableName::ITEM
 }
 
+pub(crate) fn ordered_simple_json(text: &str) -> Result<String, serde_json::Error> {
+    let json: serde_json::Value = serde_json::from_str(&text)?;
+    serde_json::to_string(&json)
+}
+
 pub(crate) struct ItemTranslation {}
 impl SyncTranslation for ItemTranslation {
     fn try_translate_pull_upsert(
@@ -53,7 +58,7 @@ impl SyncTranslation for ItemTranslation {
             code: data.code,
             unit_id: None,
             r#type: to_item_type(data.type_of),
-            legacy_record: sync_record.data.clone(),
+            legacy_record: ordered_simple_json(&sync_record.data)?,
         };
 
         if data.unit_ID != "" {

--- a/server/util/src/json.rs
+++ b/server/util/src/json.rs
@@ -1,0 +1,13 @@
+// https://github.com/serde-rs/json/issues/377#issuecomment-341490464
+pub fn merge_json(a: &mut serde_json::Value, b: &serde_json::Value) {
+    match (a, b) {
+        (&mut serde_json::Value::Object(ref mut a), &serde_json::Value::Object(ref b)) => {
+            for (k, v) in b {
+                merge_json(a.entry(k.clone()).or_insert(serde_json::Value::Null), v);
+            }
+        }
+        (a, b) => {
+            *a = b.clone();
+        }
+    }
+}

--- a/server/util/src/lib.rs
+++ b/server/util/src/lib.rs
@@ -14,3 +14,9 @@ pub use number_operations::*;
 
 mod date_operations;
 pub use date_operations::*;
+
+mod test_helpers;
+pub use test_helpers::*;
+
+mod json;
+pub use json::*;


### PR DESCRIPTION
closes: #327 

Branch wouldn't compile. Full changes and branch to use locally when reviewing is form this [PR](https://github.com/openmsupply/open-msupply/pull/335), which also has a [README.md](https://github.com/openmsupply/open-msupply/blob/a83bdbade3259bd5122e846b1e7f9ea6100f8c8a/server/service/src/sync/test/integration/README.MD)

Using `SyncRecordTester` which relies on existing mechanism of checking `IntegrationRecords` deletes and upserts against database
