### PR TITLE
Make use of user permissions

### DIFF
--- a/client/packages/common/src/authentication/api/api.ts
+++ b/client/packages/common/src/authentication/api/api.ts
@@ -95,6 +95,26 @@ export const getAuthQueries = (sdk: Sdk, t: TypedTFunction<LocaleKey>) => ({
         LocalStorage.setItem('/auth/error', AuthError.ServerError);
       }
     },
+    permissions: async ({
+      storeId,
+      token,
+    }: {
+      storeId: string;
+      token?: string;
+    }) => {
+      try {
+        const result = await sdk.permissions(
+          { storeId },
+          {
+            Authorization: `Bearer ${token}`,
+          }
+        );
+        return result?.me?.permissions;
+      } catch (e) {
+        console.error(e);
+        return { nodes: [] };
+      }
+    },
     stores: () => async () => {
       try {
         const result = await sdk.me();

--- a/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
+++ b/client/packages/common/src/authentication/api/hooks/useUserDetails.ts
@@ -5,7 +5,7 @@ import { useAuthApi } from './useAuthApi';
 export const useUserDetails = () => {
   const api = useAuthApi();
   return useMutation<
-    UserNode | undefined,
+    Partial<UserNode> | undefined,
     unknown,
     string | undefined,
     unknown
@@ -18,4 +18,9 @@ export const useUserStores = (token: string) => {
     cacheTime: 0,
     enabled: !!token,
   });
+};
+
+export const useUserPermissions = () => {
+  const api = useAuthApi();
+  return useMutation(api.get.permissions);
 };

--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -24,6 +24,13 @@ export type RefreshTokenQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 export type RefreshTokenQuery = { __typename: 'FullQuery', refreshToken: { __typename: 'RefreshToken', token: string } | { __typename: 'RefreshTokenError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'InternalError', description: string, fullError: string } | { __typename: 'InvalidToken', description: string } | { __typename: 'NoRefreshTokenProvided', description: string } | { __typename: 'NotARefreshToken', description: string } | { __typename: 'TokenExpired', description: string } } };
 
+export type PermissionsQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String'];
+}>;
+
+
+export type PermissionsQuery = { __typename: 'FullQuery', me: { __typename: 'UserNode', username: string, permissions: { __typename: 'UserStorePermissionConnector', totalCount: number, nodes: Array<{ __typename: 'UserStorePermissionNode', permissions: Array<Types.UserPermissionNodePermission>, storeId: string }> } } };
+
 export const UserStoreNodeFragmentDoc = gql`
     fragment UserStoreNode on UserStoreNode {
   code
@@ -115,6 +122,23 @@ export const RefreshTokenDocument = gql`
   }
 }
     `;
+export const PermissionsDocument = gql`
+    query permissions($storeId: String!) {
+  me {
+    ... on UserNode {
+      __typename
+      username
+      permissions(storeId: $storeId) {
+        nodes {
+          permissions
+          storeId
+        }
+        totalCount
+      }
+    }
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
@@ -131,6 +155,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     refreshToken(variables?: RefreshTokenQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<RefreshTokenQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<RefreshTokenQuery>(RefreshTokenDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'refreshToken', 'query');
+    },
+    permissions(variables: PermissionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PermissionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PermissionsQuery>(PermissionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'permissions', 'query');
     }
   };
 }
@@ -182,5 +209,22 @@ export const mockMeQuery = (resolver: ResponseResolver<GraphQLRequest<MeQueryVar
 export const mockRefreshTokenQuery = (resolver: ResponseResolver<GraphQLRequest<RefreshTokenQueryVariables>, GraphQLContext<RefreshTokenQuery>, any>) =>
   graphql.query<RefreshTokenQuery, RefreshTokenQueryVariables>(
     'refreshToken',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockPermissionsQuery((req, res, ctx) => {
+ *   const { storeId } = req.variables;
+ *   return res(
+ *     ctx.data({ me })
+ *   )
+ * })
+ */
+export const mockPermissionsQuery = (resolver: ResponseResolver<GraphQLRequest<PermissionsQueryVariables>, GraphQLContext<PermissionsQuery>, any>) =>
+  graphql.query<PermissionsQuery, PermissionsQueryVariables>(
+    'permissions',
     resolver
   )

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -84,3 +84,19 @@ query refreshToken {
     }
   }
 }
+
+query permissions($storeId: String!) {
+  me {
+    ... on UserNode {
+      __typename
+      username
+      permissions(storeId: $storeId) {
+        nodes {
+          permissions
+          storeId
+        }
+        totalCount
+      }
+    }
+  }
+}

--- a/client/packages/common/src/authentication/hooks/index.ts
+++ b/client/packages/common/src/authentication/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './usePermissionCheck';

