### PR TITLE
Fix the navigation history

### DIFF
--- a/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
+++ b/client/packages/common/src/hooks/useUrlQuery/useUrlQuery.ts
@@ -23,7 +23,7 @@ export const useUrlQuery = ({ skipParse = [] }: useUrlQueryProps = {}) => {
       else newQueryObject[key] = String(value);
     });
 
-    setSearchParams(newQueryObject);
+    setSearchParams(newQueryObject, { replace: true });
   };
 
   return {


### PR DESCRIPTION
Closes #397 

The trade off is that the sort history isn't logged as separate navigation - so you cannot sort by column a, then column b, then go 'Back' and show the list sorted by column a.

Without the change you can navigate to the previous sort option, but then to get back to the list view you need to be very, very patient and click many times.

Exhibit A:
<img width="326" alt="Screen Shot 2022-07-28 at 1 00 21 PM" src="https://user-images.githubusercontent.com/9192912/181397981-5c946f8e-b524-461f-b804-209fbee791f5.png">


## Tests

- [ ] Go to outbounds, click on an outbound. Click 'back' in the browser: should go back to the list