### PR TITLE
326 encounter endpoints

### DIFF
--- a/server/graphql/document/src/lib.rs
+++ b/server/graphql/document/src/lib.rs
@@ -1,5 +1,11 @@
 use async_graphql::*;
 use graphql_core::pagination::PaginationInput;
+use mutations::encounter::insert::insert_encounter;
+use mutations::encounter::insert::InsertEncounterInput;
+use mutations::encounter::insert::InsertEncounterResponse;
+use mutations::encounter::update::update_encounter;
+use mutations::encounter::update::UpdateEncounterInput;
+use mutations::encounter::update::UpdateEncounterResponse;
 use mutations::insert_document_registry::*;
 use mutations::insert_form_schema::*;
 use mutations::patient::insert::*;
@@ -168,5 +174,23 @@ impl DocumentMutations {
         input: UpdateProgramInput,
     ) -> Result<UpdateProgramResponse> {
         update_program(ctx, store_id, input)
+    }
+
+    pub async fn insert_encounter(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: InsertEncounterInput,
+    ) -> Result<InsertEncounterResponse> {
+        insert_encounter(ctx, store_id, input)
+    }
+
+    pub async fn update_encounter(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: UpdateEncounterInput,
+    ) -> Result<UpdateEncounterResponse> {
+        update_encounter(ctx, store_id, input)
     }
 }

--- a/server/graphql/document/src/mutations/encounter/mod.rs
+++ b/server/graphql/document/src/mutations/encounter/mod.rs
@@ -1,0 +1,2 @@
+pub mod insert;
+pub mod update;

--- a/server/graphql/document/src/mutations/encounter/update.rs
+++ b/server/graphql/document/src/mutations/encounter/update.rs
@@ -16,6 +16,7 @@ pub struct UpdateEncounterInput {
     pub data: serde_json::Value,
     /// The schema id used for the counter data
     pub schema_id: String,
+    /// The document id of the encounter document which should be updated
     pub parent: String,
 }
 

--- a/server/graphql/document/src/mutations/mod.rs
+++ b/server/graphql/document/src/mutations/mod.rs
@@ -1,3 +1,4 @@
+pub mod encounter;
 pub mod insert_document_registry;
 pub mod insert_form_schema;
 pub mod patient;

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -74,6 +74,7 @@ pub enum Resource {
     MutatePatient,
     // patient program
     MutateProgram,
+    MutateEncounter,
 }
 
 fn all_permissions() -> HashMap<Resource, PermissionDSL> {
@@ -263,6 +264,13 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     );
     map.insert(
         Resource::MutateProgram,
+        PermissionDSL::And(vec![
+            PermissionDSL::HasStoreAccess,
+            PermissionDSL::HasPermission(Permission::PatientMutate),
+        ]),
+    );
+    map.insert(
+        Resource::MutateEncounter,
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
             PermissionDSL::HasPermission(Permission::PatientMutate),

--- a/server/service/src/document/encounter/encounter_schema.rs
+++ b/server/service/src/document/encounter/encounter_schema.rs
@@ -1,0 +1,9 @@
+extern crate schemafy_core;
+extern crate serde;
+extern crate serde_json;
+
+use serde::{Deserialize, Serialize};
+
+schemafy::schemafy!("src/document/schemas/encounter.json");
+
+pub type SchemaEncounter = Encounter;

--- a/server/service/src/document/encounter/insert.rs
+++ b/server/service/src/document/encounter/insert.rs
@@ -256,7 +256,7 @@ mod test {
             status: None,
         };
         let program_type = "ProgramType".to_string();
-        service
+        let result = service
             .insert_encounter(
                 &ctx,
                 &service_provider,
@@ -271,5 +271,12 @@ mod test {
                 },
             )
             .unwrap();
+        let found = service_provider
+            .document_service
+            .get_document(&ctx, "store_a", &result.name)
+            .unwrap()
+            .unwrap();
+        assert!(found.parent_ids.is_empty());
+        assert_eq!(found.data, serde_json::to_value(encounter.clone()).unwrap());
     }
 }