--- a/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
+++ b/client/packages/common/src/authentication/hooks/usePermissionCheck.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { AppRoute } from '@openmsupply-client/config';
+import { UserPermissionNodePermission } from '../../types/schema';
+import { AuthError, useAuthContext } from '../AuthContext';
+import { LocalStorage } from '../../localStorage';
+import { useNavigate } from 'react-router-dom';
+import { RouteBuilder } from '../../utils/navigation';
+
+export const usePermissionCheck = (
+  permission: UserPermissionNodePermission
+) => {
+  const { userHasPermission } = useAuthContext();
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (!userHasPermission(permission)) {
+      LocalStorage.setItem('/auth/error', AuthError.PermissionDenied);
+      LocalStorage.addListener<boolean>((key, value) => {
+        if (key === '/auth/error') {
+          if (!value) navigate(RouteBuilder.create(AppRoute.Dashboard).build());
+        }
+      });
+    }
+  }, []);
+};

--- a/client/packages/common/src/authentication/index.ts
+++ b/client/packages/common/src/authentication/index.ts
@@ -1,2 +1,3 @@
 export * from './AuthContext';
 export * from './api';
+export * from './hooks';

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3249,11 +3249,34 @@ export type UserNode = {
   defaultStore?: Maybe<UserStoreNode>;
   /** The user's email address */
   email?: Maybe<Scalars['String']>;
+  permissions: UserStorePermissionConnector;
   stores: UserStoreConnector;
   /** Internal user id */
   userId: Scalars['String'];
   username: Scalars['String'];
 };
+
+
+export type UserNodePermissionsArgs = {
+  storeId?: InputMaybe<Scalars['String']>;
+};
+
+export enum UserPermissionNodePermission {
+  InboundShipmentMutate = 'INBOUND_SHIPMENT_MUTATE',
+  InboundShipmentQuery = 'INBOUND_SHIPMENT_QUERY',
+  LocationMutate = 'LOCATION_MUTATE',
+  LogQuery = 'LOG_QUERY',
+  OutboundShipmentMutate = 'OUTBOUND_SHIPMENT_MUTATE',
+  OutboundShipmentQuery = 'OUTBOUND_SHIPMENT_QUERY',
+  Report = 'REPORT',
+  RequisitionMutate = 'REQUISITION_MUTATE',
+  RequisitionQuery = 'REQUISITION_QUERY',
+  ServerAdmin = 'SERVER_ADMIN',
+  StocktakeMutate = 'STOCKTAKE_MUTATE',
+  StocktakeQuery = 'STOCKTAKE_QUERY',
+  StockLineQuery = 'STOCK_LINE_QUERY',
+  StoreAccess = 'STORE_ACCESS'
+}
 
 export type UserResponse = UserNode;
 
@@ -3268,4 +3291,16 @@ export type UserStoreNode = {
   code: Scalars['String'];
   id: Scalars['String'];
   name: Scalars['String'];
+};
+
+export type UserStorePermissionConnector = {
+  __typename: 'UserStorePermissionConnector';
+  nodes: Array<UserStorePermissionNode>;
+  totalCount: Scalars['Int'];
+};
+
+export type UserStorePermissionNode = {
+  __typename: 'UserStorePermissionNode';
+  permissions: Array<UserPermissionNodePermission>;
+  storeId: Scalars['String'];
 };

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -51,6 +51,7 @@ export interface AppNavLinkProps {
   inactive?: boolean;
   text?: string;
   to: string;
+  visible?: boolean;
   onClick?: () => void;
 }
 
@@ -61,6 +62,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
     icon = <span style={{ width: 2 }} />,
     text,
     to,
+    visible = true,
     onClick,
   } = props;
   const drawer = useDrawer();
@@ -95,7 +97,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
     [to]
   );
 
