### PR TITLE
App height on mobile

### DIFF
--- a/client/packages/common/src/styles/RTLProvider.tsx
+++ b/client/packages/common/src/styles/RTLProvider.tsx
@@ -8,7 +8,7 @@ export const RTLProvider: FC<PropsWithChildrenOnly> = props => {
   return (
     <div
       style={{
-        height: '100vh',
+        height: '100%',
         width: '100vw',
         display: 'flex',
         flexDirection: 'column',

--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -206,6 +206,7 @@ export const themeOptions = {
     },
   },
 };
+
 export const createTheme = (themeOptions: ThemeOptions) => {
   const theme = createMuiTheme(themeOptions);
 
@@ -217,4 +218,3 @@ export const createTheme = (themeOptions: ThemeOptions) => {
     '0 8px 16px 0 rgba(96, 97, 112, 0.16), 0 2px 4px 0 rgba(40, 41, 61, 0.04)';
   return theme;
 };
-// export default theme;

--- a/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -42,7 +42,7 @@ const StyledDrawer = styled(Box, {
 })<{ isOpen: boolean }>(({ isOpen, theme }) => ({
   backgroundColor: theme.palette.background.menu,
   borderRadius: 8,
-  height: '100vh',
+  height: '100%',
   overflow: 'hidden',
   zIndex: theme.zIndex.drawer,
   boxShadow: theme.shadows[7],

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -97,7 +97,7 @@ const StyledDrawer = styled(Box, {
 })<{ isOpen: boolean }>(({ isOpen, theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  height: '100vh',
+  height: '100%',
   borderRadius: '0 8px 8px 0',
   overflow: 'hidden',
   boxShadow: theme.shadows[7],

--- a/client/packages/host/src/components/NotFound.tsx
+++ b/client/packages/host/src/components/NotFound.tsx
@@ -16,7 +16,7 @@ export const NotFound: React.FC = () => {
       flexDirection="column"
       justifyContent="center"
       alignContent="center"
-      sx={{ height: '100vh' }}
+      sx={{ height: '100%' }}
     >
       <Grid item display="flex" justifyContent="center">
         <Grow in timeout={1000}>

--- a/client/packages/host/src/components/Viewport.tsx
+++ b/client/packages/host/src/components/Viewport.tsx
@@ -1,26 +1,45 @@
-import React from 'react';
-import { GlobalStyles, CssBaseline } from '@openmsupply-client/common';
+import React, { useEffect, useState } from 'react';
+import {
+  GlobalStyles,
+  CssBaseline,
+  EnvUtils,
+  Platform,
+} from '@openmsupply-client/common';
 import { PropsWithChildrenOnly } from '@common/types';
 
-const globalStyles = {
-  '*:-webkit-full-screen': {
-    height: '100%',
-    width: '100%',
-  },
-  '#root': {
-    height: '100vh',
-    width: '100vw',
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  html: { position: 'fixed' },
-  'html, body': {
-    height: '100%',
-    width: '100%',
-  },
-} as const;
+// there is an issue on mobile devices when using viewport units (e.g. vh)
+// "Using vh will size the element as if the URL bar is always hidden while using % will size the element as if the URL bar were always showing."
+// the result is that using `100vh` on mobile devices will give you a greater height than is visible, and the bottom of the page will be cut off
+const getHeight = () =>
+  EnvUtils.platform === Platform.Android ? `${window.innerHeight}px` : '100vh';
 
 export const Viewport: React.FC<PropsWithChildrenOnly> = props => {
+  const [height, setHeight] = useState(getHeight());
+  const handleResize = () => setHeight(getHeight());
+
+  const globalStyles = {
+    '*:-webkit-full-screen': {
+      height: '100%',
+      width: '100%',
+    },
+    '#root': {
+      height,
+      width: '100vw',
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    html: { position: 'fixed' },
+    'html, body': {
+      height: '100%',
+      width: '100%',
+    },
+  } as const;
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
     <React.Fragment>
       <GlobalStyles styles={globalStyles} {...props} />


### PR DESCRIPTION
Fixes #412 

Have removed the unnecessary usages of `vh` as a css unit and in the single instance where it is still required, have used `window.innerHeight` instead.  

Also added a resize listener so that you can rotate the tablet without the app height going strange.