### PR TITLE
Create encounter modal

### DIFF
--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -4,6 +4,7 @@
   "button.add-prescription": "Add Prescription",
   "button.add-program": "Add Program",
   "error.encounter-not-found": "Encounter not found.",
+  "error.encounter-not-created": "Unable to create encounter",
   "filename.patients": "patients",
   "label.date-of-birth": "Date of Birth",
   "label.age": "Age",

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -7,6 +7,7 @@ import {
   differenceInMonths,
   differenceInYears,
   isPast,
+  isFuture,
   isThisWeek,
   isToday,
   isThisMonth,
@@ -45,6 +46,8 @@ export const DateUtils = {
     const maybeDate = new Date(date);
     return isValid(maybeDate) ? maybeDate : null;
   },
+  isPast,
+  isFuture,
   isExpired: (expiryDate: Date): boolean => isPast(expiryDate),
   isAlmostExpired: (
     expiryDate: Date,

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1897,7 +1897,7 @@ export type InsertProgramEnrolmentInput = {
   type: Scalars['String'];
 };
 
-export type InsertProgramEnrolmentResponse = DocumentNode;
+export type InsertProgramEnrolmentResponse = ProgramEnrolmentNode;
 
 export type InsertRequestRequisitionError = {
   __typename: 'InsertRequestRequisitionError';
@@ -3797,7 +3797,7 @@ export type UpdateProgramEnrolmentInput = {
   type: Scalars['String'];
 };
 
-export type UpdateProgramEnrolmentResponse = DocumentNode;
+export type UpdateProgramEnrolmentResponse = ProgramEnrolmentNode;
 
 export type UpdateRequestRequisitionError = {
   __typename: 'UpdateRequestRequisitionError';

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1658,7 +1658,7 @@ export type InsertEncounterInput = {
   type: Scalars['String'];
 };
 
-export type InsertEncounterResponse = DocumentNode;
+export type InsertEncounterResponse = EncounterNode;
 
 export type InsertErrorInterface = {
   description: Scalars['String'];
@@ -3549,7 +3549,7 @@ export type UpdateEncounterInput = {
   schemaId: Scalars['String'];
 };
 
-export type UpdateEncounterResponse = DocumentNode;
+export type UpdateEncounterResponse = EncounterNode;
 
 export type UpdateErrorInterface = {
   description: Scalars['String'];

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useTranslation,
   DetailViewSkeleton,
@@ -6,6 +6,8 @@ import {
   useNavigate,
   RouteBuilder,
   useDebounceCallback,
+  useBreadcrumbs,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import { EncounterFragment, useEncounter } from '../api';
 
@@ -20,10 +22,21 @@ export const DetailView: FC = () => {
   const navigate = useNavigate();
 
   const handleSave = useEncounter.document.upsert(
+  const dateFormat = useFormatDateTime();
     encounter?.patient.id ?? '',
     encounter?.program ?? '',
     encounter?.type ?? ''
   );
+
+  const { setSuffix } = useBreadcrumbs([AppRoute.Encounter]);
+  useEffect(() => {
+    if (encounter)
+      setSuffix(
+        `${
+          encounter.document.documentRegistry?.name
+        } - ${dateFormat.localisedDateTime(encounter.startDatetime)}`
+      );
+  }, [encounter]);
 
   const {
     JsonForm,

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -21,8 +21,8 @@ export const DetailView: FC = () => {
   const { data: encounter, isLoading } = useEncounter.document.get();
   const navigate = useNavigate();
 
-  const handleSave = useEncounter.document.upsert(
   const dateFormat = useFormatDateTime();
+  const handleSave = useEncounter.document.upsertDocument(
     encounter?.patient.id ?? '',
     encounter?.program ?? '',
     encounter?.type ?? ''

--- a/client/packages/system/src/Encounter/api/api.ts
+++ b/client/packages/system/src/Encounter/api/api.ts
@@ -6,7 +6,6 @@ import {
   EncounterSortFieldInput,
 } from '@openmsupply-client/common';
 import {
-  EncounterDocumentFragment,
   EncounterDocumentRegistryFragment,
   EncounterFragment,
   EncounterRowFragment,
@@ -66,13 +65,13 @@ export const getEncounterQueries = (sdk: Sdk, storeId: string) => ({
 
   insertEncounter: async (
     input: InsertEncounterInput
-  ): Promise<EncounterDocumentFragment> => {
+  ): Promise<EncounterFragment> => {
     const result = await sdk.insertEncounter({
       storeId,
       input,
     });
 
-    if (result.insertEncounter.__typename === 'DocumentNode') {
+    if (result.insertEncounter.__typename === 'EncounterNode') {
       return result.insertEncounter;
     }
 
@@ -81,13 +80,13 @@ export const getEncounterQueries = (sdk: Sdk, storeId: string) => ({
 
   updateEncounter: async (
     input: UpdateEncounterInput
-  ): Promise<EncounterDocumentFragment> => {
+  ): Promise<EncounterFragment> => {
     const result = await sdk.updateEncounter({
       storeId,
       input,
     });
 
-    if (result.updateEncounter.__typename === 'DocumentNode') {
+    if (result.updateEncounter.__typename === 'EncounterNode') {
       return result.updateEncounter;
     }
 

--- a/client/packages/system/src/Encounter/api/hooks/document/index.ts
+++ b/client/packages/system/src/Encounter/api/hooks/document/index.ts
@@ -2,7 +2,10 @@ import { useInsertEncounter } from './useInsertEncounter';
 import { useEncounters } from './useEncounters';
 import { useEncounter } from './useEncounter';
 import { useUpdateEncounter } from './useUpdateEncounter';
-import { useUpsertEncounter } from './useUpsertEncounter';
+import {
+  useUpsertEncounter,
+  useUpsertEncounterDocument,
+} from './useUpsertEncounter';
 
 export const Document = {
   useEncounter,
@@ -10,4 +13,5 @@ export const Document = {
   useInsertEncounter,
   useUpdateEncounter,
   useUpsertEncounter,
+  useUpsertEncounterDocument,
 };

--- a/client/packages/system/src/Encounter/api/hooks/document/useEncounter.ts
+++ b/client/packages/system/src/Encounter/api/hooks/document/useEncounter.ts
@@ -7,6 +7,15 @@ export const useEncounter = () => {
   const id = useEncounterId();
 
   return {
-    ...useQuery(api.keys.detail(id), () => api.get.byId(id)),
+    ...useQuery(
+      api.keys.detail(id),
+      () => api.get.byId(id),
+      // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+      // is inactive. For example, when navigating away from the page and back again, refetch.
+      {
+        refetchOnMount: false,
+        cacheTime: 0,
+      }
+    ),
   };
 };

--- a/client/packages/system/src/Encounter/api/hooks/document/useUpsertEncounter.ts
+++ b/client/packages/system/src/Encounter/api/hooks/document/useUpsertEncounter.ts
@@ -1,12 +1,19 @@
 import { SaveDocumentMutation } from '../../../../Patient/JsonForms';
+import { EncounterFragment } from '../../operations.generated';
 import { useInsertEncounter } from './useInsertEncounter';
 import { useUpdateEncounter } from './useUpdateEncounter';
+
+export type UpsertEncounterMutation = (
+  jsonData: unknown,
+  formSchemaId: string,
+  parent?: string
+) => Promise<EncounterFragment>;
 
 export const useUpsertEncounter = (
   patientId: string,
   programType: string,
   type: string
-): SaveDocumentMutation => {
+): UpsertEncounterMutation => {
   const { mutateAsync: insertEncounter } = useInsertEncounter();
   const { mutateAsync: updateEncounter } = useUpdateEncounter();
   return async (jsonData: unknown, formSchemaId: string, parent?: string) => {
@@ -27,5 +34,17 @@ export const useUpsertEncounter = (
       });
       return result;
     }
+  };
+};
+
+export const useUpsertEncounterDocument = (
+  patientId: string,
+  programType: string,
+  type: string
+): SaveDocumentMutation => {
+  const upsert = useUpsertEncounter(patientId, programType, type);
+  return async (jsonData: unknown, formSchemaId: string, parent?: string) => {
+    const result = await upsert(jsonData, formSchemaId, parent);
+    return result.document;
   };
 };

--- a/client/packages/system/src/Encounter/api/hooks/index.ts
+++ b/client/packages/system/src/Encounter/api/hooks/index.ts
@@ -14,6 +14,7 @@ export const useEncounter = {
     insert: Document.useInsertEncounter,
     update: Document.useUpdateEncounter,
     upsert: Document.useUpsertEncounter,
+    upsertDocument: Document.useUpsertEncounterDocument,
   },
 
   registry: {

--- a/client/packages/system/src/Encounter/api/operations.generated.ts
+++ b/client/packages/system/src/Encounter/api/operations.generated.ts
@@ -10,7 +10,7 @@ export type EncounterDocumentRegistryFragment = { __typename: 'DocumentRegistryN
 
 export type EncounterDocumentFragment = { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null };
 
-export type EncounterFragment = { __typename: 'EncounterNode', type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } };
+export type EncounterFragment = { __typename: 'EncounterNode', id: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } };
 
 export type EncountersQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -35,7 +35,7 @@ export type EncounterByIdQueryVariables = Types.Exact<{
 }>;
 
 
-export type EncounterByIdQuery = { __typename: 'FullQuery', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } }> } };
+export type EncounterByIdQuery = { __typename: 'FullQuery', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } }> } };
 
 export type InsertEncounterMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -43,7 +43,7 @@ export type InsertEncounterMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertEncounterMutation = { __typename: 'FullMutation', insertEncounter: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } };
+export type InsertEncounterMutation = { __typename: 'FullMutation', insertEncounter: { __typename: 'EncounterNode', id: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } } };
 
 export type UpdateEncounterMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -51,7 +51,7 @@ export type UpdateEncounterMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEncounterMutation = { __typename: 'FullMutation', updateEncounter: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } };
+export type UpdateEncounterMutation = { __typename: 'FullMutation', updateEncounter: { __typename: 'EncounterNode', id: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, program: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'NameNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', context: Types.DocumentRegistryNodeContext, documentType: string, formSchemaId: string, id: string, jsonSchema: any, name?: string | null, parentId?: string | null, uiSchema: any, uiSchemaType: string, children: Array<{ __typename: 'DocumentRegistryNode', id: string }> } | null } } };
 
 export const EncounterRowFragmentDoc = gql`
     fragment EncounterRow on EncounterNode {
@@ -107,6 +107,7 @@ export const EncounterDocumentFragmentDoc = gql`
     ${EncounterDocumentRegistryFragmentDoc}`;
 export const EncounterFragmentDoc = gql`
     fragment Encounter on EncounterNode {
+  id
   type
   name
   status
@@ -164,23 +165,23 @@ export const EncounterByIdDocument = gql`
 export const InsertEncounterDocument = gql`
     mutation insertEncounter($storeId: String!, $input: InsertEncounterInput!) {
   insertEncounter(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on EncounterNode {
       __typename
-      ...EncounterDocument
+      ...Encounter
     }
   }
 }
-    ${EncounterDocumentFragmentDoc}`;
+    ${EncounterFragmentDoc}`;
 export const UpdateEncounterDocument = gql`
     mutation updateEncounter($storeId: String!, $input: UpdateEncounterInput!) {
   updateEncounter(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on EncounterNode {
       __typename
-      ...EncounterDocument
+      ...Encounter
     }
   }
 }
-    ${EncounterDocumentFragmentDoc}`;
+    ${EncounterFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 

--- a/client/packages/system/src/Encounter/api/operations.graphql
+++ b/client/packages/system/src/Encounter/api/operations.graphql
@@ -48,6 +48,7 @@ fragment EncounterDocument on DocumentNode {
 }
 
 fragment Encounter on EncounterNode {
+  id
   type
   name
   status
@@ -110,18 +111,18 @@ query encounterById($storeId: String!, $encounterId: String!) {
 
 mutation insertEncounter($storeId: String!, $input: InsertEncounterInput!) {
   insertEncounter(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on EncounterNode {
       __typename
-      ...EncounterDocument
+      ...Encounter
     }
   }
 }
 
 mutation updateEncounter($storeId: String!, $input: UpdateEncounterInput!) {
   updateEncounter(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on EncounterNode {
       __typename
-      ...EncounterDocument
+      ...Encounter
     }
   }
 }

--- a/client/packages/system/src/Patient/Encounter/DetailModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/DetailModal.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   DatePickerInput,
   DialogButton,
+  EncounterNodeStatus,
   InputWithLabelRow,
   RouteBuilder,
   Stack,
@@ -26,7 +27,10 @@ import {
 } from '../../Encounter/api/operations.generated';
 import { AppRoute } from 'packages/config/src';
 
-type Encounter = Pick<EncounterFragment, 'startDatetime' | 'endDatetime'>;
+type Encounter = Pick<
+  EncounterFragment,
+  'startDatetime' | 'endDatetime' | 'status'
+>;
 
 export const EncounterDetailModal: FC = () => {
   const patientId = usePatient.utils.id();
@@ -87,9 +91,17 @@ export const EncounterDetailModal: FC = () => {
   }, [registryData]);
 
   const setStartDatetime = (date: Date | null): void => {
-    const startDatetime = date ? DateUtils.formatRFC3339(date) : undefined;
-    if (!startDatetime) return;
-    setData({ ...data, startDatetime });
+    if (!date) return;
+
+    const startDatetime = DateUtils.formatRFC3339(date);
+
+    setData({
+      ...data,
+      startDatetime,
+      status: DateUtils.isFuture(date)
+        ? EncounterNodeStatus.Scheduled
+        : data?.status,
+    });
   };
 
   const setEndDatetime = (date: Date | null): void => {

--- a/client/packages/system/src/Patient/Encounter/DetailModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/DetailModal.tsx
@@ -3,87 +3,123 @@ import {
   AlertIcon,
   BasicSpinner,
   Box,
+  DatePickerInput,
   DialogButton,
   InputWithLabelRow,
+  RouteBuilder,
   Stack,
+  TimePickerInput,
   Typography,
   useDialog,
+  useNavigate,
+  useNotification,
 } from '@openmsupply-client/common';
-import { useTranslation } from '@common/intl';
+import { DateUtils, useTranslation } from '@common/intl';
 import { useEncounter } from '../../Encounter';
 import { usePatientModalStore } from '../hooks';
 import { PatientModal } from '../PatientView';
 import { ProgramRowFragmentWithId, usePatient } from '../api';
-import { CreateDocument, useJsonForms } from '../JsonForms';
 import { ProgramEnrolmentSearchInput } from '../Components';
+import {
+  EncounterFragment,
+  EncounterDocumentRegistryFragment,
+} from '../../Encounter/api/operations.generated';
+import { AppRoute } from 'packages/config/src';
+
+type Encounter = Pick<EncounterFragment, 'startDatetime' | 'endDatetime'>;
 
 export const EncounterDetailModal: FC = () => {
   const patientId = usePatient.utils.id();
   const t = useTranslation('patients');
-  const { current, reset, document } = usePatientModalStore();
+  const { current, setCurrent } = usePatientModalStore();
   const [program, setProgram] = useState<ProgramRowFragmentWithId | null>(null);
-  const [error, setError] = useState(false);
-  const { mutate: fetch, isLoading, data } = useEncounter.registry.byProgram();
-  const isCreate = !document?.name;
-  const [createDoc, setCreateDoc] = useState<CreateDocument | undefined>(
-    undefined
-  );
+  const [isError, setIsError] = useState(false);
+  const {
+    mutate: fetch,
+    isLoading,
+    data: registryData,
+  } = useEncounter.registry.byProgram();
+  const [documentRegistry, setDocumentRegistry] = useState<
+    EncounterDocumentRegistryFragment | undefined
+  >(undefined);
+
+  const [data, setData] = useState<Encounter | undefined>(undefined);
+  const navigate = useNavigate();
+  const { error } = useNotification();
 
   const handleSave = useEncounter.document.upsert(
     patientId,
     program?.type ?? '',
-    createDoc?.documentRegistry?.documentType ?? ''
-  );
-  const { JsonForm, saveData, isDirty, validationError } = useJsonForms(
-    document?.name,
-    {
-      handleSave,
-    },
-    createDoc
+    documentRegistry?.documentType ?? ''
   );
 
-  const onClose = () => {
-    reset();
+  const reset = () => {
+    setCurrent(undefined);
     setProgram(null);
-    setCreateDoc(undefined);
-    setError(false);
+    setDocumentRegistry(undefined);
+    setData(undefined);
+    setIsError(false);
   };
 
   const { Modal } = useDialog({
     isOpen: current === PatientModal.Encounter,
-    onClose,
+    onClose: reset,
   });
 
   const onChangeProgram = (program: ProgramRowFragmentWithId) => {
     setProgram(program);
-    setError(false);
+    setIsError(false);
     fetch(program.document.documentRegistry?.id || '');
   };
 
   useEffect(() => {
-    if (data && data?.totalCount > 0) {
-      const documentRegistry = data.nodes[0];
+    if (registryData && registryData?.totalCount > 0) {
+      const documentRegistry = registryData.nodes[0];
       if (documentRegistry) {
-        setCreateDoc({ data: {}, documentRegistry });
-        setError(false);
+        setDocumentRegistry(documentRegistry);
+        setIsError(false);
         return;
       }
     } else {
-      setError(true);
+      setIsError(true);
     }
-    setCreateDoc(undefined);
-  }, [data]);
+    setDocumentRegistry(undefined);
+  }, [registryData]);
+
+  const setStartDatetime = (date: Date | null): void => {
+    const startDatetime = date ? DateUtils.formatRFC3339(date) : undefined;
+    if (!startDatetime) return;
+    setData({ ...data, startDatetime });
+  };
+
+  const setEndDatetime = (date: Date | null): void => {
+    const endDatetime = date ? DateUtils.formatRFC3339(date) : null;
+    if (endDatetime && data?.startDatetime) setData({ ...data, endDatetime });
+  };
 
   return (
     <Modal
-      title={t(isCreate ? 'label.new-encounter' : 'label.edit-encounter')}
-      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      title={t('label.new-encounter')}
+      cancelButton={<DialogButton variant="cancel" onClick={reset} />}
       okButton={
         <DialogButton
-          variant={isCreate ? 'create' : 'ok'}
-          disabled={!isDirty || !!validationError}
+          variant={'create'}
+          disabled={data === undefined || isLoading}
           onClick={async () => {
-            await saveData();
+            if (documentRegistry !== undefined) {
+              const { id } = await handleSave(
+                data,
+                documentRegistry.formSchemaId
+              );
+              if (!!id)
+                navigate(
+                  RouteBuilder.create(AppRoute.Dispensary)
+                    .addPart(AppRoute.Encounter)
+                    .addPart(id)
+                    .build()
+                );
+              else error(t('error.encounter-not-created'))();
+            }
             reset();
           }}
         />
@@ -91,24 +127,56 @@ export const EncounterDetailModal: FC = () => {
       width={700}
     >
       <React.Suspense fallback={<div />}>
-        <Stack alignItems="center">
-          {isCreate && (
-            <InputWithLabelRow
-              label={t('label.program')}
-              Input={
-                <ProgramEnrolmentSearchInput
-                  onChange={onChangeProgram}
-                  value={program}
-                />
-              }
-            />
-          )}
+        <Stack alignItems="flex-start" gap={1} sx={{ paddingLeft: '20px' }}>
+          <InputWithLabelRow
+            label={t('label.program')}
+            Input={
+              <ProgramEnrolmentSearchInput
+                onChange={onChangeProgram}
+                value={program}
+              />
+            }
+          />
           <RenderForm
-            Form={JsonForm}
-            isCreate={isCreate}
-            isError={error}
+            isError={isError}
             isLoading={isLoading}
             isProgram={!!program}
+            form={
+              <>
+                <InputWithLabelRow
+                  label={t('label.visit-date')}
+                  Input={
+                    <DatePickerInput
+                      value={DateUtils.getDateOrNull(
+                        data?.startDatetime ?? null
+                      )}
+                      onChange={setStartDatetime}
+                    />
+                  }
+                />
+                <InputWithLabelRow
+                  label={t('label.visit-start')}
+                  Input={
+                    <TimePickerInput
+                      value={DateUtils.getDateOrNull(
+                        data?.startDatetime ?? null
+                      )}
+                      onChange={setStartDatetime}
+                    />
+                  }
+                />
+                <InputWithLabelRow
+                  label={t('label.visit-end')}
+                  Input={
+                    <TimePickerInput
+                      value={DateUtils.getDateOrNull(data?.endDatetime ?? null)}
+                      disabled={data?.startDatetime === undefined}
+                      onChange={setEndDatetime}
+                    />
+                  }
+                />
+              </>
+            }
           />
         </Stack>
       </React.Suspense>
@@ -117,20 +185,18 @@ export const EncounterDetailModal: FC = () => {
 };
 
 const RenderForm = ({
-  Form,
-  isCreate,
+  form,
   isError,
   isLoading,
   isProgram,
 }: {
-  Form: React.ReactNode;
-  isCreate: boolean;
+  form: React.ReactNode;
   isError: boolean;
   isLoading: boolean;
   isProgram: boolean;
 }) => {
   const t = useTranslation('common');
-  if (!isProgram && isCreate) return null;
+  if (!isProgram) return null;
   if (isError)
     return (
       <Box display="flex" gap={1} padding={3}>
@@ -140,5 +206,5 @@ const RenderForm = ({
     );
   if (isLoading) return <BasicSpinner />;
 
-  return <>{Form}</>;
+  return <>{form}</>;
 };

--- a/client/packages/system/src/Patient/ProgramEnrolment/api/api.ts
+++ b/client/packages/system/src/Patient/ProgramEnrolment/api/api.ts
@@ -24,8 +24,8 @@ export const getProgramEnrolmentQueries = (sdk: Sdk, storeId: string) => ({
       input,
     });
 
-    if (result.insertProgramEnrolment.__typename === 'DocumentNode') {
-      return result.insertProgramEnrolment;
+    if (result.insertProgramEnrolment.__typename === 'ProgramEnrolmentNode') {
+      return result.insertProgramEnrolment.document;
     }
 
     throw new Error('Could not insert program');
@@ -39,8 +39,8 @@ export const getProgramEnrolmentQueries = (sdk: Sdk, storeId: string) => ({
       input,
     });
 
-    if (result.updateProgramEnrolment.__typename === 'DocumentNode') {
-      return result.updateProgramEnrolment;
+    if (result.updateProgramEnrolment.__typename === 'ProgramEnrolmentNode') {
+      return result.updateProgramEnrolment.document;
     }
 
     throw new Error('Could not update program');

--- a/client/packages/system/src/Patient/ProgramEnrolment/api/operations.generated.ts
+++ b/client/packages/system/src/Patient/ProgramEnrolment/api/operations.generated.ts
@@ -22,7 +22,7 @@ export type InsertProgramEnrolmentMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertProgramEnrolmentMutation = { __typename: 'FullMutation', insertProgramEnrolment: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', uiSchemaType: string, documentType: string, context: Types.DocumentRegistryNodeContext, formSchemaId: string, jsonSchema: any, uiSchema: any } | null } };
+export type InsertProgramEnrolmentMutation = { __typename: 'FullMutation', insertProgramEnrolment: { __typename: 'ProgramEnrolmentNode', type: string, programPatientId?: string | null, patientId: string, name: string, enrolmentDatetime: string, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', uiSchemaType: string, documentType: string, context: Types.DocumentRegistryNodeContext, formSchemaId: string, jsonSchema: any, uiSchema: any } | null } } };
 
 export type UpdateProgramEnrolmentMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -30,7 +30,7 @@ export type UpdateProgramEnrolmentMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateProgramEnrolmentMutation = { __typename: 'FullMutation', updateProgramEnrolment: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', uiSchemaType: string, documentType: string, context: Types.DocumentRegistryNodeContext, formSchemaId: string, jsonSchema: any, uiSchema: any } | null } };
+export type UpdateProgramEnrolmentMutation = { __typename: 'FullMutation', updateProgramEnrolment: { __typename: 'ProgramEnrolmentNode', type: string, programPatientId?: string | null, patientId: string, name: string, enrolmentDatetime: string, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, author: string, timestamp: string, type: string, data: any, documentRegistry?: { __typename: 'DocumentRegistryNode', uiSchemaType: string, documentType: string, context: Types.DocumentRegistryNodeContext, formSchemaId: string, jsonSchema: any, uiSchema: any } | null } } };
 
 export const ProgramEnrolmentDocumentFragmentDoc = gql`
     fragment ProgramEnrolmentDocument on DocumentNode {
@@ -79,23 +79,23 @@ export const ProgramEnrolmentByIdDocument = gql`
 export const InsertProgramEnrolmentDocument = gql`
     mutation insertProgramEnrolment($storeId: String!, $input: InsertProgramEnrolmentInput!) {
   insertProgramEnrolment(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on ProgramEnrolmentNode {
       __typename
-      ...ProgramEnrolmentDocument
+      ...ProgramEnrolment
     }
   }
 }
-    ${ProgramEnrolmentDocumentFragmentDoc}`;
+    ${ProgramEnrolmentFragmentDoc}`;
 export const UpdateProgramEnrolmentDocument = gql`
     mutation updateProgramEnrolment($storeId: String!, $input: UpdateProgramEnrolmentInput!) {
   updateProgramEnrolment(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on ProgramEnrolmentNode {
       __typename
-      ...ProgramEnrolmentDocument
+      ...ProgramEnrolment
     }
   }
 }
-    ${ProgramEnrolmentDocumentFragmentDoc}`;
+    ${ProgramEnrolmentFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 

--- a/client/packages/system/src/Patient/ProgramEnrolment/api/operations.graphql
+++ b/client/packages/system/src/Patient/ProgramEnrolment/api/operations.graphql
@@ -47,9 +47,9 @@ mutation insertProgramEnrolment(
   $input: InsertProgramEnrolmentInput!
 ) {
   insertProgramEnrolment(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on ProgramEnrolmentNode {
       __typename
-      ...ProgramEnrolmentDocument
+      ...ProgramEnrolment
     }
   }
 }
@@ -59,9 +59,9 @@ mutation updateProgramEnrolment(
   $input: UpdateProgramEnrolmentInput!
 ) {
   updateProgramEnrolment(storeId: $storeId, input: $input) {
-    ... on DocumentNode {
+    ... on ProgramEnrolmentNode {
       __typename
-      ...ProgramEnrolmentDocument
+      ...ProgramEnrolment
     }
   }
 }

--- a/server/graphql/document/src/mutations/encounter/insert.rs
+++ b/server/graphql/document/src/mutations/encounter/insert.rs
@@ -3,12 +3,13 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
+use repository::{EncounterFilter, EqualFilter};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     document::encounter::{InsertEncounter, InsertEncounterError},
 };
 
-use crate::types::document::DocumentNode;
+use crate::types::encounter::EncounterNode;
 
 #[derive(InputObject)]
 pub struct InsertEncounterInput {
@@ -25,7 +26,7 @@ pub struct InsertEncounterInput {
 
 #[derive(Union)]
 pub enum InsertEncounterResponse {
-    Response(DocumentNode),
+    Response(EncounterNode),
 }
 
 pub fn insert_encounter(
@@ -37,14 +38,14 @@ pub fn insert_encounter(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::MutateEncounter,
-            store_id: Some(store_id),
+            store_id: Some(store_id.clone()),
         },
     )?;
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
 
-    match service_provider.encounter_service.insert_encounter(
+    let document = match service_provider.encounter_service.insert_encounter(
         &service_context,
         service_provider,
         &user.user_id,
@@ -56,7 +57,7 @@ pub fn insert_encounter(
             r#type: input.r#type,
         },
     ) {
-        Ok(document) => Ok(InsertEncounterResponse::Response(DocumentNode { document })),
+        Ok(document) => document,
         Err(error) => {
             let formatted_error = format!("{:#?}", error);
             let std_err = match error {
@@ -76,7 +77,22 @@ pub fn insert_encounter(
                     StandardGraphqlError::InternalError(formatted_error)
                 }
             };
-            Err(std_err.extend())
+            return Err(std_err.extend());
         }
-    }
+    };
+
+    let encounter_row = service_provider
+        .encounter_service
+        .encounter(
+            &service_context,
+            EncounterFilter::new().name(EqualFilter::equal_to(&document.name)),
+        )?
+        .ok_or(
+            StandardGraphqlError::InternalError("Encounter went missing".to_string()).extend(),
+        )?;
+
+    Ok(InsertEncounterResponse::Response(EncounterNode {
+        store_id,
+        encounter_row,
+    }))
 }

--- a/server/graphql/document/src/mutations/program_enrolment/insert.rs
+++ b/server/graphql/document/src/mutations/program_enrolment/insert.rs
@@ -3,12 +3,13 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
+use repository::{EqualFilter, ProgramEnrolmentFilter};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     document::program::{UpsertProgramEnrolment, UpsertProgramEnrolmentError},
 };
 
-use crate::types::document::DocumentNode;
+use crate::types::program_enrolment::ProgramEnrolmentNode;
 
 #[derive(InputObject)]
 pub struct InsertProgramEnrolmentInput {
@@ -23,7 +24,7 @@ pub struct InsertProgramEnrolmentInput {
 
 #[derive(Union)]
 pub enum InsertProgramEnrolmentResponse {
-    Response(DocumentNode),
+    Response(ProgramEnrolmentNode),
 }
 
 pub fn insert_program_enrolment(
@@ -35,14 +36,14 @@ pub fn insert_program_enrolment(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::MutateProgram,
-            store_id: Some(store_id),
+            store_id: Some(store_id.clone()),
         },
     )?;
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
 
-    match service_provider
+    let document = match service_provider
         .program_enrolment_service
         .upsert_program_enrolment(
             &service_context,
@@ -56,9 +57,7 @@ pub fn insert_program_enrolment(
                 r#type: input.r#type,
             },
         ) {
-        Ok(document) => Ok(InsertProgramEnrolmentResponse::Response(DocumentNode {
-            document,
-        })),
+        Ok(document) => document,
         Err(error) => {
             let formatted_error = format!("{:#?}", error);
             let std_err = match error {
@@ -84,7 +83,24 @@ pub fn insert_program_enrolment(
                     StandardGraphqlError::InternalError(formatted_error)
                 }
             };
-            Err(std_err.extend())
+            return Err(std_err.extend());
         }
-    }
+    };
+
+    let program_row = service_provider
+        .program_enrolment_service
+        .program_enrolment(
+            &service_context,
+            ProgramEnrolmentFilter::new().r#type(EqualFilter::equal_to(&document.r#type)),
+        )?
+        .ok_or(
+            StandardGraphqlError::InternalError("Program enrolment went missing".to_string())
+                .extend(),
+        )?;
+    Ok(InsertProgramEnrolmentResponse::Response(
+        ProgramEnrolmentNode {
+            store_id,
+            program_row,
+        },
+    ))
 }

--- a/server/graphql/document/src/queries/encounter.rs
+++ b/server/graphql/document/src/queries/encounter.rs
@@ -99,7 +99,7 @@ pub fn encounters(
 
     let result = service_provider
         .encounter_service
-        .get_patient_program_encounters(
+        .encounters(
             &context,
             page.map(PaginationOption::from),
             filter.map(|f| f.to_domain_filter()),

--- a/server/graphql/document/src/queries/patient.rs
+++ b/server/graphql/document/src/queries/patient.rs
@@ -117,7 +117,7 @@ impl PatientNode {
         let entries = ctx
             .service_provider()
             .program_enrolment_service
-            .get_patient_program_enrolments(
+            .program_enrolments(
                 &context,
                 Pagination::all(),
                 None,

--- a/server/graphql/document/src/queries/program_enrolment.rs
+++ b/server/graphql/document/src/queries/program_enrolment.rs
@@ -79,7 +79,7 @@ pub fn program_enrolments(
 
     let nodes: Vec<ProgramEnrolmentNode> = service_provider
         .program_enrolment_service
-        .get_patient_program_enrolments(
+        .program_enrolments(
             &context,
             Pagination::all(),
             sort.map(ProgramEnrolmentSortInput::to_domain),

--- a/server/graphql/document/src/types/program_enrolment.rs
+++ b/server/graphql/document/src/types/program_enrolment.rs
@@ -85,7 +85,7 @@ impl ProgramEnrolmentNode {
         let entries = ctx
             .service_provider()
             .encounter_service
-            .get_patient_program_encounters(
+            .encounters(
                 &context,
                 None,
                 Some(

--- a/server/service/src/document/encounter/mod.rs
+++ b/server/service/src/document/encounter/mod.rs
@@ -3,6 +3,7 @@ use repository::Encounter;
 use repository::EncounterFilter;
 use repository::EncounterSort;
 use repository::PaginationOption;
+use repository::RepositoryError;
 
 use crate::service_provider::ServiceContext;
 use crate::service_provider::ServiceProvider;
@@ -13,7 +14,8 @@ use self::encounter_fields::encounter_fields;
 use self::encounter_fields::EncounterFields;
 use self::encounter_fields::EncounterFieldsResult;
 pub use self::insert::*;
-use self::query::get_patient_program_encounters;
+use self::query::encounter;
+use self::query::encounters;
 pub use self::update::*;
 
 pub mod encounter_fields;
@@ -45,14 +47,22 @@ pub trait EncounterServiceTrait: Sync + Send {
         update_encounter(ctx, service_provider, user_id, input)
     }
 
-    fn get_patient_program_encounters(
+    fn encounter(
+        &self,
+        ctx: &ServiceContext,
+        filter: EncounterFilter,
+    ) -> Result<Option<Encounter>, RepositoryError> {
+        encounter(ctx, filter)
+    }
+
+    fn encounters(
         &self,
         ctx: &ServiceContext,
         pagination: Option<PaginationOption>,
         filter: Option<EncounterFilter>,
         sort: Option<EncounterSort>,
     ) -> Result<ListResult<Encounter>, ListError> {
-        get_patient_program_encounters(ctx, pagination, filter, sort)
+        encounters(ctx, pagination, filter, sort)
     }
 
     fn encounters_fields(

--- a/server/service/src/document/encounter/query.rs
+++ b/server/service/src/document/encounter/query.rs
@@ -1,5 +1,6 @@
 use repository::{
     Encounter, EncounterFilter, EncounterRepository, EncounterSort, PaginationOption,
+    RepositoryError,
 };
 
 use crate::{
@@ -9,7 +10,7 @@ use crate::{
 pub const MAX_LIMIT: u32 = 1000;
 pub const MIN_LIMIT: u32 = 1;
 
-pub(crate) fn get_patient_program_encounters(
+pub(crate) fn encounters(
     ctx: &ServiceContext,
     pagination: Option<PaginationOption>,
     filter: Option<EncounterFilter>,
@@ -21,4 +22,12 @@ pub(crate) fn get_patient_program_encounters(
         rows: repository.query(pagination, filter.clone(), sort)?,
         count: i64_to_u32(repository.count(filter)?),
     })
+}
+
+pub(crate) fn encounter(
+    ctx: &ServiceContext,
+    filter: EncounterFilter,
+) -> Result<Option<Encounter>, RepositoryError> {
+    let repository = EncounterRepository::new(&ctx.connection);
+    Ok(repository.query_by_filter(filter)?.pop())
 }

--- a/server/service/src/document/program/mod.rs
+++ b/server/service/src/document/program/mod.rs
@@ -9,7 +9,8 @@ use repository::Sort;
 use crate::service_provider::ServiceContext;
 use crate::service_provider::ServiceProvider;
 
-use self::query::get_patient_program_enrolments;
+use self::query::program_enrolment;
+use self::query::program_enrolments;
 pub use self::upsert::*;
 
 pub mod program_schema;
@@ -28,14 +29,22 @@ pub trait ProgramEnrolmentServiceTrait: Sync + Send {
         upsert_program_enrolment(ctx, service_provider, user_id, input)
     }
 
-    fn get_patient_program_enrolments(
+    fn program_enrolment(
+        &self,
+        ctx: &ServiceContext,
+        filter: ProgramEnrolmentFilter,
+    ) -> Result<Option<ProgramEnrolment>, RepositoryError> {
+        program_enrolment(ctx, filter)
+    }
+
+    fn program_enrolments(
         &self,
         ctx: &ServiceContext,
         pagination: Pagination,
         sort: Option<Sort<ProgramEnrolmentSortField>>,
         filter: Option<ProgramEnrolmentFilter>,
     ) -> Result<Vec<ProgramEnrolment>, RepositoryError> {
-        get_patient_program_enrolments(ctx, pagination, sort, filter)
+        program_enrolments(ctx, pagination, sort, filter)
     }
 }
 

--- a/server/service/src/document/program/query.rs
+++ b/server/service/src/document/program/query.rs
@@ -5,7 +5,16 @@ use repository::{
 
 use crate::service_provider::ServiceContext;
 
-pub(crate) fn get_patient_program_enrolments(
+pub(crate) fn program_enrolment(
+    ctx: &ServiceContext,
+    filter: ProgramEnrolmentFilter,
+) -> Result<Option<ProgramEnrolment>, RepositoryError> {
+    Ok(ProgramEnrolmentRepository::new(&ctx.connection)
+        .query_by_filter(filter)?
+        .pop())
+}
+
+pub(crate) fn program_enrolments(
     ctx: &ServiceContext,
     pagination: Pagination,
     sort: Option<Sort<ProgramEnrolmentSortField>>,


### PR DESCRIPTION
Closes #526 

Updated the create modal. 
There's two problems still outstanding:
- the `id` returned by the 'create encounter' api method, is not the id for the encounter. not sure what it is..
- the wrong id is causing problems on the encounter detail view now.. the page re-renders infinitely

I'll revisit those issues when I can. Just popping the changes into a PR now in case you want to use them.