### PR TITLE
548 encounter list view

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -1,10 +1,11 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode, useEffect, useState } from 'react';
 import { TabContext } from '@mui/lab';
 import { Box } from '@mui/material';
 import { LocaleKey, useTranslation } from '@common/intl';
 import { AppBarTabsPortal } from '../../portals';
 import { DetailTab } from './DetailTab';
 import { ShortTabList, Tab } from './Tabs';
+import { useUrlQuery } from '@common/hooks';
 
 export type TabDefinition = {
   Component: ReactNode;
@@ -14,8 +15,24 @@ interface DetailTabsProps {
   tabs: TabDefinition[];
 }
 export const DetailTabs: FC<DetailTabsProps> = ({ tabs }) => {
+  const { urlQuery, updateQuery } = useUrlQuery();
   const [currentTab, setCurrentTab] = useState<string>(tabs[0]?.value ?? '');
   const t = useTranslation('common');
+
+  const onChange:
+    | ((event: React.SyntheticEvent<Element, Event>, value: any) => void)
+    | undefined = (_, tab) => {
+    updateQuery({ tab });
+    setCurrentTab(tab);
+  };
+
+  const isValidTab = (tab?: string) =>
+    !!tab && tabs.some(({ value }) => value === tab);
+
+  useEffect(() => {
+    const tab = urlQuery['tab'];
+    if (isValidTab(tab)) setCurrentTab(tab);
+  }, []);
 
   return (
     <TabContext value={currentTab}>
@@ -27,11 +44,7 @@ export const DetailTabs: FC<DetailTabsProps> = ({ tabs }) => {
         }}
       >
         <Box flex={1}>
-          <ShortTabList
-            value={currentTab}
-            centered
-            onChange={(_, v) => setCurrentTab(v)}
-          >
+          <ShortTabList value={currentTab} centered onChange={onChange}>
             {tabs.map(({ value }, index) => (
               <Tab
                 key={value}

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -19,9 +19,7 @@ export const DetailTabs: FC<DetailTabsProps> = ({ tabs }) => {
   const [currentTab, setCurrentTab] = useState<string>(tabs[0]?.value ?? '');
   const t = useTranslation('common');
 
-  const onChange:
-    | ((event: React.SyntheticEvent<Element, Event>, value: any) => void)
-    | undefined = (_, tab) => {
+  const onChange  = (_: React.SyntheticEvent, tab: string) => {
     updateQuery({ tab });
     setCurrentTab(tab);
   };

--- a/client/packages/system/src/Encounter/DetailView/Footer.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Footer.tsx
@@ -7,14 +7,12 @@ import {
   CheckIcon,
   XCircleIcon,
   useNavigate,
-  RouteBuilder,
   Typography,
   DetailContainer,
   DialogButton,
   ClockIcon,
   useDialog,
 } from '@openmsupply-client/common';
-import { AppRoute } from 'packages/config/src';
 import { DocumentHistory } from '../../Patient/DocumentHistory';
 
 interface FooterProps {
@@ -63,11 +61,7 @@ export const Footer: FC<FooterProps> = ({
               Icon={<XCircleIcon />}
               onClick={() => {
                 onCancel();
-                navigate(
-                  RouteBuilder.create(AppRoute.Dispensary)
-                    .addPart(AppRoute.Encounter)
-                    .build()
-                );
+                navigate(-1);
               }}
               label={t('button.cancel')}
             />

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -19,12 +19,17 @@ interface ToolbarProps {
   onChange: (patch: Partial<EncounterFragment>) => void;
 }
 export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
-  const { data: encounter } = useEncounter.document.get();
+  const { mutate: fetchEncounter, data: encounter } =
+    useEncounter.document.get();
   const [startDatetime, setStartDatetime] = useState<string | undefined>();
   const [endDatetime, setEndDatetime] = useState<string | undefined | null>();
   const t = useTranslation('patients');
+
+  useEffect(() => fetchEncounter(), []);
+
   useEffect(() => {
     if (!encounter) return;
+
     setStartDatetime(encounter.startDatetime);
     setEndDatetime(encounter.endDatetime);
   }, [encounter]);

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -1,0 +1,92 @@
+import {
+  useColumns,
+  ColumnAlign,
+  Column,
+  ColumnDescription,
+  SortBy,
+} from '@openmsupply-client/common';
+import { useFormatDateTime } from '@common/intl';
+import { EncounterRowFragment } from '../api';
+import { ProgramEventFragment } from '../api/operations.generated';
+
+const encounterEventCellValue = (events: ProgramEventFragment[]) => {
+  // just take the name of the first event
+  return events[0]?.name ?? '';
+};
+
+interface useEncounterListColumnsProps {
+  onChangeSortBy: (column: Column<any>) => void;
+  sortBy: SortBy<EncounterRowFragment>;
+  includePatient?: boolean;
+}
+
+export const useEncounterListColumns = ({
+  onChangeSortBy,
+  sortBy,
+  includePatient = false,
+}: useEncounterListColumnsProps) => {
+  const { localisedDate, localisedTime } = useFormatDateTime();
+  includePatient;
+
+  const columnList: ColumnDescription<EncounterRowFragment>[] = [
+    {
+      key: 'encounter-type',
+      label: 'label.encounter-type',
+      sortable: false,
+      accessor: ({ rowData }) => rowData?.document.documentRegistry?.name,
+    },
+    {
+      key: 'program',
+      label: 'label.program',
+    },
+    {
+      key: 'startDatetime',
+      label: 'label.date',
+      accessor: ({ rowData }) => rowData?.startDatetime,
+      formatter: dateString =>
+        dateString ? localisedDate((dateString as string) || '') : '',
+    },
+    {
+      key: 'startTime',
+      label: 'label.encounter-start',
+      sortable: false,
+      accessor: ({ rowData }) => rowData?.startDatetime,
+      formatter: dateString =>
+        dateString ? localisedTime((dateString as string) || '') : '',
+    },
+    {
+      key: 'endDatetime',
+      label: 'label.encounter-end',
+      formatter: dateString =>
+        dateString ? localisedTime((dateString as string) || '') : '',
+    },
+  ];
+  if (includePatient)
+    columnList.push({
+      key: 'patientId',
+      label: 'label.patient',
+      accessor: ({ rowData }) => rowData?.patient?.name,
+    });
+  columnList.push({
+    key: 'events',
+    label: 'label.label',
+    sortable: false,
+    formatter: events =>
+      encounterEventCellValue((events as ProgramEventFragment[]) ?? []),
+  });
+  columnList.push({
+    key: 'effectiveStatus',
+    label: 'label.status',
+    sortable: false,
+    align: ColumnAlign.Right,
+    width: 175,
+  });
+
+  const columns = useColumns<EncounterRowFragment>(
+    columnList,
+    { onChangeSortBy, sortBy },
+    [sortBy]
+  );
+
+  return columns;
+};

--- a/client/packages/system/src/Encounter/index.ts
+++ b/client/packages/system/src/Encounter/index.ts
@@ -1,3 +1,4 @@
 export * from './ListView';
 export * from './Service';
 export * from './api';
+export * from './utils';

--- a/client/packages/system/src/Encounter/utils.ts
+++ b/client/packages/system/src/Encounter/utils.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import {
+  DateUtils,
+  LocaleKey,
+  TypedTFunction,
+  useTranslation,
+} from '@common/intl';
+import { EncounterRowFragment } from './api';
+import { EncounterNodeStatus } from '@common/types';
+
+const effectiveStatus = (
+  encounter: EncounterRowFragment,
+  t: TypedTFunction<LocaleKey>
+) => {
+  const status = encounter.status;
+  if (!status) {
+    return '';
+  }
+  switch (status) {
+    case EncounterNodeStatus.Cancelled:
+      return t('label.encounter-status-cancelled');
+    case EncounterNodeStatus.Done:
+      return t('label.encounter-status-done');
+    case EncounterNodeStatus.Scheduled:
+      if (DateUtils.isBefore(new Date(encounter.startDatetime), Date.now())) {
+        return t('label.encounter-status-missed');
+      }
+      return t('label.encounter-status-scheduled');
+    default:
+      ((_: never) => {
+        // exhaustive check
+        _;
+      })(status);
+  }
+  return '';
+};
+
+export type EncounterFragmentWithStatus = {
+  effectiveStatus: string;
+} & EncounterRowFragment;
+
+export const useEncounterFragmentWithStatus = (
+  nodes?: EncounterRowFragment[]
+): EncounterFragmentWithStatus[] | undefined => {
+  const t = useTranslation('common');
+  return useMemo(
+    () =>
+      nodes?.map(node => ({
+        effectiveStatus: effectiveStatus(node, t),
+        ...node,
+      })),
+    [nodes]
+  );
+};

--- a/client/packages/system/src/Patient/Encounter/ListView.tsx
+++ b/client/packages/system/src/Patient/Encounter/ListView.tsx
@@ -1,77 +1,22 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 import {
   TableProvider,
   DataTable,
-  useColumns,
   createTableStore,
   NothingHere,
   createQueryParamsStore,
-  useFormatDateTime,
-  ColumnAlign,
   useNavigate,
   RouteBuilder,
-  EncounterNodeStatus,
-  useTranslation,
-  LocaleKey,
-  TypedTFunction,
-  DateUtils,
   useQueryParamsStore,
   EncounterSortFieldInput,
 } from '@openmsupply-client/common';
 import { usePatient } from '../api';
 import { AppRoute } from 'packages/config/src';
-import { EncounterRowFragment } from '../../Encounter';
-import { ProgramEventFragment } from '../ProgramEnrolment/api';
-
-const effectiveStatus = (
-  encounter: EncounterRowFragment,
-  t: TypedTFunction<LocaleKey>
-) => {
-  const status = encounter.status;
-  if (!status) {
-    return '';
-  }
-  switch (status) {
-    case EncounterNodeStatus.Cancelled:
-      return t('label.encounter-status-cancelled');
-    case EncounterNodeStatus.Done:
-      return t('label.encounter-status-done');
-    case EncounterNodeStatus.Scheduled:
-      if (DateUtils.isBefore(new Date(encounter.startDatetime), Date.now())) {
-        return t('label.encounter-status-missed');
-      }
-      return t('label.encounter-status-scheduled');
-    default:
-      ((_: never) => {
-        // exhaustive check
-        _;
-      })(status);
-  }
-  return '';
-};
-
-type EncounterFragmentExt = {
-  effectiveStatus: string;
-} & EncounterRowFragment;
-
-const useExtendEncounterFragment = (
-  nodes?: EncounterRowFragment[]
-): EncounterFragmentExt[] | undefined => {
-  const t = useTranslation('common');
-  return useMemo(
-    () =>
-      nodes?.map(node => ({
-        effectiveStatus: effectiveStatus(node, t),
-        ...node,
-      })),
-    [nodes]
-  );
-};
-
-const encounterEventCellValue = (events: ProgramEventFragment[]) => {
-  // just take the name of the first event
-  return events[0]?.name ?? '';
-};
+import {
+  EncounterFragmentWithStatus,
+  useEncounterFragmentWithStatus,
+} from '../../Encounter';
+import { useEncounterListColumns } from '../../Encounter/ListView/columns';
 
 const EncounterListComponent: FC = () => {
   const {
@@ -83,52 +28,12 @@ const EncounterListComponent: FC = () => {
     key: sortBy.key as EncounterSortFieldInput,
     isDesc: sortBy.isDesc,
   });
-  const dataExt: EncounterFragmentExt[] | undefined =
-    useExtendEncounterFragment(data?.nodes);
+  const dataWithStatus: EncounterFragmentWithStatus[] | undefined =
+    useEncounterFragmentWithStatus(data?.nodes);
   const pagination = { page, first, offset };
-  const { localisedDateTime } = useFormatDateTime();
   const navigate = useNavigate();
 
-  const columns = useColumns<EncounterFragmentExt>(
-    [
-      {
-        key: 'type',
-        label: 'label.encounter-type',
-      },
-      {
-        key: 'program',
-        label: 'label.program',
-      },
-      {
-        key: 'startDatetime',
-        label: 'label.encounter-start',
-        formatter: dateString =>
-          dateString ? localisedDateTime((dateString as string) || '') : '',
-      },
-      {
-        key: 'endDatetime',
-        label: 'label.encounter-end',
-        formatter: dateString =>
-          dateString ? localisedDateTime((dateString as string) || '') : '',
-      },
-      {
-        key: 'events',
-        label: 'label.label',
-        formatter: events =>
-          encounterEventCellValue((events as ProgramEventFragment[]) ?? []),
-        sortable: false,
-      },
-      {
-        key: 'effectiveStatus',
-        label: 'label.status',
-        align: ColumnAlign.Right,
-        width: 175,
-        sortable: false,
-      },
-    ],
-    { onChangeSortBy, sortBy },
-    [sortBy]
-  );
+  const columns = useEncounterListColumns({ onChangeSortBy, sortBy });
 
   return (
     <DataTable
@@ -136,7 +41,7 @@ const EncounterListComponent: FC = () => {
       pagination={{ ...pagination, total: data?.totalCount }}
       onChangePage={onChangePage}
       columns={columns}
-      data={dataExt}
+      data={dataWithStatus}
       isLoading={isLoading}
       isError={isError}
       onRowClick={row => {
@@ -155,7 +60,7 @@ const EncounterListComponent: FC = () => {
 export const EncounterListView: FC = () => (
   <TableProvider
     createStore={createTableStore}
-    queryParamsStore={createQueryParamsStore<EncounterFragmentExt>({
+    queryParamsStore={createQueryParamsStore<EncounterFragmentWithStatus>({
       initialSortBy: { key: 'startDatetime' },
     })}
   >


### PR DESCRIPTION
Closes #548 

Rationalises the encounter list views - with a little fix-up along the way.

## Changes
- Fixed the start time column, which was showing blank
- Used the same columns in both encounter list views
- Added the current tab to the URL query params, so that refreshing the page or returning to the page will show the correct tab
- Updated the encounter detail view cancel button action; now navigates back rather than always showing the encounter list
- Fixed the encounter detail view toolbar which was no longer showing the details


## Test
- [ ] The patient list view now has date, and start and end times
- [ ] The main list view shows the 'effective status' 
- [ ] Only the main list view shows the patient name
- [ ] Clicking cancel on the encounter detail view returns you to the previous screen ( patient encounter list tab or main encounter list )
- [ ] The start time shows correctly now 🙄 
- [ ] The encounter detail view shows the encounter details in the toolbar
- [ ] After selecting a tab in the patient detail view ( or any detail view with tabs ), and refreshing, the selected tab is shown