--- a/server/service/src/document/encounter/insert.rs
+++ b/server/service/src/document/encounter/insert.rs
@@ -1,0 +1,275 @@
+use chrono::Utc;
+use repository::{Document, DocumentRepository, RepositoryError, TransactionError};
+
+use crate::{
+    document::{
+        document_service::DocumentInsertError,
+        patient::{patient_program_doc_name, patient_program_encounter_doc_name},
+        raw_document::RawDocument,
+    },
+    service_provider::{ServiceContext, ServiceProvider},
+};
+
+use super::encounter_schema::SchemaEncounter;
+
+#[derive(PartialEq, Debug)]
+pub enum InsertEncounterError {
+    InvalidPatientOrProgram,
+    InvalidDataSchema(Vec<String>),
+    InternalError(String),
+    DatabaseError(RepositoryError),
+}
+
+pub struct InsertEncounter {
+    pub patient_id: String,
+    /// The program type
+    pub program_type: String,
+    pub r#type: String,
+    pub data: serde_json::Value,
+    pub schema_id: String,
+}
+
+pub fn insert_encounter(
+    ctx: &ServiceContext,
+    service_provider: &ServiceProvider,
+    store_id: String,
+    user_id: &str,
+    input: InsertEncounter,
+) -> Result<Document, InsertEncounterError> {
+    let patient = ctx
+        .connection
+        .transaction_sync(|_| {
+            validate(ctx, &store_id, &input)?;
+            let doc = generate(user_id, input)?;
+
+            // Updating the document will trigger an update in the patient (names) table
+            let result = service_provider
+                .document_service
+                .update_document(ctx, &store_id, doc)
+                .map_err(|err| match err {
+                    DocumentInsertError::InvalidDataSchema(err) => {
+                        InsertEncounterError::InvalidDataSchema(err)
+                    }
+                    DocumentInsertError::DatabaseError(err) => {
+                        InsertEncounterError::DatabaseError(err)
+                    }
+                    DocumentInsertError::InternalError(err) => {
+                        InsertEncounterError::InternalError(err)
+                    }
+                    _ => InsertEncounterError::InternalError(format!("{:?}", err)),
+                })?;
+
+            Ok(result)
+        })
+        .map_err(|err: TransactionError<InsertEncounterError>| err.to_inner_error())?;
+    Ok(patient)
+}
+
+impl From<RepositoryError> for InsertEncounterError {
+    fn from(err: RepositoryError) -> Self {
+        InsertEncounterError::DatabaseError(err)
+    }
+}
+
+fn generate(user_id: &str, input: InsertEncounter) -> Result<RawDocument, RepositoryError> {
+    let encounter_name = Utc::now().to_rfc3339();
+    Ok(RawDocument {
+        name: patient_program_encounter_doc_name(&input.patient_id, &input.r#type, &encounter_name),
+        parents: vec![],
+        author: user_id.to_string(),
+        timestamp: Utc::now(),
+        r#type: input.r#type,
+        data: input.data,
+        schema_id: Some(input.schema_id),
+    })
+}
+
+fn validate_encounter_schema(
+    input: &InsertEncounter,
+) -> Result<SchemaEncounter, serde_json::Error> {
+    serde_json::from_value(input.data.clone())
+}
+
+fn validate_patient_program_exists(
+    ctx: &ServiceContext,
+    store_id: &str,
+    patient_id: &str,
+    program: &str,
+) -> Result<bool, RepositoryError> {
+    let doc_name = patient_program_doc_name(patient_id, program);
+    let document =
+        DocumentRepository::new(&ctx.connection).find_one_by_name(store_id, &doc_name)?;
+    Ok(document.is_some())
+}
+
+fn validate(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: &InsertEncounter,
+) -> Result<(), InsertEncounterError> {
+    if !validate_patient_program_exists(ctx, store_id, &input.patient_id, &input.program_type)? {
+        return Err(InsertEncounterError::InvalidPatientOrProgram);
+    }
+
+    validate_encounter_schema(input).map_err(|err| {
+        InsertEncounterError::InvalidDataSchema(vec![format!("Invalid program data: {}", err)])
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::Utc;
+    use repository::{
+        mock::{mock_form_schema_empty, MockDataInserts},
+        test_db::setup_all,
+        FormSchemaRowRepository,
+    };
+    use serde_json::json;
+
+    use crate::{
+        document::{
+            encounter::{encounter_schema::SchemaEncounter, InsertEncounter},
+            patient::{test::mock_patient_1, UpdatePatient},
+            program::{program_schema::SchemaProgram, UpsertProgram},
+        },
+        service_provider::ServiceProvider,
+    };
+
+    use super::InsertEncounterError;
+
+    #[actix_rt::test]
+    async fn test_encounter_insert() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_encounter_insert",
+            MockDataInserts::none().names().stores().form_schemas(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "");
+        let ctx = service_provider.context().unwrap();
+
+        // dummy schema
+        let schema = mock_form_schema_empty();
+        FormSchemaRowRepository::new(&ctx.connection)
+            .upsert_one(&schema)
+            .unwrap();
+
+        // insert patient and program
+        let patient = mock_patient_1();
+        service_provider
+            .patient_service
+            .update_patient(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                &patient.id,
+                UpdatePatient {
+                    data: serde_json::to_value(&patient).unwrap(),
+                    schema_id: schema.id.clone(),
+                    parent: None,
+                },
+            )
+            .unwrap();
+        let program = SchemaProgram {
+            enrolment_datetime: Utc::now().to_rfc3339(),
+        };
+        let program_type = "ProgramType".to_string();
+        service_provider
+            .program_service
+            .upsert_program(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                UpsertProgram {
+                    data: serde_json::to_value(program.clone()).unwrap(),
+                    schema_id: schema.id.clone(),
+                    parent: None,
+                    patient_id: patient.id.clone(),
+                    r#type: program_type.clone(),
+                },
+            )
+            .unwrap();
+
+        // start actual test:
+        let service = &service_provider.encounter_service;
+        // InvalidPatientOrProgram,
+        let err = service
+            .insert_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                InsertEncounter {
+                    data: json!({"enrolment_datetime":true}),
+                    schema_id: schema.id.clone(),
+                    patient_id: "some_id".to_string(),
+                    r#type: "SomeType".to_string(),
+                    program_type: program_type.clone(),
+                },
+            )
+            .err()
+            .unwrap();
+        matches!(err, InsertEncounterError::InvalidPatientOrProgram);
+        let err = service
+            .insert_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                InsertEncounter {
+                    data: json!({"enrolment_datetime":true}),
+                    schema_id: schema.id.clone(),
+                    patient_id: patient.id.clone(),
+                    r#type: "SomeType".to_string(),
+                    program_type: "invalid".to_string(),
+                },
+            )
+            .err()
+            .unwrap();
+        matches!(err, InsertEncounterError::InvalidPatientOrProgram);
+
+        // InvalidDataSchema
+        let err = service
+            .insert_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                InsertEncounter {
+                    data: json!({"encounter_datetime": true}),
+                    schema_id: schema.id.clone(),
+                    patient_id: patient.id.clone(),
+                    r#type: "SomeType".to_string(),
+                    program_type: program_type.clone(),
+                },
+            )
+            .err()
+            .unwrap();
+        matches!(err, InsertEncounterError::InvalidDataSchema(_));
+
+        // success insert
+        let encounter = SchemaEncounter {
+            encounter_datetime: Utc::now().to_rfc3339(),
+            status: None,
+        };
+        let program_type = "ProgramType".to_string();
+        service
+            .insert_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                InsertEncounter {
+                    data: serde_json::to_value(encounter.clone()).unwrap(),
+                    schema_id: schema.id.clone(),
+                    patient_id: patient.id.clone(),
+                    r#type: program_type.clone(),
+                    program_type: program_type.clone(),
+                },
+            )
+            .unwrap();
+    }
+}

