### PR TITLE
Invalid encounter rerender

### DIFF
--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -18,7 +18,12 @@ import { Footer } from './Footer';
 
 export const DetailView: FC = () => {
   const t = useTranslation('patients');
-  const { data: encounter, isLoading } = useEncounter.document.get();
+  const id = useEncounter.utils.id;
+  const {
+    data: encounter,
+    isLoading,
+    mutate: fetchEncounter,
+  } = useEncounter.document.get();
   const navigate = useNavigate();
 
   const dateFormat = useFormatDateTime();
@@ -58,6 +63,8 @@ export const DetailView: FC = () => {
       }),
     [data, setData]
   );
+
+  useEffect(() => fetchEncounter(), [id]);
 
   if (isLoading) return <DetailViewSkeleton />;
 

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -19,29 +19,22 @@ import { Footer } from './Footer';
 export const DetailView: FC = () => {
   const t = useTranslation('patients');
   const id = useEncounter.utils.id;
+  const navigate = useNavigate();
+  const { setSuffix } = useBreadcrumbs([AppRoute.Encounter]);
+  const dateFormat = useFormatDateTime();
+
   const {
     data: encounter,
-    isLoading,
     mutate: fetchEncounter,
+    isSuccess,
+    isError,
   } = useEncounter.document.get();
-  const navigate = useNavigate();
 
-  const dateFormat = useFormatDateTime();
   const handleSave = useEncounter.document.upsertDocument(
     encounter?.patient.id ?? '',
     encounter?.program ?? '',
     encounter?.type ?? ''
   );
-
-  const { setSuffix } = useBreadcrumbs([AppRoute.Encounter]);
-  useEffect(() => {
-    if (encounter)
-      setSuffix(
-        `${
-          encounter.document.documentRegistry?.name
-        } - ${dateFormat.localisedDateTime(encounter.startDatetime)}`
-      );
-  }, [encounter]);
 
   const {
     JsonForm,
@@ -70,7 +63,16 @@ export const DetailView: FC = () => {
   // if the id is invalid and a query is used
   useEffect(() => fetchEncounter(), [id]);
 
-  if (isLoading) return <DetailViewSkeleton />;
+  useEffect(() => {
+    if (encounter)
+      setSuffix(
+        `${
+          encounter.document.documentRegistry?.name
+        } - ${dateFormat.localisedDateTime(encounter.startDatetime)}`
+      );
+  }, [encounter]);
+
+  if (!isSuccess && !isError) return <DetailViewSkeleton />;
 
   return (
     <React.Suspense fallback={<DetailViewSkeleton />}>

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -64,6 +64,10 @@ export const DetailView: FC = () => {
     [data, setData]
   );
 
+  // using a mutation to fetch rather than a query
+  // because the API does not error on invalid ids
+  // which results in an infinite re-render
+  // if the id is invalid and a query is used
   useEffect(() => fetchEncounter(), [id]);
 
   if (isLoading) return <DetailViewSkeleton />;

--- a/client/packages/system/src/Encounter/api/hooks/document/useEncounter.ts
+++ b/client/packages/system/src/Encounter/api/hooks/document/useEncounter.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@openmsupply-client/common';
+import { useMutation } from '@openmsupply-client/common';
 import { useEncounterApi } from '../utils/useEncounterApi';
 import { useEncounterId } from '../utils/useEncounterId';
 
@@ -7,15 +7,6 @@ export const useEncounter = () => {
   const id = useEncounterId();
 
   return {
-    ...useQuery(
-      api.keys.detail(id),
-      () => api.get.byId(id),
-      // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
-      // is inactive. For example, when navigating away from the page and back again, refetch.
-      {
-        refetchOnMount: false,
-        cacheTime: 0,
-      }
-    ),
+    ...useMutation(api.keys.detail(id), () => api.get.byId(id)),
   };
 };


### PR DESCRIPTION
Fixes #557 

The other API get requests throw an error when the ID is invalid - but the encounter endpoint helpfully does not.
The encounter detail page gets `undefined` for the encounter object, but the query is not in an error state and so will requery and return undefined again. React is unable to use undefined as a stable reference and can't determine that the result is the same, so renders again.

What happens in the other areas of the site is that the query errors, we catch and return an empty object to use as a reference at the cache level and the query is in an error state, so doesn't requery. 

To work around the difference, I've changed the encounter fetch to use a mutation, and am directly calling that only when the requested id changes using an effect. That way the returned data isn't changing and react doesn't feel the need to rerender.

## Tests
- [ ] Navigate to the encounter list and click on one. Expected result: will show the encounter
- [ ] Change the id in the URL - e.g. appending another character. Expected result: will show error toast, and modal saying that the encounter is not found. Page only renders once ( the skeleton behind doesn't flicker constantly )