### PR TITLE
Use correct keys as used in other api

### DIFF
--- a/client/packages/system/src/Patient/api/hooks/utils/usePatientApi.ts
+++ b/client/packages/system/src/Patient/api/hooks/utils/usePatientApi.ts
@@ -15,11 +15,11 @@ export const usePatientApi = () => {
     history: (id: string) => [...keys.base(), 'history', storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
-    enrolmentParamList: (params: ProgramEnrolmentListParams) =>
-      [...keys.list(), params] as const,
     sortedList: (sortBy: SortBy<PatientRowFragment>) =>
       [...keys.list(), sortBy] as const,
-    listEncounter: () => [...keys.base(), storeId, 'listEncounter'] as const,
+    enrolmentParamList: (params: ProgramEnrolmentListParams) =>
+      ['program-enrolment', storeId, 'list', params] as const,
+    listEncounter: () => ['encounter', storeId, 'list'] as const,
     paramListEncounter: (params: EncounterListParams) =>
       [...keys.listEncounter(), params] as const,
   };


### PR DESCRIPTION
Fix some api key invalidation problems (enrolment list didn't get updated).

Think the api hooks should somehow be unified in the future, for now I just manually set the correct keys in the existing hook.

Closes #569 