### PR TITLE
Handle server errors

### DIFF
--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -21,6 +21,7 @@ const TOKEN_CHECK_INTERVAL = 60 * 1000;
 export enum AuthError {
   NoStoreAssigned = 'NoStoreAssigned',
   PermissionDenied = 'Forbidden',
+  ServerError = 'ServerError',
   Unauthenticated = 'Unauthenticated',
   Timeout = 'Timeout',
 }
@@ -150,6 +151,8 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   };
 
   const setLoginError = (isLoggedIn: boolean, hasValidStore: boolean) => {
+    if (LocalStorage.getItem('/auth/error') === AuthError.ServerError) return;
+
     switch (true) {
       case isLoggedIn && hasValidStore: {
         removeError();
@@ -184,6 +187,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       case AuthError.NoStoreAssigned:
       case AuthError.Unauthenticated:
       case AuthError.Timeout:
+      case AuthError.ServerError:
         return true;
       default:
         return false;

--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -1,4 +1,4 @@
-import { LocaleKey, TypedTFunction } from '../..';
+import { AuthError, LocaleKey, LocalStorage, TypedTFunction } from '../..';
 import { Sdk, AuthTokenQuery, RefreshTokenQuery } from './operations.generated';
 
 export type AuthenticationError = {
@@ -90,11 +90,19 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
           }
         );
         return result.me;
-      } catch {}
+      } catch (e) {
+        console.error(e);
+        LocalStorage.setItem('/auth/error', AuthError.ServerError);
+      }
     },
     stores: () => async () => {
-      const result = await sdk.me();
-      return result?.me?.stores?.nodes;
+      try {
+        const result = await sdk.me();
+        return result?.me?.stores?.nodes;
+      } catch (e) {
+        console.error(e);
+        LocalStorage.setItem('/auth/error', AuthError.ServerError);
+      }
     },
   },
 });

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -5,6 +5,7 @@
   "auth.unauthenticated-message": "You are not currently logged in. Click OK to return to the login screen.",
   "auth.no-store-assigned": "You are not assigned to any stores. Please login as a different user, or contact your administrator.",
   "auth.permission-denied": "Permission denied",
+  "auth.server-error": "The server has returned an error when fetching user details! \r\nUnable to continue, please contact support.",
   "auth.timeout-title": "Session Timed Out",
   "auth.timeout-message": "You have been logged out of your session due to inactivity. Click OK to return to the login screen.",
   "button.close-the-menu": "Close the menu",

--- a/client/packages/common/src/ui/components/modals/AlertModal/AlertModal.tsx
+++ b/client/packages/common/src/ui/components/modals/AlertModal/AlertModal.tsx
@@ -12,7 +12,7 @@ export interface AlertModalProps {
 // allowing you to use the modal in a declarative syntax
 // without creating multiple overlaying modals
 // Set the important prop only if this is a critical alert
-// which should only be superceded by other critical alerts
+// which should only be superseded by other critical alerts
 // Apart from the important / non-important distinction,
 // the latest caller wins, and will be displayed
 export const AlertModal: React.FC<AlertModalProps> = ({

--- a/client/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
+++ b/client/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
@@ -33,7 +33,9 @@ const AlertModal = ({
           </Typography>
         </Grid>
       </Grid>
-      <Grid item>{message}</Grid>
+      <Grid item style={{ whiteSpace: 'pre-line' }}>
+        {message}
+      </Grid>
       <Grid item display="flex" justifyContent="flex-end" flex={1}>
         <DialogButton variant="ok" onClick={onClick} autoFocus />
       </Grid>

--- a/client/packages/host/src/components/AuthenticationAlert.tsx
+++ b/client/packages/host/src/components/AuthenticationAlert.tsx
@@ -95,6 +95,11 @@ const translateErrorMessage = (
         title: t('auth.alert-title'),
         message: t('auth.permission-denied'),
       };
+    case AuthError.ServerError:
+      return {
+        title: t('auth.alert-title'),
+        message: t('auth.server-error'),
+      };
     default:
       return undefined;
   }


### PR DESCRIPTION
Fixes #498 

A quick mangle of the `permission_type` caused an issue for me

```
ALTER TABLE user_permission  ALTER COLUMN "permission" TYPE text  USING permission::text;

update user_permission 
set "permission" = 'QUERY'
where "permission" ='LOG_QUERY';
```

Gives an error:

```
react_devtools_backend.js:4026 Error: DBError {
    msg: "DIESEL_DESERIALIZATION_ERROR",
    extra: "\"Unrecognized enum variant: 'QUERY'\"",
}
    at handleResponseError (GqlContext.tsx:55:9)
    at GqlContext.tsx:99:11
```

Have added a server error type, and am setting that when the `me` query fails with an error. Am also writing the error to console to help with debugging.

