### PR TITLE
Send tax on insert of OS service lines

### DIFF
--- a/client/packages/common/src/utils/pricing/PricingUtils.ts
+++ b/client/packages/common/src/utils/pricing/PricingUtils.ts
@@ -1,9 +1,15 @@
+const ROUNDING_PRECISION = Math.pow(10, 12);
+
 export const PricingUtils = {
   taxAmount: (subtotal: number, total: number) => {
     return Math.max(total - subtotal, 0);
   },
   effectiveTax: (subtotal: number, total: number) => {
     const taxAmount = PricingUtils.taxAmount(subtotal, total);
-    return (taxAmount / Math.max(subtotal, 1)) * 100;
+    const x =
+      Math.round(
+        (taxAmount / Math.max(subtotal, 1)) * 100 * ROUNDING_PRECISION
+      ) / ROUNDING_PRECISION;
+    return x;
   },
 };

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -128,7 +128,7 @@ const outboundParsers = {
     id: line.id,
     invoiceId: line.invoiceId,
     itemId: line.item.id,
-    tax: 0.0,
+    tax: line.taxPercentage,
     totalBeforeTax: line.totalBeforeTax,
     note: line.note,
   }),


### PR DESCRIPTION
Fixes #455 

though it leaves open the question of why? 
When inserting we supply the percentage as a float, when updating we use a `TaxInput` struct

```
export type InsertOutboundShipmentServiceLineInput = {
...
  tax?: InputMaybe<Scalars['Float']>;
...
```

vs.

```
export type UpdateOutboundShipmentServiceLineInput = {
...
  tax?: InputMaybe<TaxInput>;
...
```