--- a/server/service/src/document/encounter/mod.rs
+++ b/server/service/src/document/encounter/mod.rs
@@ -1,0 +1,36 @@
+use repository::Document;
+
+use crate::service_provider::ServiceContext;
+use crate::service_provider::ServiceProvider;
+
+pub use self::insert::*;
+pub use self::update::*;
+pub mod encounter_schema;
+mod insert;
+mod update;
+pub trait EncounterServiceTrait: Sync + Send {
+    fn insert_encounter(
+        &self,
+        ctx: &ServiceContext,
+        service_provider: &ServiceProvider,
+        store_id: String,
+        user_id: &str,
+        input: InsertEncounter,
+    ) -> Result<Document, InsertEncounterError> {
+        insert_encounter(ctx, service_provider, store_id, user_id, input)
+    }
+
+    fn update_encounter(
+        &self,
+        ctx: &ServiceContext,
+        service_provider: &ServiceProvider,
+        store_id: String,
+        user_id: &str,
+        input: UpdateEncounter,
+    ) -> Result<Document, UpdateEncounterError> {
+        update_encounter(ctx, service_provider, store_id, user_id, input)
+    }
+}
+
+pub struct EncounterService {}
+impl EncounterServiceTrait for EncounterService {}

--- a/server/service/src/document/encounter/update.rs
+++ b/server/service/src/document/encounter/update.rs
@@ -248,18 +248,25 @@ mod test {
             encounter_datetime: Utc::now().to_rfc3339(),
             status: None,
         };
