### PR TITLE
584 transfer integration tests

### DIFF
--- a/server/service/src/sync/test/integration/transfer/shipments.rs
+++ b/server/service/src/sync/test/integration/transfer/shipments.rs
@@ -22,10 +22,10 @@ async fn integration_sync_shipment_transfers_normal() {
     });
 
     let SyncIntegrationTransferContext {
-        site_1,
-        site_2,
-        site_1_processors_task,
-        site_2_processors_task,
+        site_1: outbound_and_response_site,
+        site_2: inbound_and_request_site,
+        site_1_processors_task: outbound_and_response_site_processors_task,
+        site_2_processors_task: inbound_and_request_site_processors_task,
     } = initialise_transfer_sites(
         json!({
             "item": [
@@ -38,108 +38,128 @@ async fn integration_sync_shipment_transfers_normal() {
     .await;
 
     let test = async move {
-        let mut tester = ShipmentTransferTester::new(&site_1.store, &site_2.store, &item1, &item2);
+        let mut tester = ShipmentTransferTester::new(
+            &outbound_and_response_site.store,
+            &inbound_and_request_site.store,
+            &item1,
+            &item2,
+        );
 
-        log::info!("Inserting request requisition on site {:?}", site_2.config);
+        log::info!(
+            "Inserting request requisition on site {:?}",
+            inbound_and_request_site.config
+        );
         tester
-            .insert_request_requisition(&site_2.service_provider)
+            .insert_request_requisition(&inbound_and_request_site.service_provider)
             .await;
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Checking response requisition is created on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
         tester
-            .check_response_requisition_created(&site_1.connection)
+            .check_response_requisition_created(&outbound_and_response_site.connection)
             .await;
 
-        log::info!("Inserting outbound shipment on site {:?}", site_1.config);
-        tester.insert_outbound_shipment(&site_1.connection).await;
+        log::info!(
+            "Inserting outbound shipment on site {:?}",
+            outbound_and_response_site.config
+        );
+        tester
+            .insert_outbound_shipment(&outbound_and_response_site.connection)
+            .await;
 
-        sync_and_delay(&site_1, &site_2).await;
+        sync_and_delay(&outbound_and_response_site, &inbound_and_request_site).await;
 
         log::info!(
             "Checking inbound shipment is not created on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.check_inbound_shipment_not_created(&site_2.connection);
+        tester.check_inbound_shipment_not_created(&inbound_and_request_site.connection);
 
         log::info!(
             "Updating outbound shipment to picked on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
-        tester.update_outbound_shipment_to_picked(&site_1.service_provider);
+        tester.update_outbound_shipment_to_picked(&outbound_and_response_site.service_provider);
 
-        sync_and_delay(&site_1, &site_2).await;
+        sync_and_delay(&outbound_and_response_site, &inbound_and_request_site).await;
 
         log::info!(
             "Checking inbound shipment is created on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.check_inbound_shipment_created(&site_2.connection);
+        tester.check_inbound_shipment_created(&inbound_and_request_site.connection);
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Checking outbound shipment was linked on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
 
-        tester.check_outbound_shipment_was_linked(&site_1.connection);
+        tester.check_outbound_shipment_was_linked(&outbound_and_response_site.connection);
 
-        log::info!("Update outbound shipment lines on site {:?}", site_1.config);
+        log::info!(
+            "Update outbound shipment lines on site {:?}",
+            outbound_and_response_site.config
+        );
 
-        tester.update_outbound_shipment_lines(&site_1.service_provider);
+        tester.update_outbound_shipment_lines(&outbound_and_response_site.service_provider);
 
         log::info!(
             "Update outbound shipment to shipped on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
 
-        tester.update_outbound_shipment_to_shipped(&site_1.service_provider);
+        tester.update_outbound_shipment_to_shipped(&outbound_and_response_site.service_provider);
 
-        sync_and_delay(&site_1, &site_2).await;
+        sync_and_delay(&outbound_and_response_site, &inbound_and_request_site).await;
 
         log::info!(
             "Checking inbound shipment was updated on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.check_inbound_shipment_was_updated(&site_2.connection);
+        tester.check_inbound_shipment_was_updated(&inbound_and_request_site.connection);
 
         log::info!(
             "Update inbound shipment to delivered on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.update_inbound_shipment_to_delivered(&site_2.service_provider);
+        tester.update_inbound_shipment_to_delivered(&inbound_and_request_site.service_provider);
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Check outbound shipment status was update on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
-        tester.check_outbound_shipment_status_matches_inbound_shipment(&site_1.connection);
+        tester.check_outbound_shipment_status_matches_inbound_shipment(
+            &outbound_and_response_site.connection,
+        );
 
         log::info!(
             "Update inbound shipment to verified on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.update_inbound_shipment_to_verified(&site_2.service_provider);
+        tester.update_inbound_shipment_to_verified(&inbound_and_request_site.service_provider);
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Check outbound shipment status was update on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
-        tester.check_outbound_shipment_status_matches_inbound_shipment(&site_1.connection);
+        tester.check_outbound_shipment_status_matches_inbound_shipment(
+            &outbound_and_response_site.connection,
+        );
     };
 
     tokio::select! {
-        Err(err) = site_1_processors_task => unreachable!("{}", err),
-        Err(err) = site_2_processors_task => unreachable!("{}", err),
+        Err(err) = outbound_and_response_site_processors_task => unreachable!("{}", err),
+        Err(err) = inbound_and_request_site_processors_task => unreachable!("{}", err),
         _ = test => (),
     };
 }
@@ -157,10 +177,10 @@ async fn integration_sync_shipment_transfers_delete() {
     });
 
     let SyncIntegrationTransferContext {
-        site_1,
-        site_2,
-        site_1_processors_task,
-        site_2_processors_task,
+        site_1: outbound_and_response_site,
+        site_2: inbound_and_request_site,
+        site_1_processors_task: outbound_and_response_site_processors_task,
+        site_2_processors_task: inbound_and_request_site_processors_task,
     } = initialise_transfer_sites(
         json!({
             "item": [
@@ -173,54 +193,73 @@ async fn integration_sync_shipment_transfers_delete() {
     .await;
 
     let test = async move {
-        let mut tester = ShipmentTransferTester::new(&site_1.store, &site_2.store, &item1, &item2);
+        let mut tester = ShipmentTransferTester::new(
+            &outbound_and_response_site.store,
+            &inbound_and_request_site.store,
+            &item1,
+            &item2,
+        );
 
-        log::info!("Inserting request requisition on site {:?}", site_2.config);
+        log::info!(
+            "Inserting request requisition on site {:?}",
+            inbound_and_request_site.config
+        );
         tester
-            .insert_request_requisition(&site_2.service_provider)
+            .insert_request_requisition(&inbound_and_request_site.service_provider)
             .await;
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Checking response requisition is created on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
         tester
-            .check_response_requisition_created(&site_1.connection)
+            .check_response_requisition_created(&outbound_and_response_site.connection)
             .await;
 
-        log::info!("Inserting outbound shipment on site {:?}", site_1.config);
-        tester.insert_outbound_shipment(&site_1.connection).await;
+        log::info!(
+            "Inserting outbound shipment on site {:?}",
+            outbound_and_response_site.config
+        );
+        tester
+            .insert_outbound_shipment(&outbound_and_response_site.connection)
+            .await;
 
         log::info!(
             "Updating outbound shipment to picked on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
-        tester.update_outbound_shipment_to_picked(&site_1.service_provider);
+        tester.update_outbound_shipment_to_picked(&outbound_and_response_site.service_provider);
 
-        sync_and_delay(&site_1, &site_2).await;
+        sync_and_delay(&outbound_and_response_site, &inbound_and_request_site).await;
 
         log::info!(
             "Checking inbound shipment is created on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.check_inbound_shipment_created(&site_2.connection);
+        tester.check_inbound_shipment_created(&inbound_and_request_site.connection);
 
-        log::info!("Delete outbound shipment on site {:?}", site_1.config);
+        log::info!(
+            "Delete outbound shipment on site {:?}",
+            outbound_and_response_site.config
+        );
 
-        tester.delete_outbound_shipment(&site_1.service_provider);
+        tester.delete_outbound_shipment(&outbound_and_response_site.service_provider);
 
-        sync_and_delay(&site_1, &site_2).await;
+        sync_and_delay(&outbound_and_response_site, &inbound_and_request_site).await;
 
-        log::info!("Check inbound shipment delete {:?}", site_1.config);
+        log::info!(
+            "Check inbound shipment delete {:?}",
+            outbound_and_response_site.config
+        );
 
-        tester.check_inbound_shipment_deleted(&site_1.connection);
+        tester.check_inbound_shipment_deleted(&outbound_and_response_site.connection);
     };
 
     tokio::select! {
-        Err(err) = site_1_processors_task => unreachable!("{}", err),
-        Err(err) = site_2_processors_task => unreachable!("{}", err),
+        Err(err) = outbound_and_response_site_processors_task => unreachable!("{}", err),
+        Err(err) = inbound_and_request_site_processors_task => unreachable!("{}", err),
         _ = test => (),
     };
 }
@@ -239,10 +278,10 @@ async fn integration_sync_shipment_transfers_initialise() {
     });
 
     let SyncIntegrationTransferContext {
-        site_1,
-        site_2,
-        site_1_processors_task,
-        site_2_processors_task,
+        site_1: outbound_and_response_site,
+        site_2: inbound_and_request_site,
+        site_1_processors_task: outbound_and_response_site_processors_task,
+        site_2_processors_task: inbound_and_request_site_processors_task,
     } = initialise_transfer_sites(
         json!({
             "item": [
@@ -255,56 +294,70 @@ async fn integration_sync_shipment_transfers_initialise() {
     .await;
 
     let test = async move {
-        let mut tester = ShipmentTransferTester::new(&site_1.store, &site_2.store, &item1, &item2);
+        let mut tester = ShipmentTransferTester::new(
+            &outbound_and_response_site.store,
+            &inbound_and_request_site.store,
+            &item1,
+            &item2,
+        );
 
-        log::info!("Inserting request requisition on site {:?}", site_2.config);
+        log::info!(
+            "Inserting request requisition on site {:?}",
+            inbound_and_request_site.config
+        );
         tester
-            .insert_request_requisition(&site_2.service_provider)
+            .insert_request_requisition(&inbound_and_request_site.service_provider)
             .await;
 
-        sync_and_delay(&site_2, &site_1).await;
+        sync_and_delay(&inbound_and_request_site, &outbound_and_response_site).await;
 
         log::info!(
             "Checking response requisition is created on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
         tester
-            .check_response_requisition_created(&site_1.connection)
+            .check_response_requisition_created(&outbound_and_response_site.connection)
             .await;
 
-        log::info!("Inserting outbound shipment on site {:?}", site_1.config);
-        tester.insert_outbound_shipment(&site_1.connection).await;
+        log::info!(
+            "Inserting outbound shipment on site {:?}",
+            outbound_and_response_site.config
+        );
+        tester
+            .insert_outbound_shipment(&outbound_and_response_site.connection)
+            .await;
 
         log::info!(
             "Updating outbound shipment to picked on site {:?}",
-            site_1.config
+            outbound_and_response_site.config
         );
-        tester.update_outbound_shipment_to_picked(&site_1.service_provider);
-        sync_and_delay(&site_1, &site_1).await;
-        (tester, site_2)
+        tester.update_outbound_shipment_to_picked(&outbound_and_response_site.service_provider);
+        sync_and_delay(&outbound_and_response_site, &outbound_and_response_site).await;
+        (tester, inbound_and_request_site)
     };
 
-    let (mut tester, site_2) = tokio::select! {
-        Err(err) = site_1_processors_task => unreachable!("{}", err),
-        Err(err) = site_2_processors_task => unreachable!("{}", err),
+    let (mut tester, inbound_and_request_site) = tokio::select! {
+        Err(err) = outbound_and_response_site_processors_task => unreachable!("{}", err),
+        Err(err) = inbound_and_request_site_processors_task => unreachable!("{}", err),
         test_result = test => test_result,
     };
-    // Since this test check transfers are forward on initialisation, we want to re-set database for site_2
-    let (site_2, site_2_processors_task) =
-        new_instance_of_existing_site(site_2, &format!("{}_site2_2", identifier)).await;
+    // Since this test check transfers are forward on initialisation, we want to re-set database for inbound_and_request_site
+    let (inbound_and_request_site, inbound_and_request_site_processors_task) =
+        new_instance_of_existing_site(inbound_and_request_site, &format!("{}_site2_2", identifier))
+            .await;
 
     let test = async move {
         // Site 2 should be re-initialised here
-        sync_and_delay(&site_2, &site_2).await;
+        sync_and_delay(&inbound_and_request_site, &inbound_and_request_site).await;
         log::info!(
             "Checking inbound shipment is created on site {:?}",
-            site_2.config
+            inbound_and_request_site.config
         );
-        tester.check_inbound_shipment_created(&site_2.connection);
+        tester.check_inbound_shipment_created(&inbound_and_request_site.connection);
     };
 
     tokio::select! {
-        Err(err) = site_2_processors_task => unreachable!("{}", err),
+        Err(err) = inbound_and_request_site_processors_task => unreachable!("{}", err),
         _ = test => (),
     };
 }


### PR DESCRIPTION
closes #584 

These branch may not compile, check out [head PR here](https://github.com/openmsupply/open-msupply/pull/587) for full changes of transfer logic (if you are viewing/testing overall changes). PR changes will be done to that branch, with link to commit in comments they address.

* Removed empty_data_time_as_option serde translation helper, as it was use on `om_` fields only which are nullable
* Changed create sync site in integration tests to use new 4d mSupply endpoint, which uses internal 4d mSupply unit test helpers that create sync site (there is more that needs to be done then just creating site and linking visibility, `cache` needs to be refreshed in mSupply)
* Created a helper to create and initialise two sync sites for transfer test
* Used `RequisitionTransferTester` and `ShipmentTransferTester` to add integration tests, where both sides of a transfer are on different site
* Fixed a bug with average monthly consumption on requisition line
