### PR TITLE
Form submit

### DIFF
--- a/client/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
+++ b/client/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 import { LocaleKey, useTranslation } from '@common/intl';
 
 interface BasicSpinnerProps {
+  inline?: boolean;
   messageKey?: LocaleKey;
 }
 
@@ -13,7 +14,6 @@ const Container = styled(Box)({
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'column',
-  position: 'fixed',
   top: 0,
   left: 0,
   width: '100%',
@@ -28,10 +28,11 @@ const StyledText = styled(Typography)(({ theme }) => ({
 
 export const BasicSpinner: FC<BasicSpinnerProps> = ({
   messageKey = 'loading',
+  inline = false,
 }) => {
   const t = useTranslation('app');
   return (
-    <Container>
+    <Container style={inline ? {} : { position: 'fixed' }}>
       <CircularProgress />
       <StyledText>{t(messageKey)}</StyledText>
     </Container>

--- a/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
@@ -1,0 +1,155 @@
+import React, { FC, PropsWithChildren, useEffect } from 'react';
+import {
+  DocumentRegistryFragment,
+  Typography,
+  UnhappyMan,
+} from '@openmsupply-client/common';
+import { Box, useTranslation, BasicSpinner } from '@openmsupply-client/common';
+import { JsonForms } from '@jsonforms/react';
+import {
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  UISchemaElement,
+} from '@jsonforms/core';
+import { materialRenderers } from '@jsonforms/material-renderers';
+import {
+  stringTester,
+  TextField,
+  selectTester,
+  Selector,
+  groupTester,
+  Group,
+  labelTester,
+  Label,
+  dateTester,
+  Date,
+  arrayTester,
+  Array,
+} from './components';
+
+export type JsonData = {
+  [key: string]: string | number | boolean | null | unknown | JsonData;
+};
+
+interface JsonFormProps {
+  data?: JsonData;
+  documentRegistry: Pick<
+    DocumentRegistryFragment,
+    'formSchemaId' | 'jsonSchema' | 'uiSchema'
+  >;
+  isError: boolean;
+  isLoading: boolean;
+  setError: (error: string | false) => void;
+  updateData: (newData: JsonData) => void;
+}
+
+interface JsonFormsComponentProps {
+  data: JsonData;
+  jsonSchema: JsonSchema;
+  uiSchema: UISchemaElement;
+  setData: (data: JsonData) => void;
+  setError: (error: string | false) => void;
+  renderers: JsonFormsRendererRegistryEntry[];
+}
+
+// Prevents Form window being loaded with the same scroll position as its parent
+const ScrollFix = () => {
+  useEffect(() => {
+    document.getElementById('document-display')?.scrollIntoView();
+  }, []);
+  return null;
+};
+
+const FormComponent = ({
+  data,
+  jsonSchema,
+  uiSchema,
+  setData,
+  setError,
+  renderers,
+}: JsonFormsComponentProps) => {
+  return (
+    <JsonForms
+      schema={jsonSchema}
+      uischema={uiSchema}
+      data={data}
+      renderers={renderers}
+      // cells={materialCells}
+      onChange={({ errors, data }) => {
+        setData(data);
+        if (errors && errors.length) {
+          setError(errors?.map(({ message }) => message ?? '').join(', '));
+          console.warn('Errors: ', errors);
+        } else {
+          setError(false);
+        }
+      }}
+    />
+  );
+};
+
+const renderers = [
+  // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
+  ...materialRenderers,
+  { tester: stringTester, renderer: TextField },
+  { tester: selectTester, renderer: Selector },
+  { tester: groupTester, renderer: Group },
+  { tester: labelTester, renderer: Label },
+  { tester: dateTester, renderer: Date },
+  { tester: arrayTester, renderer: Array },
+];
+
+export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
+  children,
+  data,
+  documentRegistry,
+  isError,
+  isLoading,
+  setError,
+  updateData,
+}) => {
+  const t = useTranslation('common');
+
+  if (isError)
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        width="100%"
+        gap={2}
+      >
+        <UnhappyMan />
+        <Typography color="error">{t('error.unable-to-load-data')}</Typography>
+      </Box>
+    );
+
+  return (
+    <Box
+      id="document-display"
+      display="flex"
+      flexDirection="column"
+      justifyContent={!data ? 'flex-end' : 'flex-start'}
+      alignItems="center"
+      width="100%"
+      gap={2}
+      paddingX={10}
+    >
+      <ScrollFix />
+      {isLoading || !data ? (
+        <BasicSpinner inline />
+      ) : (
+        <FormComponent
+          data={data}
+          jsonSchema={documentRegistry.jsonSchema}
+          uiSchema={documentRegistry.uiSchema}
+          setData={updateData}
+          setError={setError}
+          renderers={renderers}
+        />
+      )}
+      {children}
+    </Box>
+  );
+};

--- a/client/packages/common/src/ui/forms/JsonForms/components/Array.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Array.tsx
@@ -31,7 +31,7 @@ import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
 } from '../styleConstants';
-import { JsonData } from '../useJsonForms';
+import { JsonData } from '../JsonForm';
 
 interface UISchemaWithCustomProps extends ControlElement {
   defaultNewItem?: JsonData;

--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
 import { ControlProps, rankWith, schemaTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { DetailInputWithLabelRow } from '@openmsupply-client/common';
+import {
+  DetailInputWithLabelRow,
+  useDebounceCallback,
+} from '@openmsupply-client/common';
 
 export const stringTester = rankWith(3, schemaTypeIs('string'));
 
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path } = props;
   const [localData, setLocalData] = useState<string>(data);
+  const onChange = useDebounceCallback(
+    (value: string) => handleChange(path, value),
+    [path]
+  );
   return (
     <DetailInputWithLabelRow
       label={label}
@@ -16,8 +23,8 @@ const UIComponent = (props: ControlProps) => {
         sx: { margin: 0.5, width: '100%' },
         onChange: e => {
           setLocalData(e.target.value);
+          onChange(e.target.value);
         },
-        onBlur: () => handleChange(path, localData),
         disabled: !props.enabled,
         error: !!props.errors,
       }}

--- a/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
@@ -145,10 +145,11 @@ export const useJsonForms = (
   const navigate = useNavigate();
 
   // fetch document (only if there is as document name)
-  const { data: databaseResponse, isLoading } = useDocument.get.document(
-    documentName ?? '',
-    !!documentName
-  );
+  const {
+    data: databaseResponse,
+    isLoading,
+    isError,
+  } = useDocument.get.document(documentName ?? '', !!documentName);
   useEffect(() => {
     if (!databaseResponse) return;
 
@@ -270,45 +271,48 @@ export const useJsonForms = (
     </Box>
   );
 
-  const JsonForm = !!data ? (
-    <Box
-      id="document-display"
-      display="flex"
-      flexDirection="column"
-      justifyContent="flex-start"
-      alignItems="center"
-      width="100%"
-      gap={2}
-      paddingX={10}
-    >
-      <ScrollFix />
-      {isLoading ? (
-        <BasicSpinner />
-      ) : (
-        <FormComponent
-          data={data}
-          jsonSchema={documentRegistry.jsonSchema}
-          uiSchema={documentRegistry.uiSchema}
-          setData={updateData}
-          setError={setError}
-          renderers={renderers}
-        />
-      )}
-      {showButtonPanel && <ButtonPanel />}
-    </Box>
-  ) : (
-    <Box
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-      width="100%"
-      gap={2}
-    >
-      <UnhappyMan />
-      <Typography color="error">{t('error.unable-to-load-data')}</Typography>
-    </Box>
-  );
+  const JsonForm =
+    //  isLoading || !!data ? (
+    isError ? (
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        width="100%"
+        gap={2}
+      >
+        <UnhappyMan />
+        <Typography color="error">{t('error.unable-to-load-data')}</Typography>
+      </Box>
+    ) : (
+      <Box
+        id="document-display"
+        display="flex"
+        flexDirection="column"
+        justifyContent={!data ? 'flex-end' : 'flex-start'}
+        alignItems="center"
+        width="100%"
+        gap={2}
+        paddingX={10}
+      >
+        <ScrollFix />
+        {isLoading || !data ? (
+          <BasicSpinner />
+        ) : (
+          <FormComponent
+            data={data}
+            jsonSchema={documentRegistry.jsonSchema}
+            uiSchema={documentRegistry.uiSchema}
+            setData={updateData}
+            setError={setError}
+            renderers={renderers}
+          />
+        )}
+        {showButtonPanel && <ButtonPanel />}
+      </Box>
+      // ) : (
+    );
 
   return {
     JsonForm,

--- a/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from '@openmsupply-client/common';
+import {
+  Typography,
+  UnhappyMan,
+  useNavigate,
+} from '@openmsupply-client/common';
 import {
   Box,
   DialogButton,
@@ -250,13 +254,14 @@ export const useJsonForms = (
           else onCancel();
         }}
         isLoading={saving}
-        disabled={error !== false}
+        disabled={error !== false || isLoading}
         color="secondary"
       >
         {t('button.save')}
       </LoadingButton>
       <DialogButton
         variant="cancel"
+        disabled={isLoading}
         onClick={() => {
           if (isDirty) showCancelConfirmation();
           else onCancel();
@@ -265,34 +270,48 @@ export const useJsonForms = (
     </Box>
   );
 
+  const JsonForm = !!data ? (
+    <Box
+      id="document-display"
+      display="flex"
+      flexDirection="column"
+      justifyContent="flex-start"
+      alignItems="center"
+      width="100%"
+      gap={2}
+      paddingX={10}
+    >
+      <ScrollFix />
+      {isLoading ? (
+        <BasicSpinner />
+      ) : (
+        <FormComponent
+          data={data}
+          jsonSchema={documentRegistry.jsonSchema}
+          uiSchema={documentRegistry.uiSchema}
+          setData={updateData}
+          setError={setError}
+          renderers={renderers}
+        />
+      )}
+      {showButtonPanel && <ButtonPanel />}
+    </Box>
+  ) : (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      width="100%"
+      gap={2}
+    >
+      <UnhappyMan />
+      <Typography color="error">{t('error.unable-to-load-data')}</Typography>
+    </Box>
+  );
+
   return {
-    JsonForm: (
-      <Box
-        id="document-display"
-        display="flex"
-        flexDirection="column"
-        justifyContent="flex-start"
-        alignItems="center"
-        width="100%"
-        gap={2}
-        paddingX={10}
-      >
-        <ScrollFix />
-        {isLoading || !data ? (
-          <BasicSpinner />
-        ) : (
-          <FormComponent
-            data={data}
-            jsonSchema={documentRegistry.jsonSchema}
-            uiSchema={documentRegistry.uiSchema}
-            setData={updateData}
-            setError={setError}
-            renderers={renderers}
-          />
-        )}
-        {showButtonPanel && !isLoading && <ButtonPanel />}
-      </Box>
-    ),
+    JsonForm,
     saveData,
     loading: isLoading,
     error,

--- a/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/useJsonForms.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Typography,
-  UnhappyMan,
-  useNavigate,
-} from '@openmsupply-client/common';
+import { RouteBuilder, useNavigate } from '@openmsupply-client/common';
 import {
   Box,
   DialogButton,
@@ -12,80 +8,13 @@ import {
   useTranslation,
   useNotification,
   useConfirmOnLeaving,
-  BasicSpinner,
 } from '@openmsupply-client/common';
-import { JsonForms } from '@jsonforms/react';
-import {
-  JsonFormsRendererRegistryEntry,
-  JsonSchema,
-  UISchemaElement,
-} from '@jsonforms/core';
-import { materialRenderers } from '@jsonforms/material-renderers';
-import {
-  stringTester,
-  TextField,
-  selectTester,
-  Selector,
-  groupTester,
-  Group,
-  labelTester,
-  Label,
-  dateTester,
-  Date,
-  arrayTester,
-  Array,
-} from './components';
+import { JsonSchema, UISchemaElement } from '@jsonforms/core';
+
 import { useDocument } from './api';
 import { DocumentRegistryFragment } from './api/operations.generated';
-
-export type JsonData = {
-  [key: string]: string | number | boolean | null | unknown | JsonData;
-};
-
-interface JsonFormsComponentProps {
-  data: JsonData;
-  jsonSchema: JsonSchema;
-  uiSchema: UISchemaElement;
-  setData: (data: JsonData) => void;
-  setError: (error: string | false) => void;
-  renderers: JsonFormsRendererRegistryEntry[];
-}
-
-const FormComponent = ({
-  data,
-  jsonSchema,
-  uiSchema,
-  setData,
-  setError,
-  renderers,
-}: JsonFormsComponentProps) => {
-  return (
-    <JsonForms
-      schema={jsonSchema}
-      uischema={uiSchema}
-      data={data}
-      renderers={renderers}
-      // cells={materialCells}
-      onChange={({ errors, data }) => {
-        setData(data);
-        if (errors && errors.length) {
-          setError(errors?.map(({ message }) => message ?? '').join(', '));
-          console.warn('Errors: ', errors);
-        } else {
-          setError(false);
-        }
-      }}
-    />
-  );
-};
-
-// Prevents Form window being loaded with the same scroll position as its parent
-const ScrollFix = () => {
-  useEffect(() => {
-    document.getElementById('document-display')?.scrollIntoView();
-  }, []);
-  return null;
-};
+import { JsonData, JsonForm } from './JsonForm';
+import { AppRoute } from '@openmsupply-client/config';
 
 export type SavedDocument = {
   id: string;
@@ -112,7 +41,7 @@ interface JsonFormOptions {
  * Information required to create a new document
  */
 export interface CreateDocument {
-  data: any;
+  data: JsonData;
   documentRegistry: DocumentRegistryFragment;
 }
 
@@ -126,7 +55,6 @@ export const useJsonForms = (
   const [documentId, setDocumentId] = useState<string | undefined>();
   // document name can change from the input parameter when creating a new document
   const [documentName, setDocumentName] = useState<string | undefined>(docName);
-
   const [documentRegistry, setDocumentRegistry] = useState<{
     formSchemaId: string;
     jsonSchema: JsonSchema;
@@ -150,6 +78,82 @@ export const useJsonForms = (
     isLoading,
     isError,
   } = useDocument.get.document(documentName ?? '', !!documentName);
+
+  const {
+    showButtonPanel = true,
+    onCancel = () => navigate(RouteBuilder.create(AppRoute.Patients).build()),
+    saveConfirmationMessage = t('messages.confirm-save-generic'),
+    cancelConfirmationMessage = t('messages.confirm-cancel-generic'),
+    saveSuccessMessage = t('success.data-saved'),
+  } = options;
+
+  useConfirmOnLeaving(isDirty);
+
+  const saveData = async () => {
+    if (data === undefined) {
+      return;
+    }
+    setSaving(true);
+
+    // Run mutation...
+    try {
+      const result = await options.handleSave?.(
+        data,
+        documentRegistry.formSchemaId,
+        documentId
+      );
+
+      setDocumentName(result?.name);
+      setIsDirty(false);
+
+      const successSnack = success(saveSuccessMessage);
+      successSnack();
+    } catch (err) {
+      const errorSnack = errorNotification(t('error.problem-saving'));
+      errorSnack();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateData = (newData: JsonData) => {
+    setIsDirty(isDirty === undefined ? false : true);
+    setData(newData);
+  };
+
+  const showSaveConfirmation = useConfirmationModal({
+    onConfirm: saveData,
+    message: saveConfirmationMessage,
+    title: t('heading.are-you-sure'),
+  });
+
+  const showCancelConfirmation = useConfirmationModal({
+    onConfirm: onCancel,
+    message: cancelConfirmationMessage,
+    title: t('heading.are-you-sure'),
+  });
+
+  const ButtonPanel = () => (
+    <Box id="button-panel" paddingBottom={5} display="flex" gap={5}>
+      <LoadingButton
+        onClick={() => showSaveConfirmation()}
+        isLoading={saving}
+        disabled={error !== false || isLoading || !isDirty}
+        color="secondary"
+      >
+        {t('button.save')}
+      </LoadingButton>
+      <DialogButton
+        variant="cancel"
+        disabled={isLoading}
+        onClick={() => {
+          if (isDirty) showCancelConfirmation();
+          else onCancel();
+        }}
+      />
+    </Box>
+  );
+
   useEffect(() => {
     if (!databaseResponse) return;
 
@@ -181,141 +185,19 @@ export const useJsonForms = (
     }
   }, [createDoc]);
 
-  const {
-    showButtonPanel = true,
-    onCancel = () => navigate(-1),
-    saveConfirmationMessage = t('messages.confirm-save-generic'),
-    cancelConfirmationMessage = t('messages.confirm-cancel-generic'),
-    saveSuccessMessage = t('success.data-saved'),
-  } = options;
-
-  useConfirmOnLeaving(isDirty);
-
-  const updateData = (newData: JsonData) => {
-    setIsDirty(isDirty === undefined ? false : true);
-    setData(newData);
-  };
-
-  const saveData = async () => {
-    if (data === undefined) {
-      return;
-    }
-    setSaving(true);
-    console.log('Saving data...');
-
-    // Run mutation...
-    try {
-      const result = await options.handleSave?.(
-        data,
-        documentRegistry.formSchemaId,
-        documentId
-      );
-
-      setDocumentName(result?.name);
-      setIsDirty(false);
-
-      const successSnack = success(saveSuccessMessage);
-      successSnack();
-    } catch (err) {
-      const errorSnack = errorNotification(t('error.problem-saving'));
-      errorSnack();
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const renderers = [
-    // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
-    ...materialRenderers,
-    { tester: stringTester, renderer: TextField },
-    { tester: selectTester, renderer: Selector },
-    { tester: groupTester, renderer: Group },
-    { tester: labelTester, renderer: Label },
-    { tester: dateTester, renderer: Date },
-    { tester: arrayTester, renderer: Array },
-  ];
-
-  const showSaveConfirmation = useConfirmationModal({
-    onConfirm: saveData,
-    message: saveConfirmationMessage,
-    title: t('heading.are-you-sure'),
-  });
-
-  const showCancelConfirmation = useConfirmationModal({
-    onConfirm: onCancel,
-    message: cancelConfirmationMessage,
-    title: t('heading.are-you-sure'),
-  });
-
-  const ButtonPanel = () => (
-    <Box id="button-panel" paddingBottom={5} display="flex" gap={5}>
-      <LoadingButton
-        onClick={() => {
-          if (isDirty) showSaveConfirmation();
-          else onCancel();
-        }}
-        isLoading={saving}
-        disabled={error !== false || isLoading}
-        color="secondary"
-      >
-        {t('button.save')}
-      </LoadingButton>
-      <DialogButton
-        variant="cancel"
-        disabled={isLoading}
-        onClick={() => {
-          if (isDirty) showCancelConfirmation();
-          else onCancel();
-        }}
-      />
-    </Box>
-  );
-
-  const JsonForm =
-    //  isLoading || !!data ? (
-    isError ? (
-      <Box
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        alignItems="center"
-        width="100%"
-        gap={2}
-      >
-        <UnhappyMan />
-        <Typography color="error">{t('error.unable-to-load-data')}</Typography>
-      </Box>
-    ) : (
-      <Box
-        id="document-display"
-        display="flex"
-        flexDirection="column"
-        justifyContent={!data ? 'flex-end' : 'flex-start'}
-        alignItems="center"
-        width="100%"
-        gap={2}
-        paddingX={10}
-      >
-        <ScrollFix />
-        {isLoading || !data ? (
-          <BasicSpinner />
-        ) : (
-          <FormComponent
-            data={data}
-            jsonSchema={documentRegistry.jsonSchema}
-            uiSchema={documentRegistry.uiSchema}
-            setData={updateData}
-            setError={setError}
-            renderers={renderers}
-          />
-        )}
-        {showButtonPanel && <ButtonPanel />}
-      </Box>
-      // ) : (
-    );
-
   return {
-    JsonForm,
+    JsonForm: (
+      <JsonForm
+        data={data}
+        documentRegistry={documentRegistry}
+        isError={isError}
+        isLoading={isLoading}
+        setError={setError}
+        updateData={updateData}
+      >
+        {showButtonPanel && <ButtonPanel />}
+      </JsonForm>
+    ),
     saveData,
     loading: isLoading,
     error,


### PR DESCRIPTION
Fixes #371 

To make the form submission nicer to use, I've swapped out the `onBlur` for a debounced update. I like it better 🤷 
To make the PR much harder to read, I've refactored the hook - that file was too large for my taste and was doing too many things. I've lifted out the majority of the JSX into a new component.

Also disabled the save button when there's nothing to save, as it was, you clicked `Save` and it closed the form without saving. Minor thing, but that means the button doesn't say what it does.

Another minor tweak - have changed the cancel method; that was navigating back one, which was odd when you were on a page and then updated the URL to navigate to a patient. I've changed to an explicit navigate back to the list, as that is the expectation, I think.

When I first hit the patient page, I got this:
<img width="1112" alt="Screen Shot 2022-07-26 at 5 06 21 PM" src="https://user-images.githubusercontent.com/9192912/181121680-85b228a7-12b5-4630-aa47-201f62f7e137.png">

which is because I was in a store which had no documents.. thus:

![Screen Shot 2022-07-26 at 5 10 32 PM](https://user-images.githubusercontent.com/9192912/181121704-597fd447-ba5e-436c-be73-183592747685.png)

The layout wasn't pretty enough for me, so I've changed it to this:

<img width="1276" alt="Screen Shot 2022-07-26 at 5 25 12 PM" src="https://user-images.githubusercontent.com/9192912/181121748-087d1f36-2eba-47b6-aa3b-2b141d699f06.png">

and in doing so have also changed the behaviour slightly of when the buttons show - and have them disabled when loading, and put them at the bottom of the screen, below the loader.


## Tests

- [x] edit text in a Text input and click `Save`: should prompt on first click
- [x] observe that the `Save` button is disabled initially and is enabled once a change is made
- [x] edit text in a Text input with the `Save` button in view: observe that without leaving the field the button is enabled
- [x] change a date field: observe that `Save` is enabled
- [x] change a checkbox field: observe that `Save` is enabled
- [x] change a select field: observe that `Save` is enabled
- [ ] Navigate to a patient when in the wrong store ( you'll have to figure that one out! ): should get a nicely formatted error
- [ ] From the dashboard, enter the URL of a patient, click `Cancel`: should get to the patient list view