-        service
+        let result = service
             .update_encounter(
                 &ctx,
                 &service_provider,
                 "store_a".to_string(),
                 "user",
                 UpdateEncounter {
-                    data: serde_json::to_value(encounter).unwrap(),
+                    data: serde_json::to_value(encounter.clone()).unwrap(),
                     schema_id: schema.id.clone(),
                     parent: initial_encounter.id.clone(),
                 },
             )
             .unwrap();
+        let found = service_provider
+            .document_service
+            .get_document(&ctx, "store_a", &result.name)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.parent_ids, vec![initial_encounter.id]);
+        assert_eq!(found.data, serde_json::to_value(encounter.clone()).unwrap());
     }
 }

--- a/server/service/src/document/encounter/update.rs
+++ b/server/service/src/document/encounter/update.rs
@@ -35,7 +35,6 @@ pub fn update_encounter(
             let existing = validate(ctx, &input)?;
             let doc = generate(user_id, input, existing)?;
 
-            // Updating the document will trigger an update in the patient (names) table
             let result = service_provider
                 .document_service
                 .update_document(ctx, &store_id, doc)
@@ -83,6 +82,10 @@ fn generate(
 fn validate_encounter_schema(
     input: &UpdateEncounter,
 ) -> Result<SchemaEncounter, serde_json::Error> {
+    // Check that we can parse the data into a default encounter object, i.e. that it's following
+    // the default encounter JSON schema.
+    // If the encounter data uses a derived encounter schema, the derived schema is validated in the
+    // document service.
     serde_json::from_value(input.data.clone())
 }
 

--- a/server/service/src/document/encounter/update.rs
+++ b/server/service/src/document/encounter/update.rs
@@ -1,0 +1,262 @@
+use chrono::Utc;
+use repository::{Document, DocumentRepository, RepositoryError, TransactionError};
+
+use crate::{
+    document::{document_service::DocumentInsertError, raw_document::RawDocument},
+    service_provider::{ServiceContext, ServiceProvider},
+};
+
+use super::encounter_schema::SchemaEncounter;
+
+#[derive(PartialEq, Debug)]
+pub enum UpdateEncounterError {
+    InvalidParentId,
+    InvalidDataSchema(Vec<String>),
+    InternalError(String),
+    DatabaseError(RepositoryError),
+}
+
+pub struct UpdateEncounter {
+    pub parent: String,
+    pub data: serde_json::Value,
+    pub schema_id: String,
+}
+
+pub fn update_encounter(
+    ctx: &ServiceContext,
+    service_provider: &ServiceProvider,
+    store_id: String,
+    user_id: &str,
+    input: UpdateEncounter,
+) -> Result<Document, UpdateEncounterError> {
+    let patient = ctx
+        .connection
+        .transaction_sync(|_| {
+            let existing = validate(ctx, &input)?;
+            let doc = generate(user_id, input, existing)?;
+
+            // Updating the document will trigger an update in the patient (names) table
+            let result = service_provider
+                .document_service
+                .update_document(ctx, &store_id, doc)
+                .map_err(|err| match err {
+                    DocumentInsertError::InvalidDataSchema(err) => {
+                        UpdateEncounterError::InvalidDataSchema(err)
+                    }
+                    DocumentInsertError::DatabaseError(err) => {
+                        UpdateEncounterError::DatabaseError(err)
+                    }
+                    DocumentInsertError::InternalError(err) => {
+                        UpdateEncounterError::InternalError(err)
+                    }
+                    _ => UpdateEncounterError::InternalError(format!("{:?}", err)),
+                })?;
+
+            Ok(result)
+        })
+        .map_err(|err: TransactionError<UpdateEncounterError>| err.to_inner_error())?;
+    Ok(patient)
+}
+
+impl From<RepositoryError> for UpdateEncounterError {
+    fn from(err: RepositoryError) -> Self {
+        UpdateEncounterError::DatabaseError(err)
+    }
+}
+
+fn generate(
+    user_id: &str,
+    input: UpdateEncounter,
+    existing: Document,
+) -> Result<RawDocument, RepositoryError> {
+    Ok(RawDocument {
+        name: existing.name,
+        parents: vec![input.parent],
+        author: user_id.to_string(),
+        timestamp: Utc::now(),
+        r#type: existing.r#type,
+        data: input.data,
+        schema_id: Some(input.schema_id),
+    })
+}
+
+fn validate_encounter_schema(
+    input: &UpdateEncounter,
+) -> Result<SchemaEncounter, serde_json::Error> {
+    serde_json::from_value(input.data.clone())
+}
+
+fn validate_parent(
+    ctx: &ServiceContext,
+    parent: &str,
+) -> Result<Option<Document>, RepositoryError> {
+    let parent_doc = DocumentRepository::new(&ctx.connection).find_one_by_id(parent)?;
+    Ok(parent_doc)
+}
+
+fn validate(
+    ctx: &ServiceContext,
+    input: &UpdateEncounter,
+) -> Result<Document, UpdateEncounterError> {
+    validate_encounter_schema(input).map_err(|err| {
+        UpdateEncounterError::InvalidDataSchema(vec![format!("Invalid program data: {}", err)])
+    })?;
+
+    let doc = match validate_parent(ctx, &input.parent)? {
+        Some(doc) => doc,
+        None => return Err(UpdateEncounterError::InvalidParentId),
+    };
+
+    Ok(doc)
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::Utc;
+    use repository::{
+        mock::{mock_form_schema_empty, MockDataInserts},
+        test_db::setup_all,
+        FormSchemaRowRepository,
+    };
+    use serde_json::json;
+
+    use crate::{
+        document::{
+            encounter::{encounter_schema::SchemaEncounter, InsertEncounter, UpdateEncounter},
+            patient::{test::mock_patient_1, UpdatePatient},
+            program::{program_schema::SchemaProgram, UpsertProgram},
+        },
+        service_provider::ServiceProvider,
+    };
+
+    use super::UpdateEncounterError;
+
+    #[actix_rt::test]
+    async fn test_encounter_update() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_encounter_update",
+            MockDataInserts::none().names().stores().form_schemas(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "");
+        let ctx = service_provider.context().unwrap();
+
+        // dummy schema
+        let schema = mock_form_schema_empty();
+        FormSchemaRowRepository::new(&ctx.connection)
+            .upsert_one(&schema)
+            .unwrap();
+
+        // insert patient, program and initial encounter
+        let patient = mock_patient_1();
+        service_provider
+            .patient_service
+            .update_patient(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                &patient.id,
+                UpdatePatient {
+                    data: serde_json::to_value(&patient).unwrap(),
+                    schema_id: schema.id.clone(),
+                    parent: None,
+                },
+            )
+            .unwrap();
+        let program = SchemaProgram {
+            enrolment_datetime: Utc::now().to_rfc3339(),
+        };
+        let program_type = "ProgramType".to_string();
+        service_provider
+            .program_service
+            .upsert_program(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                UpsertProgram {
+                    data: serde_json::to_value(program.clone()).unwrap(),
+                    schema_id: schema.id.clone(),
+                    parent: None,
+                    patient_id: patient.id.clone(),
+                    r#type: program_type.clone(),
+                },
+            )
+            .unwrap();
+        let service = &service_provider.encounter_service;
+        let encounter = SchemaEncounter {
+            encounter_datetime: Utc::now().to_rfc3339(),
+            status: None,
+        };
+        let program_type = "ProgramType".to_string();
+        let initial_encounter = service
+            .insert_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                InsertEncounter {
+                    data: serde_json::to_value(encounter.clone()).unwrap(),
+                    schema_id: schema.id.clone(),
+                    patient_id: patient.id.clone(),
+                    r#type: program_type.clone(),
+                    program_type: program_type.clone(),
+                },
+            )
+            .unwrap();
+
+        // InvalidParentId
+        let err = service
+            .update_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                UpdateEncounter {
+                    data: json!({"enrolment_datetime": true}),
+                    schema_id: schema.id.clone(),
+                    parent: "invalid".to_string(),
+                },
+            )
+            .err()
+            .unwrap();
+        matches!(err, UpdateEncounterError::InvalidParentId);
+
+        // InvalidDataSchema
+        let err = service
+            .update_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                UpdateEncounter {
+                    data: json!({"encounter_datetime": true}),
+                    schema_id: schema.id.clone(),
+                    parent: initial_encounter.id.clone(),
+                },
+            )
+            .err()
+            .unwrap();
+        matches!(err, UpdateEncounterError::InvalidDataSchema(_));
+
+        // success update
+        let encounter = SchemaEncounter {
+            encounter_datetime: Utc::now().to_rfc3339(),
+            status: None,
+        };
+        service
+            .update_encounter(
+                &ctx,
+                &service_provider,
+                "store_a".to_string(),
+                "user",
+                UpdateEncounter {
+                    data: serde_json::to_value(encounter).unwrap(),
+                    schema_id: schema.id.clone(),
+                    parent: initial_encounter.id.clone(),
+                },
+            )
+            .unwrap();
+    }
+}

