### PR TITLE
132 serial numbers postgres

### DIFF
--- a/server/repository/migrations/postgres/2021-12-10T10-00_number_table/up.sql
+++ b/server/repository/migrations/postgres/2021-12-10T10-00_number_table/up.sql
@@ -1,17 +1,20 @@
 CREATE TYPE number_type AS ENUM (
-    'INBOUND_SHIPMENT',
-    'OUTBOUND_SHIPMENT',
-    'INVENTORY_ADJUSTMENT',
-    'STOCKTAKE',
-    'REQUEST_REQUISITION',
-    'RESPONSE_REQUISITION'
+  'INBOUND_SHIPMENT',
+  'OUTBOUND_SHIPMENT',
+  'INVENTORY_ADJUSTMENT',
+  'STOCKTAKE',
+  'REQUEST_REQUISITION',
+  'RESPONSE_REQUISITION'
 );
 
 -- Numbering table holding a list of typed counters
-CREATE TABLE number (
+CREATE TABLE
+  number (
     id TEXT NOT NULL PRIMARY KEY,
     -- current counter value
     value BIGINT NOT NULL,
     store_id TEXT NOT NULL REFERENCES store(id),
     type number_type NOT NULL
-)
+  );
+
+CREATE UNIQUE INDEX ix_number_store_type_unique ON number(store_id, type);

--- a/server/repository/migrations/postgres/2021-12-10T10-00_number_table/up.sql
+++ b/server/repository/migrations/postgres/2021-12-10T10-00_number_table/up.sql
@@ -14,7 +14,7 @@ CREATE TABLE
     -- current counter value
     value BIGINT NOT NULL,
     store_id TEXT NOT NULL REFERENCES store(id),
-    type number_type NOT NULL
+    type TEXT NOT NULL
   );
 
 CREATE UNIQUE INDEX ix_number_store_type_unique ON number(store_id, type);

--- a/server/repository/migrations/sqlite/2021-12-10T10-00_number_table/up.sql
+++ b/server/repository/migrations/sqlite/2021-12-10T10-00_number_table/up.sql
@@ -5,16 +5,7 @@ CREATE TABLE
     -- current counter value
     value BIGINT NOT NULL,
     store_id TEXT NOT NULL REFERENCES store(id),
-    type TEXT CHECK (
-      type IN (
-        'INBOUND_SHIPMENT',
-        'OUTBOUND_SHIPMENT',
-        'INVENTORY_ADJUSTMENT',
-        'STOCKTAKE',
-        'REQUEST_REQUISITION',
-        'RESPONSE_REQUISITION'
-      )
-    ) NOT NULL
+    type TEXT NOT NULL
   );
 
 CREATE UNIQUE INDEX ix_number_store_type_unique ON number(store_id, type);

--- a/server/repository/migrations/sqlite/2021-12-10T10-00_number_table/up.sql
+++ b/server/repository/migrations/sqlite/2021-12-10T10-00_number_table/up.sql
@@ -1,8 +1,20 @@
 -- Numbering table holding a list of typed counters
-CREATE TABLE number (
+CREATE TABLE
+  number (
     id TEXT NOT NULL PRIMARY KEY,
     -- current counter value
     value BIGINT NOT NULL,
     store_id TEXT NOT NULL REFERENCES store(id),
-    type TEXT CHECK (type IN ('INBOUND_SHIPMENT', 'OUTBOUND_SHIPMENT', 'INVENTORY_ADJUSTMENT', 'STOCKTAKE', 'REQUEST_REQUISITION', 'RESPONSE_REQUISITION')) NOT NULL
-)
+    type TEXT CHECK (
+      type IN (
+        'INBOUND_SHIPMENT',
+        'OUTBOUND_SHIPMENT',
+        'INVENTORY_ADJUSTMENT',
+        'STOCKTAKE',
+        'REQUEST_REQUISITION',
+        'RESPONSE_REQUISITION'
+      )
+    ) NOT NULL
+  );
+
+CREATE UNIQUE INDEX ix_number_store_type_unique ON number(store_id, type);

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -10,7 +10,6 @@ use diesel::{prelude::*, sql_query, sql_types::Text};
 
 use diesel::sql_types::BigInt;
 use diesel_derive_enum::DbEnum;
