### PR TITLE
Add confirmation alert for react router navigation

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -1,10 +1,16 @@
-import { useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
+import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
+import type { History } from 'history';
+import { useTranslation } from '@common/intl';
 
-// Note: if the unsaved condition can be navigated away from using react-router
-// then this hook won't catch the navigation action
-// you will need to use the `Prompt` component instead ( or usePrompt or useBlocker )
+// Ideally we'd use the `Prompt` component instead ( or usePrompt or useBlocker ) to prompt when navigating away using react-router
 // however, these weren't implemented in react-router-dom v6 at the time of implementation
 export const useConfirmOnLeaving = (isUnsaved?: boolean) => {
+  const unblockRef = useRef<any>(null);
+  const { navigator } = useContext(NavigationContext);
+  const t = useTranslation();
+  const blockNavigator = navigator as History;
+
   const promptUser = (e: BeforeUnloadEvent) => {
     // Cancel the event
     e.preventDefault(); // If you prevent default behavior in Mozilla Firefox prompt will always be shown
@@ -12,13 +18,32 @@ export const useConfirmOnLeaving = (isUnsaved?: boolean) => {
     e.returnValue = '';
   };
 
+  const showConfirmation = (onOk: () => void) => {
+    if (
+      confirm(
+        `${t('heading.are-you-sure')}\n${t('messages.confirm-cancel-generic')}`
+      )
+    ) {
+      onOk();
+    }
+  };
+
   useEffect(() => {
     if (isUnsaved) {
       window.addEventListener('beforeunload', promptUser, { capture: true });
+      unblockRef.current = blockNavigator.block(blocker => {
+        showConfirmation(() => {
+          unblockRef.current?.();
+          blocker.retry();
+        });
+      });
     } else {
       window.removeEventListener('beforeunload', promptUser, { capture: true });
+      unblockRef.current?.();
     }
-    return () =>
+    return () => {
       window.removeEventListener('beforeunload', promptUser, { capture: true });
-  }, [isUnsaved]);
+      unblockRef.current?.();
+    };
+  }, [blockNavigator, isUnsaved]);
 };

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -105,6 +105,7 @@ module.exports = env => {
       new CopyPlugin({
         patterns: [
           { from: './public/mockServiceWorker.js', to: 'mockServiceWorker.js' },
+          { from: './public/medical-icons.css', to: 'medical-icons.css' },
           {
             context: path.resolve(
               __dirname,


### PR DESCRIPTION
Fixes #565 

Ideally I'd use the standard confirmation modal - but due to where the confirmOnLeaving hook is called, the required react context isn't available. So for now have gone full ugly:

![Screen Shot 2022-09-09 at 4 27 10 PM](https://user-images.githubusercontent.com/9192912/189272366-766cb394-c47e-4cb2-bd25-60cdb81e0c58.png)

the 'reload' version is also a system dialog, which makes the above slightly better:

<img width="292" alt="Screen Shot 2022-09-09 at 4 31 43 PM" src="https://user-images.githubusercontent.com/9192912/189272457-af8405dd-caa9-4ef3-84cd-f14840eaf395.png">


As an aside, have also fixed the css issue which causes this in the hosted version of the site:

<img width="726" alt="Screen Shot 2022-09-09 at 2 52 41 PM" src="https://user-images.githubusercontent.com/9192912/189272503-c0df6c90-430f-4179-bb40-d79763f4ff51.png">
