### PR TITLE
tooltip for datarow

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -26,6 +26,7 @@ const DataTableComponent = <T extends RecordWithId>({
   data = [],
   dense = false,
   enableColumnSelection,
+  generateRowTooltip = () => '',
   isDisabled = false,
   isError = false,
   isLoading = false,
@@ -158,6 +159,7 @@ const DataTableComponent = <T extends RecordWithId>({
               rowKey={String(idx)}
               dense={dense}
               keyboardActivated={clickFocusedRow}
+              generateRowTooltip={generateRowTooltip}
             />
           ))}
         </TableBody>

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
 } as ComponentMeta<typeof DataRow>;
 
-const Template: Story = ({ onClick }) => {
+const Template: Story = ({ onClick, generateRowTooltip = () => '' }) => {
   const columns = useColumns<{ id: string; status: string; comment: string }>([
     'type',
     'status',
@@ -33,6 +33,7 @@ const Template: Story = ({ onClick }) => {
             comment: 'Supplier invoice',
           }}
           onClick={onClick}
+          generateRowTooltip={generateRowTooltip}
         />
       </TableBody>
     </Table>
@@ -47,4 +48,11 @@ Basic.args = {
 export const WithRowClick = Template.bind({});
 WithRowClick.args = {
   onClick: () => {},
+};
+
+export const WithTooltip = Template.bind({});
+WithTooltip.args = {
+  onClick: () => {},
+  generateRowTooltip: (row: any) =>
+    `This tooltip is not very helpful. It just says that the status is ${row.status}`,
 };

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
@@ -26,6 +26,7 @@ describe('DataRow', () => {
             rowKey="rowKey"
             rowIndex={0}
             rowData={{ id: 'josh' }}
+            generateRowTooltip={() => ''}
           />
         </TableBody>
       </Table>

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -9,7 +9,7 @@ import {
   useIsFocused,
   useRowStyle,
 } from '../../context';
-import { Fade } from '@mui/material';
+import { Fade, Tooltip } from '@mui/material';
 
 interface DataRowProps<T extends RecordWithId> {
   columns: Column<T>[];
@@ -21,6 +21,7 @@ interface DataRowProps<T extends RecordWithId> {
   dense?: boolean;
   rowIndex: number;
   keyboardActivated?: boolean;
+  generateRowTooltip: (row: T) => string;
 }
 
 export const DataRow = <T extends RecordWithId>({
@@ -33,6 +34,7 @@ export const DataRow = <T extends RecordWithId>({
   dense = false,
   rows,
   keyboardActivated,
+  generateRowTooltip,
 }: DataRowProps<T>): JSX.Element => {
   const hasOnClick = !!onClick;
   const { isExpanded } = useExpanded(rowData.id);
@@ -51,63 +53,69 @@ export const DataRow = <T extends RecordWithId>({
   return (
     <>
       <Fade in={true} timeout={500}>
-        <TableRow
-          sx={{
-            '&.MuiTableRow-root': {
-              '&:hover': hasOnClick
-                ? { backgroundColor: 'background.menu' }
-                : {},
-            },
-            color: isDisabled ? 'gray.main' : 'black',
-            backgroundColor: isFocused ? 'background.menu' : null,
-            alignItems: 'center',
-            height: '40px',
-            maxHeight: '45px',
-            boxShadow: dense
-              ? 'none'
-              : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
-            ...rowStyle,
-          }}
-          onClick={onRowClick}
+        <Tooltip
+          title={generateRowTooltip(rowData)}
+          followCursor
+          placement="bottom-start"
         >
-          {columns.map((column, columnIndex) => {
-            return (
-              <TableCell
-                key={`${rowKey}${String(column.key)}`}
-                align={column.align}
-                sx={{
-                  borderBottom: 'none',
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap',
-                  paddingLeft: paddingX,
-                  paddingRight: paddingX,
-                  paddingTop: paddingY,
-                  paddingBottom: paddingY,
-                  ...(hasOnClick && { cursor: 'pointer' }),
-                  minWidth: column.minWidth,
-                  maxWidth: column.maxWidth,
-                  width: column.width,
-                  color: 'inherit',
-                  fontSize: dense ? '12px' : '14px',
-                  backgroundColor: column.backgroundColor,
-                  fontWeight: 'normal',
-                }}
-              >
-                <column.Cell
-                  isDisabled={isDisabled}
-                  rows={rows}
-                  rowData={rowData}
-                  columns={columns}
-                  column={column}
-                  rowKey={rowKey}
-                  columnIndex={columnIndex}
-                  rowIndex={rowIndex}
-                  autocompleteName={column.autocompleteProvider?.(rowData)}
-                />
-              </TableCell>
-            );
-          })}
-        </TableRow>
+          <TableRow
+            sx={{
+              '&.MuiTableRow-root': {
+                '&:hover': hasOnClick
+                  ? { backgroundColor: 'background.menu' }
+                  : {},
+              },
+              color: isDisabled ? 'gray.main' : 'black',
+              backgroundColor: isFocused ? 'background.menu' : null,
+              alignItems: 'center',
+              height: '40px',
+              maxHeight: '45px',
+              boxShadow: dense
+                ? 'none'
+                : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
+              ...rowStyle,
+            }}
+            onClick={onRowClick}
+          >
+            {columns.map((column, columnIndex) => {
+              return (
+                <TableCell
+                  key={`${rowKey}${String(column.key)}`}
+                  align={column.align}
+                  sx={{
+                    borderBottom: 'none',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    paddingLeft: paddingX,
+                    paddingRight: paddingX,
+                    paddingTop: paddingY,
+                    paddingBottom: paddingY,
+                    ...(hasOnClick && { cursor: 'pointer' }),
+                    minWidth: column.minWidth,
+                    maxWidth: column.maxWidth,
+                    width: column.width,
+                    color: 'inherit',
+                    fontSize: dense ? '12px' : '14px',
+                    backgroundColor: column.backgroundColor,
+                    fontWeight: 'normal',
+                  }}
+                >
+                  <column.Cell
+                    isDisabled={isDisabled}
+                    rows={rows}
+                    rowData={rowData}
+                    columns={columns}
+                    column={column}
+                    rowKey={rowKey}
+                    columnIndex={columnIndex}
+                    rowIndex={rowIndex}
+                    autocompleteName={column.autocompleteProvider?.(rowData)}
+                  />
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        </Tooltip>
       </Fade>
       {isExpanded && !!ExpandContent ? (
         <tr>

--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -21,6 +21,7 @@ export interface TableProps<T extends RecordWithId> {
   dense?: boolean;
   ExpandContent?: FC<{ rowData: T }>;
   enableColumnSelection?: boolean;
+  generateRowTooltip?: (row: T) => string;
   key: string;
   isDisabled?: boolean;
   isError?: boolean;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.test.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/usePackSizeController.test.tsx
@@ -361,6 +361,6 @@ describe('usePackSizeController', () => {
       usePackSizeController(lines)
     );
 
-    expect(result.current.options.map(({ value }) => value)).toEqual([-1]);
+    expect(result.current.options.map(({ value }) => value)).toEqual([]);
   });
 });

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.test.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.test.ts
@@ -84,7 +84,10 @@ describe('allocateQuantities - standard behaviour.', () => {
       draftOutboundLines
     );
 
-    const expected = [{ ...lineOne, numberOfPacks: 3 }, placeholder];
+    const expected = [
+      { ...lineOne, numberOfPacks: 3, isUpdated: true },
+      placeholder,
+    ];
 
     expect(allocate(3, 1)).toEqual(expected);
   });
@@ -99,9 +102,9 @@ describe('allocateQuantities - standard behaviour.', () => {
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
-    const lineTwo = { ...two };
+    const lineTwo = { ...two, isUpdated: true };
     lineTwo.numberOfPacks = 1;
 
     const expected = [lineOne, lineTwo, placeholder];
@@ -121,7 +124,7 @@ describe('Allocate quantities - placeholder row behaviour', () => {
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
     const placeholderLine = { ...placeholder, numberOfPacks: 9 };
 
@@ -140,9 +143,9 @@ describe('Allocate quantities - placeholder row behaviour', () => {
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
-    const lineTwo = { ...two };
+    const lineTwo = { ...two, isUpdated: true };
     lineTwo.numberOfPacks = 1;
     const placeholderLine = { ...placeholder };
     placeholderLine.numberOfPacks = 1;
@@ -160,7 +163,7 @@ describe('Allocate quantities - placeholder row behaviour', () => {
       const draftOutboundLines = [one, placeholder];
       const allocate = allocateQuantities(status, draftOutboundLines);
 
-      const lineOne = { ...one };
+      const lineOne = { ...one, isUpdated: true };
       lineOne.numberOfPacks = 1;
       const placeholderLine = getPlaceholder();
 
@@ -200,7 +203,7 @@ describe('Allocate quantities - differing pack size behaviour', () => {
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
     const lineTwo = { ...two };
     const placeholderLine = { ...placeholder };
@@ -221,7 +224,7 @@ describe('Allocate quantities - differing pack size behaviour', () => {
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
     const lineTwo = { ...two };
     const placeholderLine = { ...placeholder };
@@ -232,8 +235,8 @@ describe('Allocate quantities - differing pack size behaviour', () => {
     expect(allocate(3, 1)).toEqual(expected);
 
     allocate = allocateQuantities(InvoiceNodeStatus.New, expected);
-    const lineOneAfterChange = { ...one };
-    const lineTwoAfterChange = { ...two };
+    const lineOneAfterChange = { ...one, isUpdated: true };
+    const lineTwoAfterChange = { ...two, isUpdated: true };
     lineOneAfterChange.numberOfPacks = 0;
     lineTwoAfterChange.numberOfPacks = 1;
     const placeholderAfterChange = { ...placeholder };
@@ -258,7 +261,7 @@ describe('Allocating quantities - behaviour when mixing placeholders and pack si
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
     const placeholderLine = { ...placeholder };
     placeholderLine.numberOfPacks = 9;
@@ -276,7 +279,7 @@ describe('Allocating quantities - behaviour when mixing placeholders and pack si
       draftOutboundLines
     );
 
-    const lineOne = { ...one };
+    const lineOne = { ...one, isUpdated: true };
     lineOne.numberOfPacks = 1;
     // The total number of units being allocated is 20. The line with a pack size of two has 1 pack available.
     // So, 18 units should be assigned to the placeholder - the 9 remaining packs * the pack size of two.
@@ -320,8 +323,12 @@ describe('Allocated quantities - expiry date behaviour', () => {
       draftOutboundLines
     );
 
-    const expiringLast = { ...expiringLastLine };
-    const expiringFirst = { ...expiringFirstLine, numberOfPacks: 10 };
+    const expiringLast = { ...expiringLastLine, isUpdated: true };
+    const expiringFirst = {
+      ...expiringFirstLine,
+      numberOfPacks: 10,
+      isUpdated: true,
+    };
 
     expect(allocate(10, 1)).toEqual([expiringLast, expiringFirst, placeholder]);
   });
@@ -337,8 +344,16 @@ describe('Allocated quantities - expiry date behaviour', () => {
       draftOutboundLines
     );
 
-    const expiringLast = { ...expiringLastLine, numberOfPacks: 5 };
-    const expiringFirst = { ...expiringFirstLine, numberOfPacks: 10 };
+    const expiringLast = {
+      ...expiringLastLine,
+      numberOfPacks: 5,
+      isUpdated: true,
+    };
+    const expiringFirst = {
+      ...expiringFirstLine,
+      numberOfPacks: 10,
+      isUpdated: true,
+    };
 
     expect(allocate(15, 1)).toEqual([expiringLast, expiringFirst, placeholder]);
   });
@@ -377,7 +392,11 @@ describe('Allocated quantities - behaviour for expired lines', () => {
       draftOutboundLines
     );
 
-    const expiringLast = { ...expiringLastLine, numberOfPacks: 10 };
+    const expiringLast = {
+      ...expiringLastLine,
+      numberOfPacks: 10,
+      isUpdated: true,
+    };
     const expired = { ...expiredLine, numberOfPacks: 0 };
 
     expect(allocate(10, 1)).toEqual([expiringLast, expired, placeholder]);
@@ -461,9 +480,9 @@ describe('Allocated quantities - coping with over-allocation', () => {
       draftOutboundLines
     );
 
-    const line1 = { ...Line1, numberOfPacks: 2 };
-    const line2 = { ...Line2, numberOfPacks: 0 };
-    const line3 = { ...Line3, numberOfPacks: 1 };
+    const line1 = { ...Line1, numberOfPacks: 2, isUpdated: true };
+    const line2 = { ...Line2, numberOfPacks: 0, isUpdated: true };
+    const line3 = { ...Line3, numberOfPacks: 1, isUpdated: true };
     const line4 = { ...Line4, numberOfPacks: 0 };
 
     expect(allocate(12, null)).toEqual([
@@ -489,9 +508,9 @@ describe('Allocated quantities - coping with over-allocation', () => {
       draftOutboundLines
     );
 
-    const line1 = { ...Line1, numberOfPacks: 2 };
-    const line2 = { ...Line2, numberOfPacks: 0 };
-    const line3 = { ...Line3, numberOfPacks: 1 };
+    const line1 = { ...Line1, numberOfPacks: 2, isUpdated: true };
+    const line2 = { ...Line2, numberOfPacks: 0, isUpdated: true };
+    const line3 = { ...Line3, numberOfPacks: 1, isUpdated: true };
     const line4 = { ...Line4, numberOfPacks: 0, packSize: 10 };
 
     expect(allocate(12, null)).toEqual([
@@ -511,16 +530,26 @@ describe('Allocated quantities - coping with over-allocation', () => {
       draftOutboundLines
     );
 
-    const line1 = { ...Line3, numberOfPacks: 1 };
-    const line2 = { ...Line4, numberOfPacks: 2 };
+    const line1 = { ...Line3, numberOfPacks: 1, isUpdated: true };
+    const line2 = { ...Line4, numberOfPacks: 2, isUpdated: true };
 
     expect(allocate(12, null)).toEqual([line1, line2, placeholder]);
   });
 
   it('reduces large pack size lines, allocating to other lines', () => {
-    const line1 = { ...Line1, packSize: 12, availableNumberOfPacks: 40 };
-    const line2 = { ...Line2, availableNumberOfPacks: 100 };
-    const line3 = { ...Line3, packSize: 1, availableNumberOfPacks: 100 };
+    const line1 = {
+      ...Line1,
+      packSize: 12,
+      availableNumberOfPacks: 40,
+      isUpdated: true,
+    };
+    const line2 = { ...Line2, availableNumberOfPacks: 100, isUpdated: true };
+    const line3 = {
+      ...Line3,
+      packSize: 1,
+      availableNumberOfPacks: 100,
+      isUpdated: true,
+    };
     const line4 = { ...Line4 };
 
     const draftOutboundLines = [
@@ -540,7 +569,7 @@ describe('Allocated quantities - coping with over-allocation', () => {
       { ...line1, numberOfPacks: 5 },
       { ...line2, numberOfPacks: 1 },
       line3,
-      line4,
+      { ...line4, isUpdated: true },
       placeholder,
     ]);
   });


### PR DESCRIPTION
Closes #462 

Adds tooltip support - and doesn't use that for any existing screens 😁 
You can see the behaviour with the story.. or just wait until this is merged and then develop gets merged into the feature branch 🤷 
I targeted develop so that I could get the functionality merged into both branches. perhaps a bad idea?
It has resulted in an offroad to fix up the tests, so there is some benefit