-use serde::Serialize;
 
 table! {
     number (id) {
@@ -21,9 +20,8 @@ table! {
     }
 }
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum NumberRowType {
     InboundShipment,
     OutboundShipment,

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::fmt;
 
 use super::{number_row::number::dsl as number_dsl, StorageConnection};
@@ -9,19 +10,23 @@ use diesel::result::Error::NotFound;
 use diesel::{prelude::*, sql_query, sql_types::Text};
 
 use diesel::sql_types::BigInt;
-use diesel_derive_enum::DbEnum;
 
 table! {
     number (id) {
         id -> Text,
         value -> BigInt,
         store_id -> Text,
-        #[sql_name = "type"] type_ -> crate::db_diesel::number_row::NumberRowTypeMapping,
+        #[sql_name = "type"] type_ -> Text,
     }
 }
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
-#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NumberRowTypeError {
+    UnknownTypePrefix(String),
+    MissingTypePrefix,
+}
+
+#[derive(AsExpression, Debug, Clone, PartialEq, Eq)]
 pub enum NumberRowType {
     InboundShipment,
     OutboundShipment,
@@ -29,6 +34,7 @@ pub enum NumberRowType {
     RequestRequisition,
     ResponseRequisition,
     Stocktake,
+    Program(String),
 }
 
 impl fmt::Display for NumberRowType {
@@ -40,6 +46,32 @@ impl fmt::Display for NumberRowType {
             NumberRowType::RequestRequisition => write!(f, "REQUEST_REQUISITION"),
             NumberRowType::ResponseRequisition => write!(f, "RESPONSE_REQUISITION"),
             NumberRowType::Stocktake => write!(f, "STOCKTAKE"),
+            NumberRowType::Program(custom_string) => write!(f, "PROGRAM_{}", custom_string),
+        }
+    }
+}
+
+impl TryFrom<String> for NumberRowType {
+    type Error = NumberRowTypeError;
+
+    fn try_from(s: String) -> Result<Self, NumberRowTypeError> {
+        match s.as_str() {
+            "INBOUND_SHIPMENT" => Ok(NumberRowType::InboundShipment),
+            "OUTBOUND_SHIPMENT" => Ok(NumberRowType::OutboundShipment),
+            "INVENTORY_ADJUSTMENT" => Ok(NumberRowType::InventoryAdjustment),
+            "REQUEST_REQUISITION" => Ok(NumberRowType::RequestRequisition),
+            "RESPONSE_REQUISITION" => Ok(NumberRowType::ResponseRequisition),
+            "STOCKTAKE" => Ok(NumberRowType::Stocktake),
+            _ => match s.split_once('_') {
+                Some((prefix, custom_string)) => {
+                    if prefix == "PROGRAM" {
+                        Ok(NumberRowType::Program(custom_string.to_string()))
+                    } else {
+                        Err(NumberRowTypeError::UnknownTypePrefix(prefix.to_string()))
+                    }
+                }
+                None => Err(NumberRowTypeError::MissingTypePrefix),
+            },
         }
     }
 }
@@ -53,9 +85,8 @@ pub struct NumberRow {
     pub store_id: String,
     // Table
     #[column_name = "type_"]
-    pub r#type: NumberRowType,
+    pub r#type: String,
 }
-
 pub struct NumberRowRepository<'a> {
     connection: &'a StorageConnection,
 }
