### PR TITLE
add insensitive equality filter

### DIFF
--- a/server/graphql/core/src/generic_filters.rs
+++ b/server/graphql/core/src/generic_filters.rs
@@ -7,6 +7,8 @@ use repository::{DateFilter, DatetimeFilter, EqualFilter, SimpleStringFilter};
 pub struct SimpleStringFilterInput {
     /// Search term must be an exact match (case sensitive)
     equal_to: Option<String>,
+    /// Search term must be an exact match, but case insensitive
+    insensitive_equal_to: Option<String>,
     /// Search term must be included in search candidate (case insensitive)
     like: Option<String>,
 }
@@ -15,6 +17,7 @@ impl From<SimpleStringFilterInput> for SimpleStringFilter {
     fn from(f: SimpleStringFilterInput) -> Self {
         SimpleStringFilter {
             equal_to: f.equal_to,
+            insensitive_equal_to: f.insensitive_equal_to,
             like: f.like,
         }
     }

--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -3,6 +3,7 @@ use chrono::{NaiveDate, NaiveDateTime};
 #[derive(Clone, PartialEq, Debug)]
 pub struct SimpleStringFilter {
     pub equal_to: Option<String>,
+    pub insensitive_equal_to: Option<String>,
     pub like: Option<String>,
 }
 
@@ -10,6 +11,7 @@ impl SimpleStringFilter {
     pub fn equal_to(value: &str) -> Self {
         SimpleStringFilter {
             equal_to: Some(value.to_owned()),
+            insensitive_equal_to: None,
             like: None,
         }
     }
@@ -17,7 +19,16 @@ impl SimpleStringFilter {
     pub fn like(value: &str) -> Self {
         SimpleStringFilter {
             equal_to: None,
+            insensitive_equal_to: None,
             like: Some(value.to_owned()),
+        }
+    }
+
+    pub fn insensitive_equal_to(value: &str) -> Self {
+        SimpleStringFilter {
+            equal_to: None,
+            insensitive_equal_to: Some(value.to_owned()),
+            like: None,
         }
     }
 }

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -126,7 +126,7 @@ macro_rules! apply_simple_string_filter {
             }
 
             if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.filter($dsl_field.like(value));
+                $query = $query.filter($dsl_field.like(value.replace("%", "")));
             }
 
             if let Some(value) = string_filter.like {
@@ -145,7 +145,7 @@ macro_rules! apply_simple_string_filter {
             }
 
             if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.filter($dsl_field.ilike(value));
+                $query = $query.filter($dsl_field.ilike(value.replace("%", "")));
             }
 
             if let Some(value) = string_filter.like {

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -125,6 +125,10 @@ macro_rules! apply_simple_string_filter {
                 $query = $query.filter($dsl_field.eq(value));
             }
 
+            if let Some(value) = string_filter.insensitive_equal_to {
+                $query = $query.filter($dsl_field.like(value));
+            }
+
             if let Some(value) = string_filter.like {
                 // in sqlite like is case insensitive (but on only works with ASCII chars)
                 $query = $query.filter($dsl_field.like(format!("%{}%", value)));
@@ -138,6 +142,10 @@ macro_rules! apply_simple_string_filter {
         if let Some(string_filter) = $filter_field {
             if let Some(value) = string_filter.equal_to {
                 $query = $query.filter($dsl_field.eq(value));
+            }
+
+            if let Some(value) = string_filter.insensitive_equal_to {
+                $query = $query.filter($dsl_field.ilike(value));
             }
 
             if let Some(value) = string_filter.like {

--- a/server/service/src/document/patient/search.rs
+++ b/server/service/src/document/patient/search.rs
@@ -43,10 +43,10 @@ pub fn patient_search(
         filter = filter.code_2(SimpleStringFilter::equal_to(&code_2));
     }
     if let Some(first_name) = first_name {
-        filter = filter.first_name(SimpleStringFilter::equal_to(&first_name));
+        filter = filter.first_name(SimpleStringFilter::insensitive_equal_to(&first_name));
     }
     if let Some(last_name) = last_name {
-        filter = filter.last_name(SimpleStringFilter::equal_to(&last_name));
+        filter = filter.last_name(SimpleStringFilter::insensitive_equal_to(&last_name));
     }
     if let Some(date_of_birth) = date_of_birth {
         filter = filter.date_of_birth(DateFilter::equal_to(date_of_birth));


### PR DESCRIPTION
Fixes #484 

Extends the `SimpleStringFilter` in order to support case-insensitive equality comparisons.
Thought about just using a `StringFilter` with `starts_with` and `ends_with` but thought that an actual insensitive equality would be useful elsewhere, so went down that path. Suggestions welcome!


## Tests
- [ ] Can search for the patient `Tina Ling` using firstname: `tina`
- [ ] and/or lastname: `ling` or `LING` etc..
- [ ] No match made when searching for partials, e.g. `in` for the firstname
- [ ] No match made when using wildcards, e.g. `%ina` for the firstname