### PR TITLE
OS pack size selection

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.tsx
@@ -94,13 +94,16 @@ export const usePackSizeController = (lines: DraftOutboundLine[]) => {
       (packSize.isPlaceholder && packSize.hasAllocated) ||
       // - is a placeholder and is the only line.
       (packSize.isPlaceholder && packSizes.length === 1) ||
-      // Is not on hold, expired has available stock and is not a placeholder..
+      // Is not on hold, has available stock and is not a placeholder..
       (!packSize.isPlaceholder &&
         !packSize.isOnHold &&
         packSize.hasAvailableStock)
   );
+  // filter out expired, non-placeholder lines.
   const validPackSizes = ArrayUtils.uniqBy(
-    allPackSizes.filter(({ isExpired }) => !isExpired),
+    allPackSizes.filter(
+      ({ isExpired, isPlaceholder }) => !isExpired || isPlaceholder
+    ),
     'packSize'
   );
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.tsx
@@ -88,28 +88,27 @@ export const usePackSizeController = (lines: DraftOutboundLine[]) => {
   // - is not on hold.
   // - is not expired.
   // - has some available stock.
+  const allPackSizes = packSizes.filter(
+    packSize =>
+      // - is a placeholder and has allocated stock.
+      (packSize.isPlaceholder && packSize.hasAllocated) ||
+      // - is a placeholder and is the only line.
+      (packSize.isPlaceholder && packSizes.length === 1) ||
+      // Is not on hold, expired has available stock and is not a placeholder..
+      (!packSize.isPlaceholder &&
+        !packSize.isOnHold &&
+        packSize.hasAvailableStock)
+  );
   const validPackSizes = ArrayUtils.uniqBy(
-    packSizes.filter(
-      packSize =>
-        // - is a placeholder and has allocated stock.
-        (packSize.isPlaceholder && packSize.hasAllocated) ||
-        // - is a placeholder and is the only line.
-        (packSize.isPlaceholder && packSizes.length === 1) ||
-        // Is not on hold, expired has available stock and is not a placeholder..
-        (!packSize.isPlaceholder &&
-          !packSize.isOnHold &&
-          !packSize.isExpired &&
-          packSize.hasAvailableStock)
-    ),
+    allPackSizes.filter(({ isExpired }) => !isExpired),
     'packSize'
   );
 
   // Add the any option when:
   // - There are multiple valid pack sizes to choose from.
-  // - There is an expired line.
+  // - There is an expired line with a different pack size.
   // - There are no valid options (i.e. there are no stock lines, only a placeholder).
-  const hasExpiredLine = packSizes.some(({ isExpired }) => isExpired);
-  if (validPackSizes.length !== 1 || hasExpiredLine) {
+  if (ArrayUtils.uniqBy(allPackSizes, 'packSize').length !== 1) {
     validPackSizes.unshift(createAnyOption(t)());
   }
 


### PR DESCRIPTION
Fixes #350 

The issue is that the pack size options include `Any` if expired lines are present. The only reason I could see for this is to provide an option which enables the expired line if the expired line has a different pack size ( if the pack size is the same, then you can already allocate from it ).

In the example given, an expiry date had been entered incorrectly ( `03/0024` ) and so the `Any` option was shown, even though all pack sizes were `20`.

## Tests

- [ ] add an item with all stock lines the same pack size, and at least one is expired. Should show only the pack size in the units selection
- [ ] add an item with all stock lines the same pack size, and at least one is expired and has a different pack size. Should show the pack size of the un-expired lines in the units selection, along with `Any`
  - [ ] the pack size is defaulted
  - [ ] choosing `Any` will enable the expired line ( if it has available stock )

examples:
All the same pack size, with an expired stock line:

<img width="884" alt="Screen Shot 2022-07-19 at 1 01 11 PM" src="https://user-images.githubusercontent.com/9192912/179641816-bdc82977-4fc0-43d3-9b61-4b98b44e6df3.png">

Different pack size on the expired line:

<img width="877" alt="Screen Shot 2022-07-19 at 1 01 49 PM" src="https://user-images.githubusercontent.com/9192912/179641820-4be42903-1d56-4d65-b772-942aa4a523f7.png">

When `Any` is selected, the expired line is available for allocation:

<img width="882" alt="Screen Shot 2022-07-19 at 1 01 55 PM" src="https://user-images.githubusercontent.com/9192912/179641833-d76ecc7a-22c2-4ef6-b444-c6930ffb68ee.png">