@@ -69,11 +100,14 @@ pub struct NextNumber {
 
 // feature sqlite
 #[cfg(not(feature = "postgres"))]
-const ON_CONFLICT_DO_NOTHING: &'static str = "";
+const NUMBER_INSERT_QUERY: &'static str =
+    "INSERT INTO number (id, value, store_id, type) VALUES ($1, $2, $3, $4) RETURNING value;";
 
 // feature postgres
+// We need to use the ON CONFLICT DO NOTHING Clause for postgres just in case 2 threads insert at the same time (SQLite <on disk> does not need this as it only allows a single write transaction at a time).
+// Without this postgres will throw a unique constraint violation error and rollback the transaction, which is hard to recover from, instead we just ignore the error and check if it returned a value
 #[cfg(feature = "postgres")]
-const ON_CONFLICT_DO_NOTHING: &'static str = "ON CONFLICT DO NOTHING";
+const NUMBER_INSERT_QUERY: &'static str = "INSERT INTO number (id, value, store_id, type) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING RETURNING value;";
 
 impl<'a> NumberRowRepository<'a> {
     pub fn new(connection: &'a StorageConnection) -> Self {
@@ -95,49 +129,38 @@ impl<'a> NumberRowRepository<'a> {
     ) -> Result<NextNumber, RepositoryError> {
         // 1. First we try to just grab the next number from the database, in most cases this should work and be the fast.
 
-        // Note: Format string is used here because diesel does seems to support binding NumberRowType as a String or as it's own type.
-        // It's safe to use format here, as r#type is an enum with predefined values (No user input)
-        let update_query_str = format!(
-            r#"UPDATE number SET value = value+1 WHERE store_id = $1 and type = '{}' RETURNING value;"#,
-            r#type
-        );
-        let update_query = sql_query(update_query_str.clone()).bind::<Text, _>(store_id);
+        let update_query = sql_query(r#"UPDATE number SET value = value+1 WHERE store_id = $1 and type = $2 RETURNING value;"#)
+            .bind::<Text, _>(store_id)
+            .bind::<Text, _>(r#type.to_string());
 
         // Debug diesel query
         // println!(
         //     "{}",
         //     diesel::debug_query::<crate::DBType, _>(&update_query).to_string()
         // );
-        let update_result = update_query.get_result::<NextNumber>(&self.connection.connection);
+        let update_result = update_query
+            .clone()
+            .get_result::<NextNumber>(&self.connection.connection);
 
         match update_result {
             Ok(result) => Ok(result),
             Err(NotFound) => {
                 // 2. There was no record to update, so we need to insert a new one.
 
-                // We need to add an ON CONFLICT Clause for postgres just in case 2 threads insert at the same time (SQLite <on disk> does not need this as it only allows a single write transaction at a time).
-                // Without this postgres will throw a unique constraint violation error and rollback the transaction, which is hard to recover from, instead we just ignore the error and check if it returned a value
-                // It's safe to use format here, as these inputs are not user controlled
-                let insert_query_str = format!(
-                    r#"INSERT INTO number (id, value, store_id, type) VALUES ('{}', 1, $1, '{}') {} RETURNING value;"#,
-                    uuid(),
-                    r#type,
-                    ON_CONFLICT_DO_NOTHING
-                );
+                let insert_query = sql_query(NUMBER_INSERT_QUERY)
+                    .bind::<Text, _>(uuid())
+                    .bind::<BigInt, _>(1)
+                    .bind::<Text, _>(store_id)
+                    .bind::<Text, _>(r#type.to_string());
 
-                let insert_query = sql_query(insert_query_str).bind::<Text, _>(store_id);
-                let insert_result =
-                    insert_query.get_result::<NextNumber>(&self.connection.connection);
-
-                match insert_result {
+                match insert_query.get_result::<NextNumber>(&self.connection.connection) {
                     Ok(result) => Ok(result),
                     Err(NotFound) => {
                         // 3. If we got here another thread inserted the record before we we able to (we know this because nothing was returned for the insert)
                         // We should now be able to do the same 'update returning' query as before to get our new number.
 
-                        let result = sql_query(update_query_str.clone())
-                            .bind::<Text, _>(store_id)
-                            .get_result::<NextNumber>(&self.connection.connection)?;
+                        let result =
+                            update_query.get_result::<NextNumber>(&self.connection.connection)?;
                         Ok(result)
                     }
                     Err(e) => Err(RepositoryError::from(e)),
@@ -154,7 +177,7 @@ impl<'a> NumberRowRepository<'a> {
     ) -> Result<Option<NumberRow>, RepositoryError> {
         match number_dsl::number
             .filter(number_dsl::store_id.eq(store_id))
-            .filter(number_dsl::type_.eq(r#type))
+            .filter(number_dsl::type_.eq(r#type.to_string()))
             .first(&self.connection.connection)
         {
             Ok(row) => Ok(Some(row)),
@@ -180,5 +203,66 @@ impl<'a> NumberRowRepository<'a> {
             .values(number_row)
             .execute(&self.connection.connection)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod number_row_mapping_test {
+    use std::convert::TryFrom;
+
+    use crate::NumberRowType;
+
+    #[test]
+    fn test_number_row_type() {
+        // The purpose of this test is primarily to remind you to update both the to_string AND try_from functions if any new mappings are added to NumberRowType
+        // the try_from function uses a wild card match so theoretically could be missed if you add a new mapping
+
+        let number_row_type = NumberRowType::Program("EXAMPLE_TEST".to_string());
+        match number_row_type {
+            NumberRowType::InboundShipment => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::InboundShipment.to_string()).unwrap()
+                        == NumberRowType::InboundShipment
+                )
+            }
+            NumberRowType::OutboundShipment => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::OutboundShipment.to_string()).unwrap()
+                        == NumberRowType::OutboundShipment
+                )
+            }
+            NumberRowType::InventoryAdjustment => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::InventoryAdjustment.to_string())
+                        .unwrap()
+                        == NumberRowType::InventoryAdjustment
+                )
+            }
+            NumberRowType::RequestRequisition => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::RequestRequisition.to_string()).unwrap()
+                        == NumberRowType::RequestRequisition
+                )
+            }
+            NumberRowType::ResponseRequisition => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::ResponseRequisition.to_string())
+                        .unwrap()
+                        == NumberRowType::ResponseRequisition
+                )
+            }
+            NumberRowType::Stocktake => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::Stocktake.to_string()).unwrap()
+                        == NumberRowType::Stocktake
+                )
+            }
+            NumberRowType::Program(s) => {
+                assert!(
+                    NumberRowType::try_from(NumberRowType::Program(s.clone()).to_string()).unwrap()
+                        == NumberRowType::Program(s)
+                )
+            }
+        }
     }
 }

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -135,13 +135,10 @@ impl<'a> NumberRowRepository<'a> {
                         // 3. If we got here another thread inserted the record before we we able to (we know this because nothing was returned for the insert)
                         // We should now be able to do the same 'update returning' query as before to get our new number.
 
-                        let update_query =
-                            sql_query(update_query_str.clone()).bind::<Text, _>(store_id);
-
-                        match update_query.get_result::<NextNumber>(&self.connection.connection) {
-                            Ok(result) => Ok(result),
-                            Err(e) => Err(RepositoryError::from(e)),
-                        }
+                        let result = sql_query(update_query_str.clone())
+                            .bind::<Text, _>(store_id)
+                            .get_result::<NextNumber>(&self.connection.connection)?;
+                        Ok(result)
                     }
                     Err(e) => Err(RepositoryError::from(e)),
                 }

