### PR TITLE
368 more std json forms controls

### DIFF
--- a/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
@@ -13,6 +13,8 @@ import {
 } from '@jsonforms/core';
 import { materialRenderers } from '@jsonforms/material-renderers';
 import {
+  BooleanField,
+  booleanTester,
   stringTester,
   TextField,
   selectTester,
@@ -91,6 +93,7 @@ const FormComponent = ({
 const renderers = [
   // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
   ...materialRenderers,
+  { tester: booleanTester, renderer: BooleanField },
   { tester: stringTester, renderer: TextField },
   { tester: selectTester, renderer: Selector },
   { tester: groupTester, renderer: Group },

--- a/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { rankWith, isBooleanControl, ControlProps } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import { FormLabel, Box } from '@mui/material';
+import { Switch, useDebounceCallback } from '@openmsupply-client/common';
+import {
+  FORM_LABEL_COLUMN_WIDTH,
+  FORM_INPUT_COLUMN_WIDTH,
+} from '../styleConstants';
+
+export const booleanTester = rankWith(4, isBooleanControl);
+
+const UIComponent = (props: ControlProps) => {
+  const { data, handleChange, label, path } = props;
+  const [localData, setLocalData] = useState<boolean | undefined>(data);
+  const onChange = useDebounceCallback(
+    (value: boolean) => handleChange(path, value),
+    [path]
+  );
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={2}
+      justifyContent="space-around"
+      style={{ minWidth: 300 }}
+      marginTop={0.5}
+    >
+      <Box
+        flex={1}
+        style={{ textAlign: 'end' }}
+        flexBasis={FORM_LABEL_COLUMN_WIDTH}
+      >
+        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+      </Box>
+      <Box flex={1} flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+        <Switch
+          onChange={(_, checked) => {
+            setLocalData(checked);
+            onChange(checked);
+          }}
+          value={localData}
+          checked={localData}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const BooleanField = withJsonFormsControlProps(UIComponent);

--- a/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
@@ -35,6 +35,7 @@ const UIComponent = (props: ControlProps) => {
       </Box>
       <Box flex={1} flexBasis={FORM_INPUT_COLUMN_WIDTH}>
         <Switch
+          labelPlacement="end"
           onChange={(_, checked) => {
             setLocalData(checked);
             onChange(checked);

--- a/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Boolean.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { rankWith, isBooleanControl, ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { FormLabel, Box } from '@mui/material';
-import { Switch, useDebounceCallback } from '@openmsupply-client/common';
+import { Switch } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
@@ -12,11 +12,7 @@ export const booleanTester = rankWith(4, isBooleanControl);
 
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path } = props;
-  const [localData, setLocalData] = useState<boolean | undefined>(data);
-  const onChange = useDebounceCallback(
-    (value: boolean) => handleChange(path, value),
-    [path]
-  );
+
   return (
     <Box
       display="flex"
@@ -37,11 +33,10 @@ const UIComponent = (props: ControlProps) => {
         <Switch
           labelPlacement="end"
           onChange={(_, checked) => {
-            setLocalData(checked);
-            onChange(checked);
+            handleChange(path, checked);
           }}
-          value={localData}
-          checked={localData}
+          value={data}
+          checked={data}
         />
       </Box>
     </Box>

--- a/client/packages/common/src/ui/forms/JsonForms/components/index.ts
+++ b/client/packages/common/src/ui/forms/JsonForms/components/index.ts
@@ -4,3 +4,4 @@ export * from './Text';
 export * from './Select';
 export * from './Date';
 export * from './Array';
+export * from './Boolean';


### PR DESCRIPTION
Partly fixes https://github.com/openmsupply/open-msupply/issues/368 by adding a boolean switch control.

Integer control will be added later when needed (currently not in the current schema)