--- a/server/service/src/document/mod.rs
+++ b/server/service/src/document/mod.rs
@@ -1,6 +1,7 @@
 mod common_ancestor;
 pub mod document_registry;
 pub mod document_service;
+pub mod encounter;
 pub mod form_schema_service;
 mod merge;
 mod object_array_merge;

--- a/server/service/src/document/program/mod.rs
+++ b/server/service/src/document/program/mod.rs
@@ -4,7 +4,7 @@ use crate::service_provider::ServiceContext;
 use crate::service_provider::ServiceProvider;
 
 pub use self::upsert::*;
-mod program_schema;
+pub mod program_schema;
 mod upsert;
 pub trait ProgramServiceTrait: Sync + Send {
     fn upsert_program(

--- a/server/service/src/document/program/upsert.rs
+++ b/server/service/src/document/program/upsert.rs
@@ -45,7 +45,6 @@ pub fn upsert_program(
             validate(ctx, service_provider, &store_id, &input)?;
             let doc = generate(user_id, input)?;
 
-            // Updating the document will trigger an update in the patient (names) table
             let result = service_provider
                 .document_service
                 .update_document(ctx, &store_id, doc)

--- a/server/service/src/document/schemas/encounter.json
+++ b/server/service/src/document/schemas/encounter.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Encounter": {
+      "properties": {
+        "encounterDatetime": {
+          "description": "Encounter date and time",
+          "format": "date-time",
+          "type": "string"
+        },
+        "status": {
+          "enum": ["Scheduled", "Done", "Canceled"],
+          "type": "string"
+        }
+      },
+      "required": ["encounterDatetime"],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Encounter"
+    }
+  ]
+}

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -13,6 +13,7 @@ use crate::{
     document::{
         document_registry::{DocumentRegistryService, DocumentRegistryServiceTrait},
         document_service::{DocumentService, DocumentServiceTrait},
+        encounter::{EncounterService, EncounterServiceTrait},
         form_schema_service::{FormSchemaService, FormSchemaServiceTrait},
         patient::{PatientService, PatientServiceTrait},
         program::{ProgramService, ProgramServiceTrait},
@@ -62,6 +63,7 @@ pub struct ServiceProvider {
     pub form_schema_service: Box<dyn FormSchemaServiceTrait>,
     pub patient_service: Box<dyn PatientServiceTrait>,
     pub program_service: Box<dyn ProgramServiceTrait>,
+    pub encounter_service: Box<dyn EncounterServiceTrait>,
 
     // Settings
     pub settings: Box<dyn SettingsServiceTrait>,
@@ -96,6 +98,7 @@ impl ServiceProvider {
             form_schema_service: Box::new(FormSchemaService {}),
             patient_service: Box::new(PatientService {}),
             program_service: Box::new(ProgramService {}),
+            encounter_service: Box::new(EncounterService {}),
             settings: Box::new(SettingsService {}),
             app_data_service: Box::new(AppDataService::new(app_data_folder)),
         }


### PR DESCRIPTION
Add endpoint to insert and update a patient encounter.

Testing setup to add an encounter for a patient (first add program and then add encounter under this program):
```graphql
mutation MyMutation($storeId: String, $programType: String, $programData: JSON, $encounterType: String, $encounterData: JSON, $encounterDataUpdate: JSON) {
  insertProgram(input: {type: $programType, patientId: "patient1", data: $programData, schemaId: "e7df3c13-b6eb-4883-8f00-be3b526b7c6b"}, storeId: $storeId) {
    ... on DocumentNode {
      id
      name
    }
  }
  insertEncounter(input: {type: $encounterType, patientId: "patient1", data: $encounterData, schemaId: "5a2959fd-a456-4ff4-b219-d72d907d438f", programType: $programType}, storeId: $storeId) {
    ... on DocumentNode {
      id
      name
    }
  }
}
```
with vars (schema id need to be looked up manually):
```json
{
  "storeId": "80004C94067A4CE5A34FC343EB1B4306",
  "programType": "ProgramTest",
  "programData": {
    "enrolmentDatetime": "2022-07-18T21:20:15.956Z"
  },
  "encounterType": "EncounterTest",
  "encounterData": {
    "encounterDatetime": "2022-07-18T21:20:15.956Z"
  },
  "encounterDataUpdate": {
    "encounterDatetime": "2022-07-18T21:20:15.956Z",
    "extra": "extra data"
  }
}
```

Closes #326 