--- a/server/repository/src/db_diesel/number_row.rs
+++ b/server/repository/src/db_diesel/number_row.rs
@@ -1,10 +1,16 @@
+use std::fmt;
+
 use super::{number_row::number::dsl as number_dsl, StorageConnection};
+use util::uuid::uuid;
 
 use crate::repository_error::RepositoryError;
 
-use diesel::prelude::*;
+use diesel::result::Error::NotFound;
+use diesel::{prelude::*, sql_query, sql_types::Text};
 
+use diesel::sql_types::BigInt;
 use diesel_derive_enum::DbEnum;
+use serde::Serialize;
 
 table! {
     number (id) {
@@ -15,8 +21,9 @@ table! {
     }
 }
 
-#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq, Serialize)]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum NumberRowType {
     InboundShipment,
     OutboundShipment,
@@ -24,6 +31,19 @@ pub enum NumberRowType {
     RequestRequisition,
     ResponseRequisition,
     Stocktake,
+}
+
+impl fmt::Display for NumberRowType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NumberRowType::InboundShipment => write!(f, "INBOUND_SHIPMENT"),
+            NumberRowType::OutboundShipment => write!(f, "OUTBOUND_SHIPMENT"),
+            NumberRowType::InventoryAdjustment => write!(f, "INVENTORY_ADJUSTMENT"),
+            NumberRowType::RequestRequisition => write!(f, "REQUEST_REQUISITION"),
+            NumberRowType::ResponseRequisition => write!(f, "RESPONSE_REQUISITION"),
+            NumberRowType::Stocktake => write!(f, "STOCKTAKE"),
+        }
+    }
 }
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
@@ -42,6 +62,21 @@ pub struct NumberRowRepository<'a> {
     connection: &'a StorageConnection,
 }
 
