### PR TITLE
575 processor driver

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -264,7 +264,7 @@ async fn run_server(
         () = async {
             synchroniser.run().await;
         } => unreachable!("Synchroniser unexpectedly died!?"),
-        result = processors_task => unreachable!("Transfer processor terminated ({:?})", result)
+        result = processors_task => unreachable!("Processor terminated ({:?})", result)
     };
 
     server_handle.stop(true).await;

--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -15,7 +15,7 @@ use self::transfer::{
 mod test_helpers;
 pub(crate) mod transfer;
 
-const NUMBER_OF_CHANNELS: usize = 30;
+const CHANNEL_BUFFER_SIZE: usize = 30;
 
 #[derive(Clone)]
 pub struct ProcessorsTrigger {
@@ -39,10 +39,10 @@ enum ProcessorsError {
 impl Processors {
     pub fn init() -> (ProcessorsTrigger, Processors) {
         let (requisition_transfer_sender, requisition_transfer_receiver) =
-            mpsc::channel(NUMBER_OF_CHANNELS);
+            mpsc::channel(CHANNEL_BUFFER_SIZE);
 
         let (shipment_transfer_sender, shipment_transfer_receiver) =
-            mpsc::channel(NUMBER_OF_CHANNELS);
+            mpsc::channel(CHANNEL_BUFFER_SIZE);
 
         (
             ProcessorsTrigger {


### PR DESCRIPTION
closes #575 

These branch may not compile, check out [head PR here](https://github.com/openmsupply/open-msupply/pull/587) for full changes of transfer logic (if you are viewing/testing overall changes). PR changes will be done to that branch, with link to commit in comments they address.

* Added processor driver and triggers
* Added a test initialisation helper to generate service provider and processor_handle 
* Added a couple of new cursors for shipment and requisition transfer
