### PR TITLE
333 documenation for sync integration tests

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4830,6 +4830,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "env_logger 0.8.4",
+ "serde_json",
  "sha2",
  "uuid",
 ]

--- a/server/README.md
+++ b/server/README.md
@@ -189,11 +189,7 @@ cargo test --features postgres
 
 - To run sync integration test
 
-Uncomment test attribute, and read description in method comment
-
-https://github.com/openmsupply/open-msupply/blob/e6dc29f1ace2fd22abc5e9a17e368a9d871a6f45/server/server/src/sync/integration_tests/remote_sync_integration_test.rs#L130-L131
-
-See test_remote_syncing in remote_sync_integration_test
+See [Sync Integration Tests](/service/sync/test/integration/README.md)
 
 ## Building docs
 

--- a/server/repository/src/db_diesel/invoice_line_row.rs
+++ b/server/repository/src/db_diesel/invoice_line_row.rs
@@ -54,6 +54,7 @@ impl Default for InvoiceLineRowType {
 }
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
+#[changeset_options(treat_none_as_null = "true")]
 #[table_name = "invoice_line"]
 pub struct InvoiceLineRow {
     pub id: String,

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -84,9 +84,15 @@ impl<'a> NumberRowRepository<'a> {
 
     #[cfg(not(feature = "postgres"))]
     pub fn upsert_one(&self, number_row: &NumberRow) -> Result<(), RepositoryError> {
-        diesel::replace_into(number_dsl::number)
-            .values(number_row)
-            .execute(&self.connection.connection)?;
+        let final_query = diesel::replace_into(number_dsl::number).values(number_row);
+
+        // // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&final_query).to_string()
+        // );
+
+        final_query.execute(&self.connection.connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -49,6 +49,19 @@ pub struct ReportRow {
     pub comment: Option<String>,
 }
 
+impl Default for ReportRow {
+    fn default() -> Self {
+        Self {
+            id: Default::default(),
+            name: Default::default(),
+            r#type: ReportType::OmSupply,
+            template: Default::default(),
+            context: ReportContext::InboundShipment,
+            comment: Default::default(),
+        }
+    }
+}
+
 pub struct ReportRowRepository<'a> {
     connection: &'a StorageConnection,
 }

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -54,6 +54,7 @@ pub enum RequisitionRowStatus {
 }
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[changeset_options(treat_none_as_null = "true")]
 #[table_name = "requisition"]
 pub struct RequisitionRow {
     pub id: String,

--- a/server/repository/src/db_diesel/stock_line_row.rs
+++ b/server/repository/src/db_diesel/stock_line_row.rs
@@ -32,6 +32,7 @@ joinable!(stock_line -> store (store_id));
 joinable!(stock_line -> location (location_id));
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
+#[changeset_options(treat_none_as_null = "true")]
 #[table_name = "stock_line"]
 pub struct StockLineRow {
     pub id: String,

--- a/server/repository/src/db_diesel/stocktake_line_row.rs
+++ b/server/repository/src/db_diesel/stocktake_line_row.rs
@@ -36,6 +36,7 @@ joinable!(stocktake_line -> stocktake (stocktake_id));
 joinable!(stocktake_line -> stock_line (stock_line_id));
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
+#[changeset_options(treat_none_as_null = "true")]
 #[table_name = "stocktake_line"]
 pub struct StocktakeLineRow {
     pub id: String,

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -144,7 +144,7 @@ mod test {
         test_db::setup_all_with_data,
         InvoiceRow, InvoiceRowRepository, InvoiceRowType, NameRow, NameStoreJoinRow,
     };
-    use util::{inline_edit, inline_init};
+    use util::{assert_matches, inline_edit, inline_init};
 
     use crate::{
         invoice::outbound_shipment::UpdateOutboundShipment, service_provider::ServiceProvider,
@@ -288,7 +288,7 @@ mod test {
 
         let result = service.update_outbound_shipment(&context, "store_a", get_update());
 
-        assert!(matches!(result, Ok(_)), "Not Ok(_) {:#?}", result);
+        assert_matches!(result, Ok(_));
 
         let updated_record = InvoiceRowRepository::new(&connection)
             .find_one_by_id(&invoice().id)

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -352,6 +352,7 @@ mod test {
         mock::MockDataInserts, test_db::setup_all, EqualFilter, UserFilter, UserPermissionFilter,
         UserPermissionRepository, UserRepository,
     };
+    use util::assert_matches;
 
     use crate::{
         apis::login_v4::LoginResponseV4,
@@ -443,11 +444,7 @@ mod test {
             )
             .await;
 
-            assert!(
-                matches!(result, Err(LoginError::LoginFailure)),
-                "expected login failure, got {:#?}",
-                result
-            );
+            assert_matches!(result, Err(LoginError::LoginFailure));
         }
         // Old password should still work in offline mode or if central return an error
         {
@@ -471,11 +468,7 @@ mod test {
             )
             .await;
 
-            assert!(
-                matches!(result, Ok(_)),
-                "expected Ok token pair, got {:#?}",
-                result
-            );
+            assert_matches!(result, Ok(_));
         }
         // If server password has changed, and trying to login with old password, return LoginError::LoginFailure
         {
@@ -499,11 +492,7 @@ mod test {
             )
             .await;
 
-            assert!(
-                matches!(result, Err(LoginError::LoginFailure)),
-                "expected login failure, got {:#?}",
-                result
-            );
+            assert_matches!(result, Err(LoginError::LoginFailure));
         }
         // If central server is not accessible after trying to login with old password, make sure old password does not work
         // Issue #1101 in remote-server: Extra login protection when user password has changed

--- a/server/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert.rs
@@ -144,7 +144,7 @@ mod test {
         test_db::{setup_all, setup_all_with_data},
         RequisitionLineRowRepository,
     };
-    use util::{inline_edit, inline_init};
+    use util::{assert_matches, inline_edit, inline_init};
 
     use crate::{
         requisition_line::request_requisition_line::{
@@ -320,7 +320,7 @@ mod test {
             }),
         );
 
-        assert!(matches!(result, Ok(_)), "{:#?}", result);
+        assert_matches!(result, Ok(_));
 
         // TODO test suggested = 0 (where MOS is above MIN_MOS)
     }

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -35,7 +35,8 @@ Only data that needs to be present on central server site is a new sync site:
 * Change user permissions to allow `Add/edit sync sites`
 * In preferences
   * Register
-  * Turn on both checkboxes in Syncrhonisation (under General)
+  * Turn on both checkboxes in Synchronisation (under General)
+`
   * Under server check `Start web server ..`, change port from 0 and `Start Web Server`
 * In Synchronisation window add site and add store to that site
 

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -60,7 +60,8 @@ We have the ability to update and delete central data records directly on the se
 
 Central and remote tests use SyncRecordTester implementations to do integration tests.
 
-Test sync site is created for each test (using the same `upsert` cental data endpoint above), this is where NEW_SITE_PASSWORD env var is used. See `central_server_configurations.rs` comment for site creation info
+A test sync site is created for each test (using the same `upsert` cental data endpoint above), this is where NEW_SITE_PASSWORD env var is used.
+See `central_server_configurations.rs` comment for site creation info
 
 ## Central
 

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -92,3 +92,8 @@ For each step:
 * As per normal tests, you should be testing both databases
 * When tests fail, you can uncomment `util::init_logger(util::LogLevel::Warn);`, in `test_remote_sync_record` and `test_central_sync_record` methods;
 * Sometimes central server seems to get overloaded and returns 'connection closed before message completed' or 'Site record locked preventing authentication update' for that reason 'with_retry' was added
+
+Full test including integration can be run with:
+```bash
+SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test  --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test --features integration_test,postgres 
+```

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -1,6 +1,3 @@
-
-TODO link form main
-
 # Sync Integration Tests
 
 # How to run

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -16,7 +16,7 @@ Either with cli or rust analyzer settings:
 
 ## 2 `env vars` for sync credentials
 
-The following enviromental variables shoudl be provided for sync integration test:
+The following environment variables should be provided for sync integration test:
 
 SYNC_SITE_PASSWORD
 SYNC_SITE_NAME

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -1,0 +1,97 @@
+
+TODO link form main
+
+# Sync Integration Tests
+
+# How to run
+
+1. Requires 'integration_test' feature
+2. Requires env vars to be present (for central server credentials)
+3. Running central server
+4. Run tests
+
+## 1 `integration_test` feature
+
+Either with cli or rust analyzer settings:
+* in vscode, `cmd+,`
+* top right `Open Settings (JSON)`
+* add `"rust-analyzer.cargo.features": ["integration_test"]` (might need to restart vscode)
+
+## 2 `env vars` for sync credentials
+
+The following enviromental variables shoudl be provided for sync integration test:
+
+SYNC_SITE_PASSWORD
+SYNC_SITE_NAME
+SYNC_URL
+NEW_SITE_PASSWORD
+
+As `1`, can provide via cli or rust analyzer:
+`"rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass", "NEW_SITE_PASSWORD": "pass"}`
+
+## 3 `central server`
+
+Use branch `11087-Sync-v5-integration-test-endpoint` (TODO UPDATE)
+
+Only data that needs to be present on central server site is a new sync site:
+* Create new data files
+* Change user permissions to allow `Add/edit sync sites`
+* In preferences
+  * Register
+  * Turn on both checkboxes in Syncrhonisation (under General)
+  * Under server check `Start web server ..`, change port from 0 and `Start Web Server`
+* In Synchronisation window add site and add store to that site
+
+`IMPORTANT` make sure to run `syncV5API_test_enable` method (and if you restart the data file have to re-run this method)
+
+## 4 `run tests` 
+
+Via cli: `SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test integration_sync  --features integration_test`
+
+If you've set configurations in rust analyzer, can use inlay hint play and debug buttons in:
+* integration/remote/test
+* integration/central/test
+
+# How do they work 
+
+There is a common `SyncRecordTester` trait with `test_step_data` method, which is a vector of TestData, one array element for each step. `TestData` is composed of upserts and deletes of central data and IntegrationRecords. 
+
+We have the ability to update and delete central data records directly on the server (for test purposes, see syncV5API_test_upsert/delete in mSupply). Two endpoints are used for this `sync/v5/test/upsert` and `sync/v5/test/delete`
+
+Central and remote tests use SyncRecordTester implementations to do integration tests.
+
+Test sync site is created for each test (using the same `upsert` cental data endpoint above), this is where NEW_SITE_PASSWORD env var is used
+
+## Central
+
+`First without re-initialisation`
+
+For each step:
+* Upsert central data specified in TestData
+* Delete central data specified in TestData
+* Sync
+* Check IntegrationRecords in TestData against database
+
+`Then with re-initialisation`
+For each step:
+* Upsert central data specified in TestData
+* Delete central data specified in TestData
+* Fully re-sync
+* Check IntegrationRecords in TestData against database
+
+## Remote
+
+For each step:
+* Upsert central data specified in TestData
+* Delete central data specified in TestData
+* Sync
+* Upsert/Delete (on remote server) ItegrationRecords in TestData
+* Sync
+* Completely Re Sync
+* Check IntegratonRecords in TestData against database
+
+# Extra info
+
+* As per normal tests, you should be testing both databases
+* When tests fail, you can uncomment `util::init_logger(util::LogLevel::Warn);`, in `test_remote_sync_record` and `test_central_sync_record` methods;
+* Sometimes central server seems to get overloaded and returns 'connection closed before message completed' or 'Site record locked preventing authentication update' for that reason 'with_retry' was added

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -52,7 +52,9 @@ If you've set configurations in rust analyzer, can use inlay hint play and debug
 
 # How do they work 
 
-There is a common `SyncRecordTester` trait with `test_step_data` method, which is a vector of TestData, one array element for each step. `TestData` is composed of upserts and deletes of central data and IntegrationRecords. 
+There is a common `SyncRecordTester` trait with a `test_step_data` method returning a vector of TestData.
+Each TestData struct contains the test data required for the various testing steps.
+`TestData` is composed of upserts and deletes of central data and IntegrationRecords. 
 
 We have the ability to update and delete central data records directly on the server (for test purposes, see syncV5API_test_upsert/delete in mSupply). Two endpoints are used for this `sync/v5/test/upsert` and `sync/v5/test/delete`
 

--- a/server/service/src/sync/test/integration/README.MD
+++ b/server/service/src/sync/test/integration/README.MD
@@ -57,7 +57,7 @@ We have the ability to update and delete central data records directly on the se
 
 Central and remote tests use SyncRecordTester implementations to do integration tests.
 
-Test sync site is created for each test (using the same `upsert` cental data endpoint above), this is where NEW_SITE_PASSWORD env var is used
+Test sync site is created for each test (using the same `upsert` cental data endpoint above), this is where NEW_SITE_PASSWORD env var is used. See `central_server_configurations.rs` comment for site creation info
 
 ## Central
 

--- a/server/service/src/sync/test/integration/central/test.rs
+++ b/server/service/src/sync/test/integration/central/test.rs
@@ -13,7 +13,6 @@ mod tests {
 
     #[actix_rt::test]
     async fn integration_sync_central_name_and_store_and_name_store_join() {
-        // util::init_logger(util::LogLevel::Warn);
         test_central_sync_record(
             "name_and_store_and_name_store_join",
             &NameAndStoreAndNameStoreJoinTester,
@@ -23,13 +22,11 @@ mod tests {
 
     #[actix_rt::test]
     async fn integration_sync_central_master_list() {
-        // util::init_logger(util::LogLevel::Warn);
         test_central_sync_record("master_list", &MasterListTester).await;
     }
 
     #[actix_rt::test]
     async fn integration_sync_central_report() {
-        // util::init_logger(util::LogLevel::Warn);
         test_central_sync_record("report", &ReportTester).await;
     }
 }

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -11,6 +11,8 @@ use crate::sync::{
     SyncCredentials,
 };
 
+use super::with_retry;
+
 impl SyncApiV5 {
     pub(crate) async fn upsert_central_records(
         &self,
@@ -43,10 +45,6 @@ pub(crate) struct CreateSyncSiteResult {
 }
 
 impl ConfigureCentralServer {
-    // SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test sync_integration_test --features integration_test
-    // OR in VSCODE settings if using rust analyzer:
-    // "rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass", "NEW_SITE_PASSWORD": "pass"}
-    // "rust-analyzer.cargo.features": ["integration_test"]
     pub(crate) fn from_env() -> ConfigureCentralServer {
         let password =
             env::var("SYNC_SITE_PASSWORD").expect("SYNC_SITE_PASSWORD env variable missing");
@@ -71,32 +69,15 @@ impl ConfigureCentralServer {
     }
 
     pub(crate) async fn upsert_records(&self, records: serde_json::Value) -> anyhow::Result<()> {
-        Ok(self.api.upsert_central_records(&records).await?)
+        Ok(with_retry(|| self.api.upsert_central_records(&records)).await?)
     }
 
     pub(crate) async fn delete_records(&self, records: serde_json::Value) -> anyhow::Result<()> {
-        Ok(self.api.delete_central_records(&records).await?)
+        Ok(with_retry(|| self.api.delete_central_records(&records)).await?)
     }
 
     pub(crate) async fn create_sync_site(&self) -> anyhow::Result<CreateSyncSiteResult> {
-        self.create_sync_site_with_extra_data(|_| json!({})).await
-    }
-
-    pub(crate) async fn create_sync_site_with_extra_data<F>(
-        &self,
-        // Before site is inserted and linked to store
-        pre_site_creation_data: F,
-    ) -> anyhow::Result<CreateSyncSiteResult>
-    where
-        F: Fn(&NewSiteProperties) -> serde_json::Value,
-    {
         let new_site_properties = NewSiteProperties::new(&self.new_site_password);
-        self.api
-            .upsert_central_records(&new_site_properties.preliminary_data())
-            .await?;
-        self.api
-            .upsert_central_records(&pre_site_creation_data(&new_site_properties))
-            .await?;
 
         self.api
             .upsert_central_records(&new_site_properties.site_data())
@@ -119,7 +100,6 @@ impl ConfigureCentralServer {
 pub(crate) struct NewSiteProperties {
     pub(crate) store_id: String,
     pub(crate) name_id: String,
-    pref_id: String,
     pub(crate) site_uuid: String,
     pub(crate) site_id: u16,
     password_sha256: String,
@@ -130,7 +110,6 @@ impl NewSiteProperties {
         NewSiteProperties {
             store_id: uuid(),
             name_id: uuid(),
-            pref_id: uuid(),
             // TODO max that can be used ?
             site_id: thread_rng().gen::<u16>(),
             site_uuid: uuid(),
@@ -154,9 +133,7 @@ impl NewSiteProperties {
     // $file:=File("/Users/Drei/Documents/repos/work/msupply/out.txt")
     // $file.create()
     // $file.setText($content; Document with CR)
-
-    // Data without site
-    fn preliminary_data(&self) -> serde_json::Value {
+    fn site_data(&self) -> serde_json::Value {
         json!(
         {
             "name": [
@@ -165,81 +142,6 @@ impl NewSiteProperties {
                     "name": self.name_id
                 }
             ],
-            "store": [
-                {
-                    "ID":  self.store_id,
-                    "name":  self.store_id,
-                    "code":  self.store_id,
-                    "name_ID":  self.name_id,
-                    "sync_id_remote_site": 0,
-                    "store_mode": "store"
-                }
-            ],
-            "pref": [
-                {
-                    "item": "store_preferences",
-                    "user_ID": "",
-                    "ID": self.pref_id,
-                    "network_ID": "",
-                    "store_ID":  self.store_id,
-                    "data": {
-                        "sort_batches_by_VVM_not_expiry": false,
-                        "new_patients_visible_in_this_store_only": true,
-                        "new_names_visible_in_this_store_only": true,
-                        "can_enter_total_distribution_quantities": false,
-                        "round_up_distribute_quantities": false,
-                        "can_pack_items_into_multiple_boxes": false,
-                        "can_issue_in_foreign_currency": false,
-                        "edit_sell_price_on_customer_invoice_lines": false,
-                        "purchase_order_must_be_authorised": false,
-                        "finalise_customer_invoices_automatically": false,
-                        "customer_invoices_must_be_authorised": false,
-                        "customer_invoice_authorisation_needed_only_if_over_budget": false,
-                        "confirm_customer_invoices_automatically": false,
-                        "supplier_invoices_must_be_authorised": false,
-                        "confirm_supplier_invoices_automatically": false,
-                        "goods_received_lines_must_be_authorised": false,
-                        "must_enter_locations_on_goods_received": false,
-                        "can_specify_manufacturer": false,
-                        "show_item_unit_column_while_issuing": false,
-                        "log_editing_transacts": false,
-                        "default_item_packsize_to_one": true,
-                        "shouldAuthoriseResponseRequisition": false,
-                        "includeRequisitionsInSuppliersRemoteAuthorisationProcesses": false,
-                        "canLinkRequistionToSupplierInvoice": false,
-                        "responseRequisitionAutoFillSupplyQuantity": false,
-                        "useExtraFieldsForRequisitions": false,
-                        "CommentFieldToBeShownOnSupplierInvoiceLines": false,
-                        "UseEDDPlaceholderLinesOnSupplierInvoice": false,
-                        "consolidateBatches": false,
-                        "editPrescribedQuantityOnPrescription": false,
-                        "chooseDiagnosisOnPrescription": false,
-                        "useConsumptionAndStockFromCustomersForInternalOrders": false,
-                        "monthlyConsumptionEnforceLookBackPeriod": false,
-                        "usesVaccineModule": false,
-                        "usesDashboardModule": false,
-                        "usesCashRegisterModule": false,
-                        "usesPaymentModule": false,
-                        "usesPatientTypes": false,
-                        "usesHideSnapshotColumn": false,
-                        "good_receipt_finalise_next_action": "supplier_invoice_on_hold",
-                        "stock_transfer_supplier_invoice_is_on_hold": true,
-                        "monthlyConsumptionLookBackPeriod": "0",
-                        "monthsLeadTime": "0",
-                        "usesDispensaryModule": false,
-                        "monthsOverstock": 6 as u32,
-                        "monthsUnderstock": 3 as u32,
-                        "monthsItemsExpire": 3 as u32,
-                    }
-                }
-            ]
-        })
-    }
-
-    // Data with site (relies on preliminary data already inserted)
-    fn site_data(&self) -> serde_json::Value {
-        json!(
-        {
             "site": [
                 {
                     "ID":  self.site_uuid,

--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -13,7 +13,6 @@ mod tests {
         service_provider::ServiceProvider,
         sync::{
             api::{SyncApiError, SyncErrorV5},
-            central_data_synchroniser::CentralSyncError,
             settings::SyncSettings,
             synchroniser::Synchroniser,
             test::integration::central_server_configurations::{
@@ -51,7 +50,7 @@ mod tests {
         Synchroniser::new(settings.clone(), Data::new(service_provider)).unwrap()
     }
     #[actix_rt::test]
-    async fn sync_integration_test_parsed_error() {
+    async fn integration_sync_parsed_error() {
         let CreateSyncSiteResult { sync_settings, .. } = ConfigureCentralServer::from_env()
             .create_sync_site()
             .await
@@ -76,17 +75,19 @@ mod tests {
             Err(e) => e,
         };
 
+        println!("{}", error);
+
         assert_matches!(
-            error.downcast_ref::<CentralSyncError>(),
-            Some(CentralSyncError::PullError(SyncApiError::MappedError {
+            error.downcast_ref::<SyncApiError>(),
+            Some(SyncApiError::MappedError {
                 source: SyncErrorV5::ParsedError { .. },
                 status: StatusCode::UNAUTHORIZED,
-            }))
+            })
         );
     }
 
     #[actix_rt::test]
-    async fn sync_integration_not_parsed_error() {
+    async fn integration_sync_not_parsed_error() {
         let central_config = ConfigureCentralServer::from_env();
 
         // Should result in an error in non standard format

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -53,7 +53,7 @@ trait SyncRecordTester {
 // Sometime central server returns unexpected errors
 // this seems to happen when it's `overloaded` (when multiple requests are fired up at once)
 // ingore these errors in integration tests
-const NUMBER_OF_RETRIES: u32 = 3;
+const NUMBER_OF_RETRIES: u32 = 5;
 async fn with_retry<T, E, F, Fut>(f: F) -> Result<T, E>
 where
     F: Fn() -> Fut,

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -71,6 +71,7 @@ where
 
         if error_string.contains("Site record locked preventing authentication update")
             || error_string.contains("connection closed before message completed")
+            || error_string.contains("os error 54")
         {
             retries += 1;
 

--- a/server/service/src/sync/test/integration/remote/mod.rs
+++ b/server/service/src/sync/test/integration/remote/mod.rs
@@ -10,7 +10,7 @@ use crate::sync::test::{
     check_records_against_database,
     integration::{
         central_server_configurations::{ConfigureCentralServer, CreateSyncSiteResult},
-        init_db, random_timeout,
+        init_db,
     },
 };
 
@@ -23,7 +23,6 @@ use super::SyncRecordTester;
 /// Check that pulled data matches previously upserted data
 async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester) {
     // util::init_logger(util::LogLevel::Info);
-    random_timeout().await;
     println!("test_remote_sync_record_{}_init", identifier);
 
     let central_server_configurations = ConfigureCentralServer::from_env();
@@ -42,8 +41,8 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
     let mut previous_synchroniser = synchroniser;
 
     for (index, step_data) in steps_data.into_iter().enumerate() {
-        let identifier = format!("{}_step_{}", identifier, index + 1);
-        println!("test_remote_sync_record_{}", identifier);
+        let inner_identifier = format!("{}_step_{}", identifier, index + 1);
+        println!("test_remote_sync_record_{}", inner_identifier);
 
         central_server_configurations
             .upsert_records(step_data.central_upsert)
@@ -65,7 +64,7 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
         // Push integrated changes
         previous_synchroniser.sync().await.unwrap();
         // Re initialise
-        let (connection, synchroniser) = init_db(&sync_settings, &identifier).await;
+        let (connection, synchroniser) = init_db(&sync_settings, &inner_identifier).await;
         previous_connection = connection;
         previous_synchroniser = synchroniser;
         previous_synchroniser.sync().await.unwrap();

--- a/server/service/src/sync/test/integration/remote/test.rs
+++ b/server/service/src/sync/test/integration/remote/test.rs
@@ -1,12 +1,3 @@
-// To run this test, you'll need to run central server with a data file with at least one sync site, credentials for which need to be
-// passed through with enviromental variable (TODO specify which branch)
-
-// SYNC_SITE_PASSWORD="pass" SYNC_SITE_ID="2" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" NEW_SITE_PASSWORD="pass" cargo test sync_integration_test  --features integration_test
-
-// OR in VSCODE settings if using rust analyzer (and Run Tests|Debug actions as inlay hints):
-// "rust-analyzer.runnableEnv": { "SYNC_URL": "http://localhost:2048", "SYNC_SITE_NAME": "demo","SYNC_SITE_PASSWORD": "pass", "NEW_SITE_PASSWORD": "pass"}
-// "rust-analyzer.cargo.features": ["integration_test"]
-
 #[cfg(test)]
 mod tests {
     use crate::sync::test::integration::remote::{

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -2,25 +2,34 @@ use crate::sync::{
     remote_data_synchroniser::translate_changelogs_to_push_records,
     synchroniser::integrate_and_translate_sync_buffer,
     test::{
-        check_records_against_database, extract_sync_buffer_rows,
-        test_data::{get_all_pull_upsert_test_records, get_all_push_test_records},
+        check_test_records_against_database, extract_sync_buffer_rows,
+        test_data::get_all_push_test_records,
     },
     translations::table_name_to_central,
 };
 use repository::{mock::MockDataInserts, test_db, SyncBufferRow, SyncBufferRowRepository};
-use util::{init_logger, LogLevel};
 
-use super::{insert_all_extra_data, test_data::get_all_pull_delete_test_records};
+use super::{
+    insert_all_extra_data,
+    test_data::{
+        get_all_pull_delete_central_test_records, get_all_pull_delete_remote_test_records,
+        get_all_pull_upsert_central_test_records, get_all_pull_upsert_remote_test_records,
+    },
+};
 
 #[actix_rt::test]
 async fn test_sync_pull_and_push() {
-    init_logger(LogLevel::Warn);
+    // util::init_logger(util::LogLevel::Warn);
 
     let (_, connection, _, _) =
         test_db::setup_all("test_sync_pull_and_push", MockDataInserts::all()).await;
 
     // Test Pull Upsert
-    let test_records = get_all_pull_upsert_test_records();
+    let test_records = vec![
+        get_all_pull_upsert_central_test_records(),
+        get_all_pull_upsert_remote_test_records(),
+    ]
+    .concat();
     insert_all_extra_data(&test_records, &connection).await;
     let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
@@ -30,30 +39,33 @@ async fn test_sync_pull_and_push() {
 
     integrate_and_translate_sync_buffer(&connection).unwrap();
 
-    check_records_against_database(&connection, test_records).await;
+    check_test_records_against_database(&connection, test_records).await;
 
     // Test Push
     let test_records = get_all_push_test_records();
-    for record in test_records {
-        let expected_row_id = record.change_log.row_id.to_string();
-        let expected_table_name = table_name_to_central(&record.change_log.table_name);
+    for test_record in test_records {
+        let expected_row_id = test_record.change_log.row_id.to_string();
+        let expected_table_name = table_name_to_central(&test_record.change_log.table_name);
         let mut result =
-            translate_changelogs_to_push_records(&connection, vec![record.change_log.clone()])
+            translate_changelogs_to_push_records(&connection, vec![test_record.change_log.clone()])
                 .unwrap();
         // we currently only have one entry in the data_list
         let result = result
             .pop()
-            .expect(&format!("Could not translate {:#?}", record));
-        // tests only do upsert right now, so there must be Some data:
-        let data = result.data.unwrap();
+            .expect(&format!("Could not translate {:#?}", test_record));
+        let record = result.record;
 
-        assert_eq!(result.record_id, expected_row_id);
-        assert_eq!(result.record_type, expected_table_name);
-        assert_eq!(data, record.push_data);
+        assert_eq!(record.record_id, expected_row_id);
+        assert_eq!(record.table_name, expected_table_name);
+        assert_eq!(record.data, test_record.push_data);
     }
 
     // Test Pull Delete
-    let test_records = get_all_pull_delete_test_records();
+    let test_records = vec![
+        get_all_pull_delete_central_test_records(),
+        get_all_pull_delete_remote_test_records(),
+    ]
+    .concat();
     insert_all_extra_data(&test_records, &connection).await;
     let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
@@ -63,5 +75,5 @@ async fn test_sync_pull_and_push() {
 
     integrate_and_translate_sync_buffer(&connection).unwrap();
 
-    check_records_against_database(&connection, test_records).await;
+    check_test_records_against_database(&connection, test_records).await;
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -20,32 +20,37 @@ pub(crate) mod stocktake_line;
 pub(crate) mod store;
 pub(crate) mod unit;
 
-pub(crate) fn get_all_pull_upsert_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncPullRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut item::test_pull_upsert_records());
-    test_records.append(&mut location::test_pull_upsert_records());
     test_records.append(&mut master_list_line::test_pull_upsert_records());
     test_records.append(&mut master_list_name_join::test_pull_upsert_records());
     test_records.append(&mut master_list::test_pull_upsert_records());
-    test_records.append(&mut name_store_join::test_pull_upsert_records());
     test_records.append(&mut name::test_pull_upsert_records());
-    test_records.append(&mut number::test_pull_upsert_records());
     test_records.append(&mut report::test_pull_upsert_records());
+    test_records.append(&mut store::test_pull_upsert_records());
+    test_records.append(&mut unit::test_pull_upsert_records());
+    // Central but site specific
+    test_records.append(&mut name_store_join::test_pull_upsert_records());
+    test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
+    test_records
+}
+
+pub(crate) fn get_all_pull_upsert_remote_test_records() -> Vec<TestSyncPullRecord> {
+    let mut test_records = Vec::new();
+    test_records.append(&mut location::test_pull_upsert_records());
+    test_records.append(&mut number::test_pull_upsert_records());
     test_records.append(&mut requisition_line::test_pull_upsert_records());
     test_records.append(&mut requisition::test_pull_upsert_records());
     test_records.append(&mut stock_line::test_pull_upsert_records());
     test_records.append(&mut stocktake_line::test_pull_upsert_records());
     test_records.append(&mut stocktake::test_pull_upsert_records());
-    test_records.append(&mut store::test_pull_upsert_records());
     test_records.append(&mut invoice_line::test_pull_upsert_records());
     test_records.append(&mut invoice::test_pull_upsert_records());
-    test_records.append(&mut unit::test_pull_upsert_records());
-    test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
-
     test_records
 }
 
-pub(crate) fn get_all_pull_delete_test_records() -> Vec<TestSyncPullRecord> {
+pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncPullRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut unit::test_pull_delete_records());
     test_records.append(&mut item::test_pull_delete_records());
@@ -56,7 +61,13 @@ pub(crate) fn get_all_pull_delete_test_records() -> Vec<TestSyncPullRecord> {
     test_records.append(&mut report::test_pull_delete_records());
     test_records.append(&mut store::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
+    // Central but site specific
     test_records.append(&mut name_store_join::test_pull_delete_records());
+    test_records
+}
+
+pub(crate) fn get_all_pull_delete_remote_test_records() -> Vec<TestSyncPullRecord> {
+    let mut test_records = Vec::new();
     test_records.append(&mut requisition::test_pull_delete_records());
     test_records.append(&mut requisition_line::test_pull_delete_records());
     test_records.append(&mut invoice::test_pull_delete_records());

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -159,7 +159,7 @@ fn item_line_2_pull_record() -> TestSyncPullRecord {
             total_number_of_packs: -1001,
             expiry_date: None,
             on_hold: false,
-            note: Some("".to_string()),
+            note: None,
         }),
     )
 }
@@ -184,7 +184,7 @@ fn item_line_2_push_record() -> TestSyncPushRecord {
             quantity: -1001,
             cost_price: 0.0,
             sell_price: 0.0,
-            note: Some("".to_string())
+            note: None,
         }),
     }
 }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -82,7 +82,10 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &translation_error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?} {:?}", translation_error, sync_record);
+                    warn!(
+                        "{:?} {:?} {:?}",
+                        translation_error, sync_record.record_id, sync_record.table_name
+                    );
                     // Next sync_record
                     continue;
                 }
@@ -96,7 +99,10 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?} {:?}", error, sync_record);
+                    warn!(
+                        "{:?} {:?} {:?}",
+                        error, sync_record.record_id, sync_record.table_name
+                    );
                     // Next sync_record
                     continue;
                 }
@@ -116,7 +122,10 @@ impl<'a> TranslationAndIntegration<'a> {
                     self.sync_buffer
                         .record_integration_error(&sync_record, &error)?;
                     result.insert_error(&sync_record.table_name);
-                    warn!("{:?} {:?} {:?}", error, sync_record, integration_records);
+                    warn!(
+                        "{:?} {:?} {:?}",
+                        error, sync_record.record_id, sync_record.table_name
+                    );
                 }
             }
         }
@@ -190,6 +199,14 @@ impl PullDeleteRecord {
             InvoiceLine => InvoiceLineRowRepository::new(con).delete(id),
             Requisition => RequisitionRowRepository::new(con).delete(id),
             RequisitionLine => RequisitionLineRowRepository::new(con).delete(id),
+            #[cfg(test)]
+            Location => LocationRowRepository::new(con).delete(id),
+            #[cfg(test)]
+            StockLine => StockLineRowRepository::new(con).delete(id),
+            #[cfg(test)]
+            Stocktake => StocktakeRowRepository::new(con).delete(id),
+            #[cfg(test)]
+            StocktakeLine => StocktakeLineRowRepository::new(con).delete(id),
         }
     }
 }
@@ -221,7 +238,7 @@ mod test {
     use repository::{
         mock::MockDataInserts, test_db, ItemRow, ItemRowRepository, UnitRow, UnitRowRepository,
     };
-    use util::inline_init;
+    use util::{assert_matches, inline_init};
 
     use crate::sync::translations::{IntegrationRecords, PullUpsertRecord};
 
@@ -261,15 +278,15 @@ mod test {
             .unwrap();
 
         // Record should exist
-        assert!(matches!(
+        assert_matches!(
             UnitRowRepository::new(&connection).find_one_by_id_option("unit"),
             Ok(Some(_))
-        ));
+        );
 
         // Record should not exist
-        assert!(matches!(
+        assert_matches!(
             ItemRowRepository::new(&connection).find_one_by_id("item"),
             Ok(None)
-        ));
+        );
     }
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -280,7 +280,7 @@ impl SyncTranslation for InvoiceTranslation {
             ID: id.clone(),
             user_id,
             name_ID: name_id,
-            store_ID: store_id.clone(),
+            store_ID: store_id,
             invoice_num: invoice_number,
             _type,
             status: legacy_status,
@@ -313,7 +313,6 @@ impl SyncTranslation for InvoiceTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -209,8 +209,6 @@ impl SyncTranslation for InvoiceLineTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            // TODO:
-            store_id: None,
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -82,12 +82,11 @@ impl SyncTranslation for LocationTranslation {
             name,
             code,
             on_hold,
-            store_id: store_id.clone(),
+            store_id: store_id,
         };
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -123,6 +123,14 @@ pub(crate) enum PullDeleteRecordTable {
     InvoiceLine,
     Requisition,
     RequisitionLine,
+    #[cfg(test)]
+    Location,
+    #[cfg(test)]
+    StockLine,
+    #[cfg(test)]
+    Stocktake,
+    #[cfg(test)]
+    StocktakeLine,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -161,21 +169,15 @@ impl IntegrationRecords {
         }
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.upserts.is_empty() && self.deletes.is_empty()
-    }
-
     pub(crate) fn join(self, other: IntegrationRecords) -> IntegrationRecords {
         IntegrationRecords {
-            upserts: vec![self.upserts, other.upserts]
-                .into_iter()
-                .flatten()
-                .collect(),
-            deletes: vec![self.deletes, other.deletes]
-                .into_iter()
-                .flatten()
-                .collect(),
+            upserts: vec![self.upserts, other.upserts].concat(),
+            deletes: vec![self.deletes, other.deletes].concat(),
         }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.upserts.is_empty() && self.deletes.is_empty()
     }
 }
 
@@ -208,7 +210,6 @@ pub(crate) trait SyncTranslation {
 #[derive(Debug)]
 pub(crate) struct PushUpsertRecord {
     pub(crate) sync_id: i64,
-    pub(crate) store_id: Option<String>,
     /// The translated table name
     pub(crate) table_name: &'static str,
     pub(crate) record_id: String,

--- a/server/service/src/sync/translations/number.rs
+++ b/server/service/src/sync/translations/number.rs
@@ -81,7 +81,6 @@ impl SyncTranslation for NumberTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -279,7 +279,6 @@ impl SyncTranslation for RequisitionTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -132,8 +132,6 @@ impl SyncTranslation for RequisitionLineTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            // TODO:
-            store_id: None,
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -29,6 +29,7 @@ pub struct LegacyStockLineRow {
     pub quantity: i32,
     pub cost_price: f64,
     pub sell_price: f64,
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub note: Option<String>,
 }
 
@@ -96,7 +97,7 @@ impl SyncTranslation for StockLineTranslation {
 
         let legacy_row = LegacyStockLineRow {
             ID: id.clone(),
-            store_ID: store_id.clone(),
+            store_ID: store_id,
             item_ID: item_id,
             batch,
             expiry_date,
@@ -112,7 +113,6 @@ impl SyncTranslation for StockLineTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -162,7 +162,6 @@ impl SyncTranslation for StocktakeTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: Some(store_id),
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -140,7 +140,6 @@ impl SyncTranslation for StocktakeLineTranslation {
 
         Ok(Some(vec![PushUpsertRecord {
             sync_id: changelog.id,
-            store_id: None,
             table_name,
             record_id: id,
             data: serde_json::to_value(&legacy_row)?,

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -38,11 +38,10 @@ impl SyncTranslation for StoreTranslation {
         // HIS -> Hospital Information System (no name_id)
         // SM -> Supervisor Store
         // DRG -> Drug Registration (name_id exists but no name with that id)
-        match &data.code[..] {
-            "HIS" => return Ok(None),
-            "DRG" => return Ok(None),
-            "SM" => return Ok(None),
-            _ => {}
+        // TODO: Ideally we want another state, `Ignored`
+        // (i.e. return type) Translation Not Matches, Translation Ignored (with message ?) and Translated records
+        if let "HIS" | "DRG" | "SM" = &data.code[..] {
+            return Ok(None);
         }
 
         // ignore stores without name

--- a/server/service/src/token.rs
+++ b/server/service/src/token.rs
@@ -319,6 +319,8 @@ fn create_jwt_pair(
 
 #[cfg(test)]
 mod user_account_test {
+    use util::assert_matches;
+
     use crate::token_bucket::TokenBucket;
 
     use super::*;
@@ -346,13 +348,13 @@ mod user_account_test {
         let err = bucket_validating_service
             .verify_token(&token_pair.refresh, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTValidationError::NotAnApiToken));
+        assert_matches!(err, JWTValidationError::NotAnApiToken);
 
         // should fail to refresh token refresh with api token
         let err = bucket_validating_service
             .refresh_token(&token_pair.token, 60, 120, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::NotARefreshToken));
+        assert_matches!(err, JWTRefreshError::NotARefreshToken);
 
         // should succeed to refresh token
         let token_pair = bucket_validating_service
@@ -369,11 +371,11 @@ mod user_account_test {
         let err = bucket_validating_service
             .verify_token(&token_pair.token, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTValidationError::TokenInvalidated));
+        assert_matches!(err, JWTValidationError::TokenInvalidated);
         let err = bucket_validating_service
             .refresh_token(&token_pair.refresh, 60, 120, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::TokenInvalided));
+        assert_matches!(err, JWTRefreshError::TokenInvalided);
 
         //Check that tokens are still considered valid without them being in the bucket when validate_token_bucket=false
         let claims = bucket_not_validating_service
@@ -402,10 +404,10 @@ mod user_account_test {
         let err = bucket_validating_service
             .verify_token(&token_pair.token, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTValidationError::ExpiredSignature));
+        assert_matches!(err, JWTValidationError::ExpiredSignature);
         let err = bucket_validating_service
             .refresh_token(&token_pair.refresh, 1, 1, Some(0))
             .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::ExpiredSignature));
+        assert_matches!(err, JWTRefreshError::ExpiredSignature);
     }
 }

--- a/server/service/src/user_account.rs
+++ b/server/service/src/user_account.rs
@@ -199,7 +199,7 @@ mod user_account_test {
         EqualFilter, Permission, UserFilter, UserPermissionFilter, UserPermissionRepository,
         UserRepository,
     };
-    use util::inline_edit;
+    use util::{assert_matches, inline_edit};
 
     use crate::service_provider::ServiceProvider;
 
@@ -229,15 +229,11 @@ mod user_account_test {
 
         // should fail to verify wrong password
         let err = service.verify_password(username, "wrong").unwrap_err();
-        assert!(matches!(err, VerifyPasswordError::InvalidCredentials));
+        assert_matches!(err, VerifyPasswordError::InvalidCredentials);
 
         // should fail to find invalid user
         let err = service.verify_password("invalid", password).unwrap_err();
-        assert!(
-            matches!(err, VerifyPasswordError::UsernameDoesNotExist),
-            "{:?}",
-            err
-        );
+        assert_matches!(err, VerifyPasswordError::UsernameDoesNotExist);
     }
 
     #[actix_rt::test]

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -11,3 +11,4 @@ sha2 = "0.9.5"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4.19"
 env_logger = "0.8.3"
+serde_json = "1.0.66"

--- a/server/util/src/test_helpers.rs
+++ b/server/util/src/test_helpers.rs
@@ -1,0 +1,11 @@
+#[macro_export]
+macro_rules! assert_matches {
+    ($left:expr, $right:pat_param) => {{
+        assert!(
+            matches!($left, $right),
+            "Unexpected match, expected: {} got: {:#?}",
+            stringify!($right),
+            $left
+        )
+    }};
+}


### PR DESCRIPTION
closes #333 

(this is a safepoint branch for changes in downstream PRs https://github.com/openmsupply/open-msupply/pull/328, https://github.com/openmsupply/open-msupply/pull/332, https://github.com/openmsupply/open-msupply/pull/334)

Apart from adding documentation, also added cary over changes (to reduce size of downstream PRs)
* Make sure we can set nulls via options on the data types tested in integration tests
* Common assert_matches macro used in testing
* Use with_retry rather then random_timeout
* Simplify central configuration helper
* Split check_records_against_database, so that it can be used for IntegrationRecords (and Vec of test sync pull record)
* Split test data into central and remote (didn't end up using it, but kept)
* Make error log in integration and translation more concise
* Remove store_id for PushUpsertRecord