+#[derive(QueryableByName, Queryable, PartialEq, Debug)]
+pub struct NextNumber {
+    #[column_name = "value"]
+    #[sql_type = "BigInt"]
+    pub number: i64,
+}
+
+// feature sqlite
+#[cfg(not(feature = "postgres"))]
+const ON_CONFLICT_DO_NOTHING: &'static str = "";
+
+// feature postgres
+#[cfg(feature = "postgres")]
+const ON_CONFLICT_DO_NOTHING: &'static str = "ON CONFLICT DO NOTHING";
+
 impl<'a> NumberRowRepository<'a> {
     pub fn new(connection: &'a StorageConnection) -> Self {
         NumberRowRepository { connection }
@@ -53,6 +88,67 @@ impl<'a> NumberRowRepository<'a> {
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
+    }
+
+    pub fn get_next_number_for_type_and_store(
+        &self,
+        r#type: &NumberRowType,
+        store_id: &str,
+    ) -> Result<NextNumber, RepositoryError> {
+        // 1. First we try to just grab the next number from the database, in most cases this should work and be the fast.
+
+        // Note: Format string is used here because diesel does seems to support binding NumberRowType as a String or as it's own type.
+        // It's safe to use format here, as r#type is an enum with predefined values (No user input)
+        let update_query_str = format!(
+            r#"UPDATE number SET value = value+1 WHERE store_id = $1 and type = '{}' RETURNING value;"#,
+            r#type
+        );
+        let update_query = sql_query(update_query_str.clone()).bind::<Text, _>(store_id);
+
+        // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&update_query).to_string()
+        // );
+        let update_result = update_query.get_result::<NextNumber>(&self.connection.connection);
+
+        match update_result {
+            Ok(result) => Ok(result),
+            Err(NotFound) => {
+                // 2. There was no record to update, so we need to insert a new one.
+
+                // We need to add an ON CONFLICT Clause for postgres just in case 2 threads insert at the same time (SQLite does need this it only allows a single write transaction at a time).
+                // Without this postgres will throw a unique constraint violation error and rollback the transaction, which is hard to recover from, instead we just check to see if it returned a value
+                let insert_query_str = format!(
+                    r#"INSERT INTO number (id, value, store_id, type) VALUES ('{}', 1, $1, '{}') {} RETURNING value;"#,
+                    uuid(),
+                    r#type,
+                    ON_CONFLICT_DO_NOTHING
+                ); //It's safe to use format here, as these inputs are not user controlled
+
+                let insert_query = sql_query(insert_query_str).bind::<Text, _>(store_id);
+                let insert_result =
+                    insert_query.get_result::<NextNumber>(&self.connection.connection);
+
+                match insert_result {
+                    Ok(result) => Ok(result),
+                    Err(NotFound) => {
+                        // 3. If we got here another thread inserted the record before we we able to (Nothing was returned for the insert)
+                        // We should now be able to do the same 'update returning' query as before to get our new number.
+
+                        let update_query =
+                            sql_query(update_query_str.clone()).bind::<Text, _>(store_id);
+
+                        match update_query.get_result::<NextNumber>(&self.connection.connection) {
+                            Ok(result) => Ok(result),
+                            Err(e) => Err(RepositoryError::from(e)),
+                        }
+                    }
+                    Err(e) => Err(RepositoryError::from(e)),
+                }
+            }
+            Err(e) => Err(RepositoryError::from(e)),
+        }
     }
 
     pub fn find_one_by_type_and_store(

--- a/server/repository/src/mock/number.rs
+++ b/server/repository/src/mock/number.rs
@@ -3,7 +3,7 @@ use crate::{NumberRow, NumberRowType};
 pub fn mock_inbound_shipment_number_store_a() -> NumberRow {
     NumberRow {
         id: String::from("inbound_shipment_number_store_a"),
-        r#type: NumberRowType::InboundShipment,
+        r#type: NumberRowType::InboundShipment.to_string(),
         store_id: "store_a".to_owned(),
         value: 1000,
     }
@@ -12,7 +12,7 @@ pub fn mock_inbound_shipment_number_store_a() -> NumberRow {
 pub fn mock_outbound_shipment_number_store_a() -> NumberRow {
     NumberRow {
         id: String::from("outbound_shipment_number_store_a"),
-        r#type: NumberRowType::OutboundShipment,
+        r#type: NumberRowType::OutboundShipment.to_string(),
         store_id: "store_a".to_owned(),
         value: 100,
     }

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -35,4 +35,5 @@ rand = "0.8.5"
 [features]
 default = ["sqlite"]
 sqlite = ["repository/sqlite"]
+memory = ["repository/sqlite"]
 postgres = ["repository/postgres"]

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -83,7 +83,8 @@ mod test {
             (Note: This test did fail with previous implementation of next number on postgres)
         */
 
-        // Part 1: Concurrent up date (first row) e.g. this will require an insert and an update for one these processes...
+        // Part 1: Both threads will try to add a new number row (first time this number type has been used)
+        // This should result in 1 insert and 1 update.
 
         let manager_a = connection_manager.clone();
         let process_a = std::thread::spawn(move || {
@@ -120,7 +121,8 @@ mod test {
             result.unwrap()
         });
 
-        //Part 2: Concurrent up date both doing updates
+        // Part 2: Both threads will try to increment the value in the existing row
+        // This should result in 2 updates
         let manager_b = connection_manager.clone();
         let process_b = std::thread::spawn(move || {
             let connection = manager_b.connection().unwrap();

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -57,8 +57,8 @@ mod test {
         assert_eq!(result, 2);
     }
 
-    #[cfg(not(feature = "memory"))]
     #[actix_rt::test]
+    #[cfg(not(feature = "memory"))]
     async fn test_concurrent_next_number() {
         let (_, _, connection_manager, _) = test_db::setup_all(
             "test_concurrent_numbers",

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -83,7 +83,7 @@ mod test {
             (Note: This test did fail with previous implementation of next number on postgres)
         */
 
-        //Part 1: Concurrent up date (first row) e.g. this will require an insert and an update for one these processes...
+        // Part 1: Concurrent up date (first row) e.g. this will require an insert and an update for one these processes...
 
         let manager_a = connection_manager.clone();
         let process_a = std::thread::spawn(move || {

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -11,8 +11,9 @@ pub fn next_number(
     // Should be done in transaction
     let next_number = connection.transaction_sync(|connection_tx| {
         let repo = NumberRowRepository::new(&connection_tx);
-
-        let updated_number_row = match repo.find_one_by_type_and_store(r#type, store_id)? {
+        let current = repo.find_one_by_type_and_store(r#type, store_id)?;
+        //This should compile as a no-op in production code, only used during tests
+        let updated_number_row = match current {
             Some(mut row) => {
                 // update existing counter
                 row.value = row.value + 1;
@@ -43,9 +44,11 @@ mod test {
             mock_inbound_shipment_number_store_a, mock_outbound_shipment_number_store_a,
             MockDataInserts,
         },
-        test_db::setup_all,
-        NumberRowType,
+        test_db::{self, setup_all},
+        NumberRowType, RepositoryError, TransactionError,
     };
+
+    const TEST_SLEEP_TIME: u64 = 100;
 
     use crate::number::next_number;
 
@@ -74,5 +77,71 @@ mod test {
 
         let result = next_number(&connection, &NumberRowType::OutboundShipment, "store_b").unwrap();
         assert_eq!(result, 2);
+    }
+
+    #[actix_rt::test]
+    async fn test_concurrent_next_number() {
+        let (_, _, connection_manager, _) = test_db::setup_all(
+            "test_concurrent_numbers",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+        /*
+            Test Scenario
+
+            Process A starts a transaction, and gets the next number, then waits before commiting the transaction
+            Concurrently Process B tries to get the next number
+            (Note: This test did fail with previous implementation of next number on postgres)
+        */
+
+        //Part 1: Concurrent up date (first row) e.g. this will require an insert and an update for these processes...
+
+        let manager_a = connection_manager.clone();
+        let process_a = std::thread::spawn(move || {
+            let connection = manager_a.connection().unwrap();
+            let result: Result<i64, TransactionError<RepositoryError>> = connection
+                .transaction_sync(|con| {
+                    let num = next_number(con, &NumberRowType::Stocktake, "store_a")?;
+                    std::thread::sleep(core::time::Duration::from_millis(TEST_SLEEP_TIME));
+                    Ok(num)
+                });
+            result.unwrap()
+        });
+
+        let manager_b = connection_manager.clone();
+        let process_b = std::thread::spawn(move || {
+            let connection = manager_b.connection().unwrap();
+            next_number(&connection, &NumberRowType::Stocktake, "store_a").unwrap()
+        });
+
+        let a = process_a.join().unwrap();
+        let b = process_b.join().unwrap();
+        println!("next_number (INSERT) results : a={} b={}", a, b);
+        assert!(a != b);
+
+        let manager_a = connection_manager.clone();
+        let process_a = std::thread::spawn(move || {
+            let connection = manager_a.connection().unwrap();
+            let result: Result<i64, TransactionError<RepositoryError>> = connection
+                .transaction_sync(|con| {
+                    let num = next_number(con, &NumberRowType::Stocktake, "store_a")?;
+                    std::thread::sleep(core::time::Duration::from_millis(TEST_SLEEP_TIME));
+                    Ok(num)
+                });
+            result.unwrap()
+        });
+
+        //Part 2: Concurrent up date both doing updates
+        let manager_b = connection_manager.clone();
+        let process_b = std::thread::spawn(move || {
+            let connection = manager_b.connection().unwrap();
+            next_number(&connection, &NumberRowType::Stocktake, "store_a").unwrap()
+        });
+
+        let a = process_a.join().unwrap();
+        let b = process_b.join().unwrap();
+
+        println!("next_number (UPDATE) results : a={} b={}", a, b);
+        assert!(a != b);
     }
 }

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -61,6 +61,47 @@ mod test {
     }
 
     #[actix_rt::test]
+    async fn test_number_service_for_programs() {
+        let (_, connection, _, _) = setup_all(
+            "test_number_service_for_programs",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+
+        let result = next_number(
+            &connection,
+            &NumberRowType::Program("PROGRAM_A".to_string()),
+            "store_a",
+        )
+        .unwrap();
+        assert_eq!(result, 1);
+
+        let result = next_number(
+            &connection,
+            &NumberRowType::Program("PROGRAM_A".to_string()),
+            "store_b",
+        )
+        .unwrap();
+        assert_eq!(result, 1);
+
+        let result = next_number(
+            &connection,
+            &NumberRowType::Program("PROGRAM_A".to_string()),
+            "store_a",
+        )
+        .unwrap();
+        assert_eq!(result, 2);
+
+        let result = next_number(
+            &connection,
+            &NumberRowType::Program("PROGRAM_B".to_string()),
+            "store_a",
+        )
+        .unwrap();
+        assert_eq!(result, 1);
+    }
+
+    #[actix_rt::test]
     #[cfg(not(feature = "memory"))]
     async fn test_concurrent_next_number() {
         let (_, _, connection_manager, _) = test_db::setup_all(

--- a/server/service/src/sync/integration_tests/number.rs
+++ b/server/service/src/sync/integration_tests/number.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use repository::{NumberRow, NumberRowRepository, NumberRowType, StorageConnection};
 use util::{inline_edit, uuid::uuid};
 
@@ -15,7 +17,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::InboundShipment,
+                r#type: NumberRowType::InboundShipment.to_string(),
             });
         row_0.value = gen_i64();
 
@@ -26,7 +28,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::OutboundShipment,
+                r#type: NumberRowType::OutboundShipment.to_string(),
             });
         row_1.value = gen_i64();
 
@@ -37,7 +39,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::InventoryAdjustment,
+                r#type: NumberRowType::InventoryAdjustment.to_string(),
             });
         row_2.value = gen_i64();
 
@@ -48,7 +50,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::RequestRequisition,
+                r#type: NumberRowType::RequestRequisition.to_string(),
             });
         row_3.value = gen_i64();
 
@@ -59,7 +61,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::ResponseRequisition,
+                r#type: NumberRowType::ResponseRequisition.to_string(),
             });
         row_4.value = gen_i64();
 
@@ -70,7 +72,7 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
                 id: uuid(),
                 value: 0,
                 store_id: store_id.to_string(),
-                r#type: NumberRowType::Stocktake,
+                r#type: NumberRowType::Stocktake.to_string(),
             });
         row_5.value = gen_i64();
 
@@ -100,8 +102,13 @@ impl SyncRecordTester<Vec<NumberRow>> for NumberSyncRecordTester {
     fn validate(&self, connection: &StorageConnection, rows: &Vec<NumberRow>) {
         for row_expected in rows {
             let number_repo = NumberRowRepository::new(&connection);
+            let row_type = match NumberRowType::try_from(row_expected.r#type.clone()) {
+                Ok(row_type) => row_type,
+                Err(_) => panic!("Invalid row type: {} -", row_expected.r#type),
+            };
+
             let row = number_repo
-                .find_one_by_type_and_store(&row_expected.r#type, &row_expected.store_id)
+                .find_one_by_type_and_store(&row_type, &row_expected.store_id)
                 .unwrap()
                 .expect(&format!("Number row not found: {:?} ", row_expected));
             assert_eq!(row_expected, &row);

--- a/server/service/src/sync/translation_remote/number.rs
+++ b/server/service/src/sync/translation_remote/number.rs
@@ -1,6 +1,8 @@
+use std::convert::TryFrom;
+
 use repository::{
-    RemoteSyncBufferRow, ChangelogRow, ChangelogTableName, NumberRow, NumberRowRepository,
-    NumberRowType, StorageConnection,
+    ChangelogRow, ChangelogTableName, NumberRow, NumberRowRepository, NumberRowType,
+    RemoteSyncBufferRow, StorageConnection,
 };
 
 use serde::{Deserialize, Serialize};
@@ -43,7 +45,7 @@ impl RemotePullTranslation for NumberTranslation {
                 id: data.ID.to_string(),
                 value: data.value,
                 store_id: type_and_store.1,
-                r#type: type_and_store.0,
+                r#type: type_and_store.0.to_string(),
             }),
         )))
     }
@@ -69,7 +71,12 @@ impl RemotePushUpsertTranslation for NumberTranslation {
             .find_one_by_id(&changelog.row_id)?
             .ok_or(anyhow::Error::msg("Number row not found"))?;
 
-        let name = match to_number_name(&r#type, &store_id) {
+        let number_type = match NumberRowType::try_from(r#type) {
+            Ok(number_type) => number_type,
+            Err(e) => return Err(anyhow::Error::msg(format!("Invalid number type {:?}", e))),
+        };
+
+        let name = match to_number_name(&number_type, &store_id) {
             Some(name) => name,
             None => return Ok(None),
         };
@@ -101,7 +108,10 @@ fn parse_number_name(value: String) -> Option<(NumberRowType, String)> {
         // new for omSupply
         "request_requisition" => NumberRowType::RequestRequisition,
         "response_requisition" => NumberRowType::ResponseRequisition,
-        _ => return None,
+        s => match NumberRowType::try_from(s.to_string()) {
+            Ok(number_type) => number_type,
+            Err(_) => return None,
+        },
     };
     let store = split.next()?.to_string();
     Some((number_type, store))
@@ -109,13 +119,16 @@ fn parse_number_name(value: String) -> Option<(NumberRowType, String)> {
 
 fn to_number_name(number_type: &NumberRowType, store_id: &str) -> Option<String> {
     let number_str = match number_type {
-        NumberRowType::InboundShipment => "supplier_invoice_number",
-        NumberRowType::OutboundShipment => "customer_invoice_number",
-        NumberRowType::InventoryAdjustment => "inventory_adjustment_serial_number",
-        NumberRowType::Stocktake => "stock_take_number",
+        NumberRowType::InboundShipment => "supplier_invoice_number".to_string(),
+        NumberRowType::OutboundShipment => "customer_invoice_number".to_string(),
+        NumberRowType::InventoryAdjustment => "inventory_adjustment_serial_number".to_string(),
+        NumberRowType::Stocktake => "stock_take_number".to_string(),
         // new for omSupply
-        NumberRowType::RequestRequisition => "request_requisition",
-        NumberRowType::ResponseRequisition => "response_requisition",
+        NumberRowType::RequestRequisition => "request_requisition".to_string(),
+        NumberRowType::ResponseRequisition => "response_requisition".to_string(),
+        NumberRowType::Program(s) => {
+            format!("PROGRAM_{}", s)
+        }
     };
     Some(format!("{}_for_store_{}", number_str, store_id))
 }

--- a/server/service/src/sync/translation_remote/test_data/mod.rs
+++ b/server/service/src/sync/translation_remote/test_data/mod.rs
@@ -1,7 +1,9 @@
+use std::convert::TryFrom;
+
 use repository::{
     ChangelogRow, InvoiceLineRowRepository, InvoiceRowRepository, LocationRowRepository,
-    NameRowRepository, NameStoreJoinRepository, NumberRowRepository, RemoteSyncBufferRow,
-    RepositoryError, RequisitionLineRowRepository, RequisitionRowRepository,
+    NameRowRepository, NameStoreJoinRepository, NumberRowRepository, NumberRowType,
+    RemoteSyncBufferRow, RepositoryError, RequisitionLineRowRepository, RequisitionRowRepository,
     StockLineRowRepository, StocktakeLineRowRepository, StocktakeRowRepository, StorageConnection,
 };
 
@@ -94,12 +96,14 @@ pub fn check_records_against_database(
         for upsert in translated_record.upserts {
             match upsert {
                 IntegrationUpsertRecord::Number(comparison_record) => {
+                    let row_type = match NumberRowType::try_from(comparison_record.r#type.clone()) {
+                        Ok(row_type) => row_type,
+                        Err(_) => panic!("Invalid row type: {}", comparison_record.r#type),
+                    };
+
                     assert_eq!(
                         NumberRowRepository::new(&connection)
-                            .find_one_by_type_and_store(
-                                &comparison_record.r#type,
-                                &comparison_record.store_id
-                            )
+                            .find_one_by_type_and_store(&row_type, &comparison_record.store_id)
                             .unwrap()
                             .expect(&format!("Number not found: {}", &comparison_record.id)),
                         comparison_record

--- a/server/service/src/sync/translation_remote/test_data/number.rs
+++ b/server/service/src/sync/translation_remote/test_data/number.rs
@@ -1,6 +1,6 @@
 use repository::{
-    RemoteSyncBufferAction, RemoteSyncBufferRow,
     ChangelogAction, ChangelogRow, ChangelogTableName, NumberRow, NumberRowType,
+    RemoteSyncBufferAction, RemoteSyncBufferRow,
 };
 use serde_json::json;
 
@@ -26,7 +26,7 @@ fn number_stock_take_pull_record() -> TestSyncRecord {
                 id: NUMBER_STOCK_TAKE.0.to_string(),
                 value: 1,
                 store_id: "store_remote_pull".to_string(),
-                r#type: NumberRowType::Stocktake,
+                r#type: NumberRowType::Stocktake.to_string(),
             }),
         )),
         identifier: "Stocktake",
@@ -70,7 +70,7 @@ fn number_inv_adjustment_pull_record() -> TestSyncRecord {
                 id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
                 value: 2,
                 store_id: "store_remote_pull".to_string(),
-                r#type: NumberRowType::InventoryAdjustment,
+                r#type: NumberRowType::InventoryAdjustment.to_string(),
             }),
         )),
         identifier: "Inventory adjustment",
@@ -114,7 +114,7 @@ fn number_customer_invoice_pull_record() -> TestSyncRecord {
                 id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
                 value: 8,
                 store_id: "store_remote_pull".to_string(),
-                r#type: NumberRowType::OutboundShipment,
+                r#type: NumberRowType::OutboundShipment.to_string(),
             }),
         )),
         identifier: "Customer invoice",
@@ -180,7 +180,7 @@ fn number_supplier_invoice_pull_record() -> TestSyncRecord {
                 id: SUPPLIER_INVOICE.0.to_string(),
                 value: 3,
                 store_id: "store_remote_pull".to_string(),
-                r#type: NumberRowType::InboundShipment,
+                r#type: NumberRowType::InboundShipment.to_string(),
             }),
         )),
         identifier: "Supplier invoice",
@@ -209,6 +209,52 @@ fn number_supplier_invoice_push_record() -> TestSyncPushRecord {
     }
 }
 
+const PROGRAM_NUMBER: (&'static str, &'static str) = (
+    "bd7bd0c2-9e08-436d-aafb-48b48f89c8c9",
+    r#"{
+      "ID": "bd7bd0c2-9e08-436d-aafb-48b48f89c8c9",
+      "name": "PROGRAM_TEST_EXAMPLE_for_store_store_remote_pull",
+      "value": 3
+    }"#,
+);
+
+fn number_programs_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Number(NumberRow {
+                id: PROGRAM_NUMBER.0.to_string(),
+                value: 3,
+                store_id: "store_remote_pull".to_string(),
+                r#type: NumberRowType::Program("TEST_EXAMPLE".to_string()).to_string(),
+            }),
+        )),
+        identifier: "Program Number",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_60".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: PROGRAM_NUMBER.0.to_string(),
+            data: PROGRAM_NUMBER.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+
+fn number_programs_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Number,
+            row_id: PROGRAM_NUMBER.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNumberRow {
+            ID: PROGRAM_NUMBER.0.to_string(),
+            name: "PROGRAM_TEST_EXAMPLE_for_store_store_remote_pull".to_string(),
+            value: 3,
+        }),
+    }
+}
+
 #[allow(dead_code)]
 pub fn get_test_number_records() -> Vec<TestSyncRecord> {
     vec![
@@ -217,6 +263,7 @@ pub fn get_test_number_records() -> Vec<TestSyncRecord> {
         number_customer_invoice_pull_record(),
         number_supplier_invoice_pull_record(),
         number_purchase_order_pull_record(),
+        number_programs_pull_record(),
     ]
 }
 
@@ -227,5 +274,6 @@ pub fn get_test_push_number_records() -> Vec<TestSyncPushRecord> {
         number_inv_adjustment_push_record(),
         number_customer_invoice_push_record(),
         number_supplier_invoice_push_record(),
+        number_programs_push_record(),
     ]
 }


### PR DESCRIPTION
Closes #298
Closes #468 
Closes #442 

- Test for concurrent 'next_number' requests for both insert (First number) and update (subsequent numbers) cases
-  The fix is to do most of the work in the repository layer relying on the 'returning' feature from postgres and sqlite to return the data from any updated or inserted rows.
- Add unique constraint to db

Things get a little funky in the insert case as postgres rolls back the transaction if there is a unique constraint violation without `ON CONFLICT DO NOTHING` which isn't supported in sqlite.