### PR TITLE
Add a configurable ID generator control

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -112,6 +112,7 @@
   "label.first-name": "First name",
   "label.last-name": "Last name",
   "label.gender": "Gender",
+  "label.generate": "Generate",
   "label.enrolment-program": "Program",
   "label.enrolment-patient-id": "Enrolment Patient Id",
   "label.enrolment-datetime": "Enrolment Date",

--- a/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
@@ -31,6 +31,8 @@ import {
   Array,
   FirstItemArray,
   firstItemArrayTester,
+  idGeneratorTester,
+  IdGenerator,
 } from './components';
 
 export type JsonData = {
@@ -106,6 +108,7 @@ const renderers = [
   { tester: dateOfBirthTester, renderer: DateOfBirth },
   { tester: arrayTester, renderer: Array },
   { tester: firstItemArrayTester, renderer: FirstItemArray },
+  { tester: idGeneratorTester, renderer: IdGenerator },
 ];
 
 export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({

--- a/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
@@ -6,7 +6,11 @@ import {
   uiTypeIs,
 } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { BasicTextInput, Box } from '@openmsupply-client/common';
+import {
+  BasicTextInput,
+  Box,
+  useTranslation,
+} from '@openmsupply-client/common';
 import { Button, FormLabel } from '@mui/material';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -52,7 +56,10 @@ const validateFields = (
   }
 };
 
-const generateId = (options: GeneratorOptions, data: Record<string, unknown>): string => {
+const generateId = (
+  options: GeneratorOptions,
+  data: Record<string, unknown>
+): string => {
   let output = '';
   for (const part of options.parts ?? []) {
     const field = extractField(data, part.field);
@@ -82,29 +89,28 @@ const generateId = (options: GeneratorOptions, data: Record<string, unknown>): s
 };
 
 const UIComponent = (props: ControlProps) => {
-  const { label } = props;
-  const options = props.uischema.options as GeneratorOptions | undefined;
+  const { label, path, data, visible, handleChange, uischema } = props;
+  const t = useTranslation('common');
+  const options = uischema.options as GeneratorOptions | undefined;
   const generate = useCallback(() => {
     if (!options) {
       return;
     }
     const id = generateId(options, props.data);
-    const path = composePaths(props.path, options?.targetField);
-    props.handleChange(path, id);
-  }, [options, props.path, props.data]);
+    const fullPath = composePaths(path, options?.targetField);
+    handleChange(fullPath, id);
+  }, [options, path, data, handleChange]);
 
-  const value = options?.targetField
-    ? props.data[options?.targetField]
-    : undefined;
+  const value = options?.targetField ? data[options?.targetField] : undefined;
 
   const error = useMemo(() => {
     if (!options) {
       return;
     }
-    return validateFields(options, props.data);
-  }, [options, props.data, value]);
+    return validateFields(options, data);
+  }, [options, data, value]);
 
-  if (!props.visible) {
+  if (!visible) {
     return null;
   }
   return (
@@ -134,7 +140,7 @@ const UIComponent = (props: ControlProps) => {
 
         <Box flex={0}>
           <Button disabled={!!error} onClick={generate} variant="outlined">
-            Generate
+            {t('label.generate')}
           </Button>
         </Box>
       </Box>

--- a/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
@@ -52,7 +52,7 @@ const validateFields = (
   }
 };
 
-const generateId = (options: GeneratorOptions, data: any): string => {
+const generateId = (options: GeneratorOptions, data: Record<string, unknown>): string => {
   let output = '';
   for (const part of options.parts ?? []) {
     const field = extractField(data, part.field);

--- a/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
@@ -133,7 +133,7 @@ const UIComponent = (props: ControlProps) => {
         <BasicTextInput disabled={true} value={value} />
 
         <Box flex={0}>
-          <Button disabled={!!error} onClick={generate}>
+          <Button disabled={!!error} onClick={generate} variant="outlined">
             Generate
           </Button>
         </Box>

--- a/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  composePaths,
+  ControlProps,
+  rankWith,
+  uiTypeIs,
+} from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import { BasicTextInput, Box } from '@openmsupply-client/common';
+import { Button, FormLabel } from '@mui/material';
+import {
+  FORM_LABEL_COLUMN_WIDTH,
+  FORM_INPUT_COLUMN_WIDTH,
+} from '../styleConstants';
+
+export const idGeneratorTester = rankWith(4, uiTypeIs('IdGeneratorControl'));
+
+type GeneratorOptions = {
+  targetField: string;
+  parts: Part[];
+};
+
+type Part = {
+  field: string | string[];
+  firstNChars?: number;
+  lastNChars?: number;
+  toUpperCase?: boolean;
+  enumMapping?: Record<string, string>;
+};
+
+const extractField = (
+  data: any,
+  field: string | string[]
+): unknown | undefined => {
+  const fields = typeof field === 'string' ? [field] : field;
+  return fields.reduce((prev, field) => {
+    return prev?.[field];
+  }, data);
+};
+
+const validateFields = (
+  options: GeneratorOptions,
+  data: any
+): string | undefined => {
+  for (const part of options.parts ?? []) {
+    const field = extractField(data, part.field);
+    const fieldName =
+      typeof part.field === 'string' ? part.field : part.field.join('.');
+    if (field === undefined || typeof field !== 'string' || field === '') {
+      return `Missing required field: ${fieldName}`;
+    }
+  }
+};
+
+const generateId = (options: GeneratorOptions, data: any): string => {
+  let output = '';
+  for (const part of options.parts ?? []) {
+    const field = extractField(data, part.field);
+    if (field === undefined || typeof field !== 'string') {
+      continue;
+    }
+    let strPart = field;
+    if (part.enumMapping) {
+      const replacement = part.enumMapping[strPart];
+      if (replacement !== undefined) {
+        strPart = replacement;
+      }
+    }
+    if (part.firstNChars !== undefined) {
+      strPart = field.slice(0, part.firstNChars);
+    }
+    if (part.lastNChars !== undefined) {
+      strPart = field.slice(field.length - part.lastNChars);
+    }
+    if (part.toUpperCase) {
+      strPart = strPart.toLocaleUpperCase();
+    }
+
+    output += strPart;
+  }
+  return output;
+};
+
+const UIComponent = (props: ControlProps) => {
+  const { label } = props;
+  const options = props.uischema.options as GeneratorOptions | undefined;
+  const generate = useCallback(() => {
+    if (!options) {
+      return;
+    }
+    const id = generateId(options, props.data);
+    const path = composePaths(props.path, options?.targetField);
+    props.handleChange(path, id);
+  }, [options, props.path, props.data]);
+
+  const value = options?.targetField
+    ? props.data[options?.targetField]
+    : undefined;
+
+  const error = useMemo(() => {
+    if (!options) {
+      return;
+    }
+    return validateFields(options, props.data);
+  }, [options, props.data, value]);
+
+  if (!props.visible) {
+    return null;
+  }
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={2}
+      justifyContent="space-around"
+      style={{ minWidth: 300 }}
+      marginTop={1}
+    >
+      <Box
+        flex={1}
+        style={{ textAlign: 'end' }}
+        flexBasis={FORM_LABEL_COLUMN_WIDTH}
+      >
+        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+      </Box>
+      <Box
+        flex={1}
+        flexBasis={FORM_INPUT_COLUMN_WIDTH}
+        display="flex"
+        alignItems="center"
+        gap={2}
+      >
+        <BasicTextInput disabled={true} value={value} />
+
+        <Box flex={0}>
+          <Button disabled={!!error} onClick={generate}>
+            Generate
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export const IdGenerator = withJsonFormsControlProps(UIComponent);

--- a/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/IdGenerator.tsx
@@ -40,7 +40,7 @@ const extractField = (
 
 const validateFields = (
   options: GeneratorOptions,
-  data: any
+  data: Record<string, unknown>
 ): string | undefined => {
   for (const part of options.parts ?? []) {
     const field = extractField(data, part.field);

--- a/client/packages/common/src/ui/forms/JsonForms/components/index.ts
+++ b/client/packages/common/src/ui/forms/JsonForms/components/index.ts
@@ -7,3 +7,4 @@ export * from './DateOfBirth';
 export * from './Array';
 export * from './FirstItemArray';
 export * from './Boolean';
+export * from './IdGenerator';

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -24,9 +24,52 @@
                   }
                 },
                 {
-                  "type": "Control",
+                  "type": "IdGeneratorControl",
                   "label": "NUIC",
-                  "scope": "#/properties/code"
+                  "scope": "#/",
+                  "options": {
+                    "targetField": "code",
+                    "parts": [
+                      {
+                        "field": "lastName",
+                        "firstNChars": 2,
+                        "toUpperCase": true
+                      },
+                      {
+                        "field": ["birthPlace", "district"],
+                        "firstNChars": 2,
+                        "toUpperCase": true
+                      },
+                      {
+                        "field": "hand",
+                        "enumMapping": {
+                          "LEFT": "L",
+                          "RIGHT": "R"
+                        }
+                      },
+                      {
+                        "field": "birthOrder",
+                        "firstNChars": 2,
+                        "toUpperCase": true
+                      },
+                      {
+                        "field": "gender",
+                        "enumMapping": {
+                          "MALE": "1",
+                          "FEMALE": "2",
+                          "TRANSGENDER_MALE": "3",
+                          "TRANSGENDER_FEMALE": "3",
+                          "UNKNOWN": "3",
+                          "NON_BINARY": "3"
+                        }
+                      },
+                      {
+                        "field": "firstName",
+                        "lastNChars": 2,
+                        "toUpperCase": true
+                      }
+                    ]
+                  }
                 },
                 {
                   "type": "Control",


### PR DESCRIPTION
Add a configurable control to generate an id. Haven't polished it too much since I like to get some feedback from @richardmoizeau first.

@CarlosNZ would your lib help here?

To test:
- delete existing DB file and resync (or [omsupply-database.zip](https://github.com/openmsupply/open-msupply/files/9245678/omsupply-database.zip) )
- select a patient and fill hand and birth order
- Generate button should no be enabled and you can generate the specialized it

Future work: to generate a program enrolment id we would add access to the store name and to a backend managed program enrolment counter

Closes #433 