-  return (
+  return visible ? (
     <StyledListItem isSelected={selected} to={to}>
       <ListItemButton
         sx={{
@@ -119,5 +121,5 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         </Box>
       </ListItemButton>
     </StyledListItem>
-  );
+  ) : null;
 };

--- a/client/packages/host/src/Admin/Settings.tsx
+++ b/client/packages/host/src/Admin/Settings.tsx
@@ -8,6 +8,8 @@ import {
   useNavigate,
   useTranslation,
   useNotification,
+  UserPermissionNodePermission,
+  usePermissionCheck,
 } from '@openmsupply-client/common';
 import { themeOptions } from '@common/styles';
 import { LanguageMenu } from '../components';
@@ -24,6 +26,7 @@ export const Settings: React.FC = () => {
   const [customTheme, setCustomTheme] = useLocalStorage('/theme/custom');
   const [customLogo, setCustomLogo] = useLocalStorage('/theme/logo');
   const { data } = useHost.utils.version();
+  usePermissionCheck(UserPermissionNodePermission.ServerAdmin);
   const customThemeEnabled =
     !!customTheme && Object.keys(customTheme).length > 0;
 

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -21,6 +21,7 @@ import {
   useAuthContext,
   useLocation,
   EnvUtils,
+  UserPermissionNodePermission,
 } from '@openmsupply-client/common';
 import { AppRoute, ExternalURL } from '@openmsupply-client/config';
 import {
@@ -135,7 +136,7 @@ export const AppDrawer: React.FC = () => {
   const t = useTranslation('app');
   const isMediumScreen = useIsMediumScreen();
   const drawer = useDrawer();
-  const { logout } = useAuthContext();
+  const { logout, userHasPermission } = useAuthContext();
   const location = useLocation();
 
   React.useEffect(() => {
@@ -231,6 +232,9 @@ export const AppDrawer: React.FC = () => {
             to={AppRoute.Admin}
             icon={<SettingsIcon fontSize="small" color="primary" />}
             text={t('admin')}
+            visible={userHasPermission(
+              UserPermissionNodePermission.ServerAdmin
+            )}
           />
           <AppNavLink
             to={AppRoute.Login}

--- a/client/packages/host/src/components/AuthenticationAlert.tsx
+++ b/client/packages/host/src/components/AuthenticationAlert.tsx
@@ -18,14 +18,10 @@ export const AuthenticationAlert = () => {
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation('app');
   const location = useLocation();
-  const [error, , removeItem] = useLocalStorage('/auth/error');
+  const [error, , removeError] = useLocalStorage('/auth/error');
 
   useEffect(() => {
-    if (!error) {
-      toggleOff();
-      return;
-    }
-    toggleOn();
+    if (!!error) toggleOn();
     return () => toggleOff();
   }, [error]);
 
@@ -49,7 +45,8 @@ export const AuthenticationAlert = () => {
     }
 
     if (error === AuthError.PermissionDenied) {
-      removeItem();
+      toggleOff();
+      setTimeout(removeError, 200);
       return;
     }
 

--- a/client/packages/host/src/components/AuthenticationAlert.tsx
+++ b/client/packages/host/src/components/AuthenticationAlert.tsx
@@ -9,7 +9,6 @@ import {
   useLocalStorage,
   useLocation,
   useNavigate,
-  LocalStorage,
 } from '@openmsupply-client/common';
 import { AlertModal } from '@common/components';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
@@ -19,10 +18,14 @@ export const AuthenticationAlert = () => {
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation('app');
   const location = useLocation();
-  const [error] = useLocalStorage('/auth/error');
+  const [error, , removeItem] = useLocalStorage('/auth/error');
 
   useEffect(() => {
-    if (!!error) toggleOn();
+    if (!error) {
+      toggleOff();
+      return;
+    }
+    toggleOn();
     return () => toggleOff();
   }, [error]);
 
@@ -46,7 +49,7 @@ export const AuthenticationAlert = () => {
     }
 
     if (error === AuthError.PermissionDenied) {
-      LocalStorage.removeItem('/auth/error');
+      removeItem();
       return;
     }
 

--- a/client/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/client/packages/host/src/components/Footer/StoreSelector.tsx
@@ -34,8 +34,8 @@ export const StoreSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
     <FlatButton
       label={s.name}
       disabled={s.id === store.id}
-      onClick={() => {
-        setStore(s);
+      onClick={async () => {
+        await setStore(s);
         hide();
         navigate(AppRoute.Dashboard);
       }}


### PR DESCRIPTION
Closes #252 

The changes here
- on login, fetches user permissions and adds to the user object
- on store change does the same
- conditionally hides the Admin nav link if you do not have the `SERVER_ADMIN` permission

## Testing
### Setup

- `userA` has `SERVER_ADMIN` permission
- `userB` does not have `SERVER_ADMIN` permission
- `userC` has access to multiple stores. In `storeA` they have `SERVER_ADMIN` permission, in `storeB` they don't

### Tests
- [ ] Login as `userA`: can see `Admin` in the nav
- [ ] Login as `userB`: can not see `Admin` in the nav
- [ ] Login as `userC, switch stores to `storeA`: Should see admin link
- [ ] Login as `userC, switch stores to `storeB`: Should not see admin link
- [ ] Login as `userC, switch to `storeA`, navigate to the admin page, change `storeB`: should be redirected to the dashboard
- [ ] Login as `userC`, change to `storeB`, change URL to `/admin`: should be prompted that you don't have permission
- [ ] Wait for a logout: should be prompted and on OK redirect to login as usual

## Demo

![permissions](https://user-images.githubusercontent.com/9192912/188538286-71f70c0c-dcbf-45f7-bc8a-7d4f651fb4bf.gif)
