### PR TITLE
29 document permissions

### DIFF
--- a/server/graphql/programs/src/mutations/encounter/insert.rs
+++ b/server/graphql/programs/src/mutations/encounter/insert.rs
@@ -45,6 +45,13 @@ pub fn insert_encounter(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
 
+    match user.context.into_iter().find(|c| c == &input.r#type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
+
     let document = match service_provider.encounter_service.insert_encounter(
         &service_context,
         service_provider,

--- a/server/graphql/programs/src/mutations/encounter/update.rs
+++ b/server/graphql/programs/src/mutations/encounter/update.rs
@@ -13,6 +13,8 @@ use crate::types::encounter::EncounterNode;
 
 #[derive(InputObject)]
 pub struct UpdateEncounterInput {
+    /// The encounter type
+    pub r#type: String,
     /// Encounter document data
     pub data: serde_json::Value,
     /// The schema id used for the counter data
@@ -39,6 +41,13 @@ pub fn update_encounter(
         },
     )?;
 
+    match user.context.into_iter().find(|c| c == &input.r#type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
+
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
 
@@ -47,6 +56,7 @@ pub fn update_encounter(
         service_provider,
         &user.user_id,
         UpdateEncounter {
+            r#type: input.r#type,
             data: input.data,
             schema_id: input.schema_id,
             parent: input.parent,

--- a/server/graphql/programs/src/mutations/insert_document_registry.rs
+++ b/server/graphql/programs/src/mutations/insert_document_registry.rs
@@ -30,13 +30,20 @@ pub fn insert_document_registry(
     ctx: &Context<'_>,
     input: InsertDocumentRegistryInput,
 ) -> Result<InsertDocumentResponse> {
-    validate_auth(
+    let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::MutateDocumentRegistry,
             store_id: None,
         },
     )?;
+
+    match user.context.into_iter().find(|c| c == &input.document_type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -78,6 +78,9 @@ pub fn insert_patient(
                 UpdatePatientError::InvalidParentId => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
+                UpdatePatientError::PatientDoesNotBelongToStore => {
+                    StandardGraphqlError::BadUserInput(formatted_error)
+                }
             };
             Err(std_err.extend())
         }

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -79,6 +79,9 @@ pub fn update_patient(
                 UpdatePatientError::InvalidParentId => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
+                UpdatePatientError::PatientDoesNotBelongToStore => {
+                    StandardGraphqlError::BadUserInput(formatted_error)
+                }
             };
             Err(std_err.extend())
         }

--- a/server/graphql/programs/src/mutations/program_enrolment/insert.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/insert.rs
@@ -11,7 +11,7 @@ use service::{
 
 use crate::types::program_enrolment::ProgramEnrolmentNode;
 
-#[derive(InputObject)]
+#[derive(InputObject, PartialEq)]
 pub struct InsertProgramEnrolmentInput {
     /// The program type
     pub r#type: String,
@@ -42,6 +42,13 @@ pub fn insert_program_enrolment(
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
+
+    match user.context.into_iter().find(|c| c == &input.r#type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
 
     let document = match service_provider
         .program_enrolment_service

--- a/server/graphql/programs/src/mutations/program_enrolment/update.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/update.rs
@@ -44,6 +44,13 @@ pub fn update_program_enrolment(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
 
+    match user.context.into_iter().find(|c| c == &input.r#type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
+
     let document = match service_provider
         .program_enrolment_service
         .upsert_program_enrolment(

--- a/server/graphql/programs/src/mutations/update_document.rs
+++ b/server/graphql/programs/src/mutations/update_document.rs
@@ -65,13 +65,20 @@ pub fn update_document(
     store_id: String,
     input: UpdateDocumentInput,
 ) -> Result<UpdateDocumentResponse> {
-    validate_auth(
+    let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::MutateDocument,
             store_id: Some(store_id),
         },
     )?;
+
+    match user.context.into_iter().find(|c| c == &input.r#type) {
+        None => Err(StandardGraphqlError::BadUserInput(
+            "User does not have access to document type".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }?;
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/mutations/update_document.rs
+++ b/server/graphql/programs/src/mutations/update_document.rs
@@ -73,17 +73,17 @@ pub fn update_document(
         },
     )?;
 
+    let service_provider = ctx.service_provider();
+    let context = service_provider.basic_context()?;
+
+    validate_document_type(&context.connection, &input)?;
+
     match user.context.into_iter().find(|c| c == &input.r#type) {
         None => Err(StandardGraphqlError::BadUserInput(
             "User does not have access to document type".to_string(),
         )),
         Some(_) => Ok(()),
     }?;
-
-    let service_provider = ctx.service_provider();
-    let context = service_provider.basic_context()?;
-
-    validate_document_type(&context.connection, &input)?;
 
     let response = match service_provider
         .document_service
@@ -242,7 +242,11 @@ mod graphql {
             ProgramsQueries,
             ProgramsMutations,
             "test_program_update_not_allowed",
-            MockDataInserts::none().names().stores(),
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .user_permissions()
+                .user_accounts(),
         )
         .await;
 

--- a/server/graphql/programs/src/queries/encounter.rs
+++ b/server/graphql/programs/src/queries/encounter.rs
@@ -85,7 +85,7 @@ pub fn encounters(
     ctx: &Context<'_>,
     store_id: String,
     page: Option<PaginationInput>,
-    input_filter: Option<EncounterFilterInput>,
+    filter: Option<EncounterFilterInput>,
     sort: Option<EncounterSortInput>,
 ) -> Result<EncounterResponse> {
     let user = validate_auth(
@@ -99,12 +99,11 @@ pub fn encounters(
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
 
-    let filter =
-        input_filter
-            .map(|f| f.to_domain_filter())
-            .unwrap_or(EncounterFilter::new().r#type(EqualFilter::equal_any(
-                user.context.iter().map(String::clone).collect(),
-            )));
+    let filter = filter
+        .map(|f| f.to_domain_filter())
+        .unwrap_or(EncounterFilter::new().r#type(EqualFilter::equal_any(
+            user.context.iter().map(String::clone).collect(),
+        )));
 
     let result = service_provider
         .encounter_service

--- a/server/graphql/programs/src/queries/encounter_fields.rs
+++ b/server/graphql/programs/src/queries/encounter_fields.rs
@@ -54,7 +54,7 @@ pub fn encounter_fields(
     store_id: String,
     input: EncounterFieldsInput,
     page: Option<PaginationInput>,
-    input_filter: Option<EncounterFilterInput>,
+    filter: Option<EncounterFilterInput>,
     sort: Option<EncounterSortInput>,
 ) -> Result<EncounterFieldsResponse> {
     let user = validate_auth(
@@ -68,12 +68,11 @@ pub fn encounter_fields(
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
 
-    let filter =
-        input_filter
-            .map(|f| f.to_domain_filter())
-            .unwrap_or(EncounterFilter::new().r#type(EqualFilter::equal_any(
-                user.context.iter().map(String::clone).collect(),
-            )));
+    let filter = filter
+        .map(|f| f.to_domain_filter())
+        .unwrap_or(EncounterFilter::new().r#type(EqualFilter::equal_any(
+            user.context.iter().map(String::clone).collect(),
+        )));
 
     let result = service_provider
         .encounter_service

--- a/server/graphql/programs/src/queries/patient.rs
+++ b/server/graphql/programs/src/queries/patient.rs
@@ -161,6 +161,7 @@ pub struct PatientFilterInput {
     pub address2: Option<SimpleStringFilterInput>,
     pub country: Option<SimpleStringFilterInput>,
     pub email: Option<SimpleStringFilterInput>,
+    pub is_visible: Option<bool>,
 }
 
 impl PatientFilterInput {
@@ -178,6 +179,7 @@ impl PatientFilterInput {
             address2,
             country,
             email,
+            is_visible,
         } = self;
         PatientFilter {
             id: id.map(EqualFilter::from),
@@ -192,6 +194,7 @@ impl PatientFilterInput {
             address2: address2.map(SimpleStringFilter::from),
             country: country.map(SimpleStringFilter::from),
             email: email.map(SimpleStringFilter::from),
+            is_visible,
         }
     }
 }

--- a/server/graphql/programs/src/queries/program_enrolment.rs
+++ b/server/graphql/programs/src/queries/program_enrolment.rs
@@ -66,7 +66,7 @@ pub fn program_enrolments(
     ctx: &Context<'_>,
     store_id: String,
     sort: Option<ProgramEnrolmentSortInput>,
-    input_filter: Option<ProgramEnrolmentFilterInput>,
+    filter: Option<ProgramEnrolmentFilterInput>,
 ) -> Result<ProgramEnrolmentResponse> {
     let user = validate_auth(
         ctx,
@@ -80,7 +80,7 @@ pub fn program_enrolments(
     let context = service_provider.basic_context()?;
 
     let filter =
-        input_filter
+        filter
             .map(|f| f.to_domain_filter())
             .unwrap_or(ProgramEnrolmentFilter::new().r#type(EqualFilter::equal_any(
                 user.context.iter().map(String::clone).collect(),

--- a/server/graphql/types/src/types/permissions.rs
+++ b/server/graphql/types/src/types/permissions.rs
@@ -14,7 +14,7 @@ pub struct UserStorePermissionConnector {
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
-pub enum UserPermissionNodePermission {
+pub enum UserPermission {
     ServerAdmin,
     StoreAccess,
     LocationMutate,
@@ -31,21 +31,35 @@ pub enum UserPermissionNodePermission {
     LogQuery,
     PatientQuery,
     PatientMutate,
+    Document,
+    DocumentEncounterQuery,
+    DocumentEncounterMutate,
+    DocumentProgramQuery,
+    DocumentProgramMutate,
 }
 
 #[Object]
 impl UserStorePermissionNode {
-    pub async fn permissions(&self) -> Vec<UserPermissionNodePermission> {
-        self.user_store_permission
+    pub async fn permissions(&self) -> Vec<UserPermission> {
+        self.row()
             .permissions
             .clone()
             .into_iter()
-            .map(|p| UserPermissionNodePermission::from_domain(&p.permission))
+            .map(|p| UserPermission::from_domain(&p.permission))
             .collect()
     }
 
     pub async fn store_id(&self) -> String {
         self.row().store_row.id.clone()
+    }
+
+    pub async fn context(&self) -> Vec<String> {
+        self.row()
+            .permissions
+            .clone()
+            .into_iter()
+            .filter_map(|c| c.context)
+            .collect()
     }
 }
 
@@ -61,59 +75,56 @@ impl UserStorePermissionNode {
     }
 }
 
-impl UserPermissionNodePermission {
-    pub fn from_domain(from: &Permission) -> UserPermissionNodePermission {
+impl UserPermission {
+    pub fn from_domain(from: &Permission) -> UserPermission {
         match from {
-            Permission::ServerAdmin => UserPermissionNodePermission::ServerAdmin,
-            Permission::StoreAccess => UserPermissionNodePermission::StoreAccess,
-            Permission::LocationMutate => UserPermissionNodePermission::LocationMutate,
-            Permission::StockLineQuery => UserPermissionNodePermission::StockLineQuery,
-            Permission::StocktakeQuery => UserPermissionNodePermission::StocktakeQuery,
-            Permission::StocktakeMutate => UserPermissionNodePermission::StocktakeMutate,
-            Permission::RequisitionQuery => UserPermissionNodePermission::RequisitionQuery,
-            Permission::RequisitionMutate => UserPermissionNodePermission::RequisitionMutate,
-            Permission::OutboundShipmentQuery => {
-                UserPermissionNodePermission::OutboundShipmentQuery
-            }
-            Permission::OutboundShipmentMutate => {
-                UserPermissionNodePermission::OutboundShipmentMutate
-            }
-            Permission::InboundShipmentQuery => UserPermissionNodePermission::InboundShipmentQuery,
-            Permission::InboundShipmentMutate => {
-                UserPermissionNodePermission::InboundShipmentMutate
-            }
-            Permission::Report => UserPermissionNodePermission::Report,
-            Permission::LogQuery => UserPermissionNodePermission::LogQuery,
-            Permission::Document => UserPermissionNodePermission::PatientQuery,
-            Permission::PatientQuery => UserPermissionNodePermission::PatientQuery,
-            Permission::PatientMutate => UserPermissionNodePermission::PatientMutate,
+            Permission::ServerAdmin => UserPermission::ServerAdmin,
+            Permission::StoreAccess => UserPermission::StoreAccess,
+            Permission::LocationMutate => UserPermission::LocationMutate,
+            Permission::StockLineQuery => UserPermission::StockLineQuery,
+            Permission::StocktakeQuery => UserPermission::StocktakeQuery,
+            Permission::StocktakeMutate => UserPermission::StocktakeMutate,
+            Permission::RequisitionQuery => UserPermission::RequisitionQuery,
+            Permission::RequisitionMutate => UserPermission::RequisitionMutate,
+            Permission::OutboundShipmentQuery => UserPermission::OutboundShipmentQuery,
+            Permission::OutboundShipmentMutate => UserPermission::OutboundShipmentMutate,
+            Permission::InboundShipmentQuery => UserPermission::InboundShipmentQuery,
+            Permission::InboundShipmentMutate => UserPermission::InboundShipmentMutate,
+            Permission::Report => UserPermission::Report,
+            Permission::LogQuery => UserPermission::LogQuery,
+            Permission::PatientQuery => UserPermission::PatientQuery,
+            Permission::PatientMutate => UserPermission::PatientMutate,
+            Permission::Document => UserPermission::Document,
+            Permission::DocumentEncounterQuery => UserPermission::DocumentEncounterQuery,
+            Permission::DocumentEncounterMutate => UserPermission::DocumentEncounterMutate,
+            Permission::DocumentProgramQuery => UserPermission::DocumentProgramQuery,
+            Permission::DocumentProgramMutate => UserPermission::DocumentProgramMutate,
         }
     }
 
     pub fn to_domain(self) -> Permission {
         match self {
-            UserPermissionNodePermission::ServerAdmin => Permission::ServerAdmin,
-            UserPermissionNodePermission::StoreAccess => Permission::StoreAccess,
-            UserPermissionNodePermission::LocationMutate => Permission::LocationMutate,
-            UserPermissionNodePermission::StockLineQuery => Permission::StockLineQuery,
-            UserPermissionNodePermission::StocktakeQuery => Permission::StocktakeQuery,
-            UserPermissionNodePermission::StocktakeMutate => Permission::StocktakeMutate,
-            UserPermissionNodePermission::RequisitionQuery => Permission::RequisitionQuery,
-            UserPermissionNodePermission::RequisitionMutate => Permission::RequisitionMutate,
-            UserPermissionNodePermission::OutboundShipmentQuery => {
-                Permission::OutboundShipmentQuery
-            }
-            UserPermissionNodePermission::OutboundShipmentMutate => {
-                Permission::OutboundShipmentMutate
-            }
-            UserPermissionNodePermission::InboundShipmentQuery => Permission::InboundShipmentQuery,
-            UserPermissionNodePermission::InboundShipmentMutate => {
-                Permission::InboundShipmentMutate
-            }
-            UserPermissionNodePermission::Report => Permission::Report,
-            UserPermissionNodePermission::LogQuery => Permission::LogQuery,
-            UserPermissionNodePermission::PatientQuery => Permission::PatientQuery,
-            UserPermissionNodePermission::PatientMutate => Permission::PatientMutate,
+            UserPermission::ServerAdmin => Permission::ServerAdmin,
+            UserPermission::StoreAccess => Permission::StoreAccess,
+            UserPermission::LocationMutate => Permission::LocationMutate,
+            UserPermission::StockLineQuery => Permission::StockLineQuery,
+            UserPermission::StocktakeQuery => Permission::StocktakeQuery,
+            UserPermission::StocktakeMutate => Permission::StocktakeMutate,
+            UserPermission::RequisitionQuery => Permission::RequisitionQuery,
+            UserPermission::RequisitionMutate => Permission::RequisitionMutate,
+            UserPermission::OutboundShipmentQuery => Permission::OutboundShipmentQuery,
+            UserPermission::OutboundShipmentMutate => Permission::OutboundShipmentMutate,
+            UserPermission::InboundShipmentQuery => Permission::InboundShipmentQuery,
+            UserPermission::InboundShipmentMutate => Permission::InboundShipmentMutate,
+            UserPermission::Report => Permission::Report,
+            UserPermission::LogQuery => Permission::LogQuery,
+            UserPermission::PatientQuery => Permission::PatientQuery,
+            UserPermission::PatientMutate => Permission::PatientMutate,
+            UserPermission::Document => Permission::Document,
+            UserPermission::DocumentEncounterQuery => Permission::DocumentEncounterQuery,
+            UserPermission::DocumentEncounterMutate => Permission::DocumentEncounterMutate,
+            UserPermission::DocumentProgramQuery => Permission::DocumentProgramQuery,
+            UserPermission::DocumentProgramMutate => Permission::DocumentProgramMutate,
         }
     }
 }

--- a/server/repository/migrations/postgres/2022-03-25T14-30_create_user_permission_table/up.sql
+++ b/server/repository/migrations/postgres/2022-03-25T14-30_create_user_permission_table/up.sql
@@ -15,12 +15,17 @@ CREATE TYPE permission_type AS ENUM (
     'SERVER_ADMIN',
     'DOCUMENT',
     'PATIENT_QUERY',
-    'PATIENT_MUTATE'
+    'PATIENT_MUTATE',
+    'DOCUMENT_ENCOUNTER_QUERY',
+    'DOCUMENT_ENCOUNTER_MUTATE',
+    'DOCUMENT_PROGRAM_QUERY',
+    'DOCUMENT_PROGRAM_MUTATE'
 );
 
 CREATE TABLE user_permission (
     id TEXT NOT NULL PRIMARY KEY,
     user_id TEXT NOT NULL REFERENCES user_account(id),
     store_id TEXT NOT NULL REFERENCES store(id),
-    permission permission_type NOT NULL
+    permission permission_type NOT NULL,
+    context TEXT
 )

--- a/server/repository/migrations/sqlite/2022-03-25T14-30_create_user_permission_table/up.sql
+++ b/server/repository/migrations/sqlite/2022-03-25T14-30_create_user_permission_table/up.sql
@@ -19,6 +19,11 @@ CREATE TABLE user_permission (
         'SERVER_ADMIN',
         'DOCUMENT',
         'PATIENT_QUERY',
-        'PATIENT_MUTATE'
-    )) NOT NULL
+        'PATIENT_MUTATE',
+        'DOCUMENT_ENCOUNTER_QUERY',
+        'DOCUMENT_ENCOUNTER_MUTATE',
+        'DOCUMENT_PROGRAM_QUERY',
+        'DOCUMENT_PROGRAM_MUTATE'
+    )) NOT NULL,
+    context TEXT
 )

--- a/server/repository/src/db_diesel/encounter.rs
+++ b/server/repository/src/db_diesel/encounter.rs
@@ -14,6 +14,7 @@ use diesel::{dsl::IntoBoxed, prelude::*};
 #[derive(Clone)]
 pub struct EncounterFilter {
     pub id: Option<EqualFilter<String>>,
+    pub r#type: Option<EqualFilter<String>>,
     pub patient_id: Option<EqualFilter<String>>,
     pub program: Option<EqualFilter<String>>,
     pub name: Option<EqualFilter<String>>,
@@ -26,6 +27,7 @@ impl EncounterFilter {
     pub fn new() -> EncounterFilter {
         EncounterFilter {
             id: None,
+            r#type: None,
             patient_id: None,
             program: None,
             name: None,
@@ -37,6 +39,11 @@ impl EncounterFilter {
 
     pub fn id(mut self, filter: EqualFilter<String>) -> Self {
         self.id = Some(filter);
+        self
+    }
+
+    pub fn r#type(mut self, filter: EqualFilter<String>) -> Self {
+        self.r#type = Some(filter);
         self
     }
 
@@ -92,6 +99,7 @@ fn create_filtered_query<'a>(filter: Option<EncounterFilter>) -> BoxedProgramQue
     if let Some(f) = filter {
         let EncounterFilter {
             id,
+            r#type,
             patient_id,
             program,
             name,
@@ -101,6 +109,7 @@ fn create_filtered_query<'a>(filter: Option<EncounterFilter>) -> BoxedProgramQue
         } = f;
 
         apply_equal_filter!(query, id, encounter_dsl::id);
+        apply_equal_filter!(query, r#type, encounter_dsl::type_);
         apply_equal_filter!(query, patient_id, encounter_dsl::patient_id);
         apply_equal_filter!(query, program, encounter_dsl::program);
         apply_equal_filter!(query, name, encounter_dsl::name);

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -15,7 +15,8 @@ table! {
       user_id -> Text,
       store_id -> Nullable<Text>,
       permission -> crate::db_diesel::user_permission_row::PermissionMapping,
-  }
+      context -> Nullable<Text>,
+    }
 }
 
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq, Hash)]
@@ -45,20 +46,27 @@ pub enum Permission {
     // reporting
     Report,
     LogQuery,
-    // document
-    Document,
-    // patients
     PatientQuery,
     PatientMutate,
+    // Document
+    Document,
+    DocumentEncounterQuery,
+    DocumentEncounterMutate,
+    DocumentProgramQuery,
+    DocumentProgramMutate,
 }
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]
+#[changeset_options(treat_none_as_null = "true")]
 #[table_name = "user_permission"]
 pub struct UserPermissionRow {
     pub id: String,
     pub user_id: String,
     pub store_id: Option<String>,
     pub permission: Permission,
+    /// An optional resource associated with this permission.
+    /// The resource value is only used for certain Permission variants.
+    pub context: Option<String>,
 }
 
 pub struct UserPermissionRowRepository<'a> {

--- a/server/repository/src/mock/name.rs
+++ b/server/repository/src/mock/name.rs
@@ -74,6 +74,24 @@ pub fn mock_name_master_list_filter_test() -> NameRow {
     })
 }
 
+pub fn mock_patient() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = String::from("testId");
+        r.name = String::from("testId");
+        r.code = String::from("testId");
+        r.is_customer = true;
+    })
+}
+
+pub fn mock_patient_b() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = String::from("patient2");
+        r.name = String::from("patient2");
+        r.code = String::from("patient2");
+        r.is_customer = true;
+    })
+}
+
 pub fn mock_names() -> Vec<NameRow> {
     vec![
         mock_name_store_a(),
@@ -83,5 +101,7 @@ pub fn mock_names() -> Vec<NameRow> {
         mock_name_a(),
         mock_name_invad(),
         mock_name_master_list_filter_test(),
+        mock_patient(),
+        mock_patient_b(),
     ]
 }

--- a/server/repository/src/mock/name_store_join.rs
+++ b/server/repository/src/mock/name_store_join.rs
@@ -50,6 +50,26 @@ pub fn mock_name_store_join_e() -> NameStoreJoinRow {
     }
 }
 
+pub fn mock_patient_store_join() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_patient_store_join"),
+        name_id: String::from("testId"),
+        store_id: String::from("store_a"),
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}
+
+pub fn mock_patient_store_join_b() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_patient_store_join_b"),
+        name_id: String::from("patient2"),
+        store_id: String::from("store_a"),
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}
+
 pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
     vec![
         mock_name_store_join_a(),
@@ -57,5 +77,7 @@ pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
         mock_name_store_join_c(),
         mock_name_store_join_d(),
         mock_name_store_join_e(),
+        mock_patient_store_join(),
+        mock_patient_store_join_b(),
     ]
 }

--- a/server/repository/src/mock/user_account.rs
+++ b/server/repository/src/mock/user_account.rs
@@ -57,6 +57,7 @@ pub fn mock_user_permission_a1() -> UserPermissionRow {
         user_id: "user_account_a".to_string(),
         store_id: Some("store_a".to_string()),
         permission: Permission::StocktakeMutate,
+        context: None,
     }
 }
 
@@ -66,6 +67,7 @@ pub fn mock_user_permission_a2() -> UserPermissionRow {
         user_id: "user_account_a".to_string(),
         store_id: Some("store_a".to_string()),
         permission: Permission::RequisitionQuery,
+        context: None,
     }
 }
 
@@ -75,6 +77,7 @@ pub fn mock_user_permission_b1() -> UserPermissionRow {
         user_id: "user_account_b".to_string(),
         store_id: Some("store_a".to_string()),
         permission: Permission::OutboundShipmentQuery,
+        context: None,
     }
 }
 

--- a/server/repository/src/mock/user_account.rs
+++ b/server/repository/src/mock/user_account.rs
@@ -20,6 +20,15 @@ pub fn mock_user_account_b() -> UserAccountRow {
     }
 }
 
+pub fn mock_me_user() -> UserAccountRow {
+    UserAccountRow {
+        id: String::from("me"),
+        username: String::from("me"),
+        hashed_password: String::from("password"),
+        email: Some(String::from("me@openmsupply.foundation")),
+    }
+}
+
 pub fn mock_user_store_join_a_store_a() -> UserStoreJoinRow {
     UserStoreJoinRow {
         id: "user_store_join_a_store_a".to_string(),
@@ -81,8 +90,18 @@ pub fn mock_user_permission_b1() -> UserPermissionRow {
     }
 }
 
+pub fn programs_user_permission_a() -> UserPermissionRow {
+    UserPermissionRow {
+        id: "programs_user_permission_a".to_string(),
+        user_id: "me".to_string(),
+        store_id: Some("store_a".to_string()),
+        permission: Permission::Document,
+        context: Some("TestProgram".to_string()),
+    }
+}
+
 pub fn mock_user_accounts() -> Vec<UserAccountRow> {
-    vec![mock_user_account_a(), mock_user_account_b()]
+    vec![mock_user_account_a(), mock_user_account_b(), mock_me_user()]
 }
 
 pub fn mock_user_store_joins() -> Vec<UserStoreJoinRow> {

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -268,28 +268,28 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
         Resource::QueryProgram,
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
-            PermissionDSL::HasPermission(Permission::PatientQuery),
+            PermissionDSL::HasPermission(Permission::DocumentProgramQuery),
         ]),
     );
     map.insert(
         Resource::QueryEncounter,
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
-            PermissionDSL::HasPermission(Permission::PatientQuery),
+            PermissionDSL::HasPermission(Permission::DocumentEncounterQuery),
         ]),
     );
     map.insert(
         Resource::MutateProgram,
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
-            PermissionDSL::HasPermission(Permission::PatientMutate),
+            PermissionDSL::HasPermission(Permission::DocumentProgramMutate),
         ]),
     );
     map.insert(
         Resource::MutateEncounter,
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
-            PermissionDSL::HasPermission(Permission::PatientMutate),
+            PermissionDSL::HasPermission(Permission::DocumentEncounterMutate),
         ]),
     );
 
@@ -587,6 +587,7 @@ mod validate_resource_permissions_test {
             user_id: user_id.to_string(),
             permission: Permission::ServerAdmin,
             store_id: None,
+            context: None,
         }];
         let validation_result = validate_resource_permissions(
             user_id,
@@ -638,6 +639,7 @@ mod validate_resource_permissions_test {
             user_id: user_id.to_string(),
             permission: Permission::StocktakeMutate,
             store_id: Some(store_id.to_string()),
+            context: None,
         }];
         let required_permissions = PermissionDSL::And(vec![
             PermissionDSL::HasPermission(Permission::ServerAdmin),
@@ -658,12 +660,14 @@ mod validate_resource_permissions_test {
                 user_id: user_id.to_string(),
                 permission: Permission::ServerAdmin,
                 store_id: None,
+                context: None,
             },
             UserPermissionRow {
                 id: "dummy_id2".to_string(),
                 user_id: user_id.to_string(),
                 permission: Permission::StocktakeMutate,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
         ];
         let required_permissions = PermissionDSL::And(vec![
@@ -692,12 +696,14 @@ mod validate_resource_permissions_test {
                 user_id: user_id.to_string(),
                 permission: Permission::StocktakeMutate,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
             UserPermissionRow {
                 id: "dummy_id2".to_string(),
                 user_id: user_id.to_string(),
                 permission: Permission::StoreAccess,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
         ];
         let validation_result = validate_resource_permissions(
@@ -720,6 +726,7 @@ mod validate_resource_permissions_test {
             user_id: user_id.to_string(),
             permission: Permission::ServerAdmin,
             store_id: None,
+            context: None,
         }];
         let validation_result = validate_resource_permissions(
             user_id,
@@ -743,12 +750,14 @@ mod validate_resource_permissions_test {
                 user_id: user_id.to_string(),
                 permission: Permission::StocktakeMutate,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
             UserPermissionRow {
                 id: "dummy_id2".to_string(),
                 user_id: user_id.to_string(),
                 permission: Permission::StoreAccess,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
         ];
         let validation_result = validate_resource_permissions(
@@ -765,12 +774,14 @@ mod validate_resource_permissions_test {
                 user_id: user_id.to_string(),
                 permission: Permission::ServerAdmin,
                 store_id: None,
+                context: None,
             },
             UserPermissionRow {
                 id: "dummy_id2".to_string(),
                 user_id: user_id.to_string(),
                 permission: Permission::StoreAccess,
                 store_id: Some(store_id.to_string()),
+                context: None,
             },
         ];
         let validation_result = validate_resource_permissions(
@@ -871,6 +882,7 @@ mod permission_validation_test {
                 user_id: mock_user_account_a().id,
                 store_id: Some("store_a".to_string()),
                 permission: Permission::InboundShipmentMutate,
+                context: None,
             })
             .unwrap();
         assert!(service
@@ -892,6 +904,7 @@ mod permission_validation_test {
                 user_id: mock_user_account_a().id,
                 store_id: Some("store_a".to_string()),
                 permission: Permission::StocktakeQuery,
+                context: None,
             })
             .unwrap();
         assert!(service
@@ -961,12 +974,14 @@ mod permission_validation_test {
                     user_id: user().id,
                     store_id: Some(store().id),
                     permission: Permission::RequisitionMutate,
+                    context: None,
                 },
                 UserPermissionRow {
                     id: "permission_store_access".to_string(),
                     user_id: user().id,
                     store_id: Some(store().id),
                     permission: Permission::StoreAccess,
+                    context: None,
                 },
             ]
         }

--- a/server/service/src/programs/encounter/insert.rs
+++ b/server/service/src/programs/encounter/insert.rs
@@ -175,7 +175,11 @@ mod test {
     async fn test_encounter_insert() {
         let (_, _, connection_manager, _) = setup_all(
             "test_encounter_insert",
-            MockDataInserts::none().names().stores().form_schemas(),
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .form_schemas()
+                .name_store_joins(),
         )
         .await;
 

--- a/server/service/src/programs/encounter/update.rs
+++ b/server/service/src/programs/encounter/update.rs
@@ -25,6 +25,7 @@ pub enum UpdateEncounterError {
 }
 
 pub struct UpdateEncounter {
+    pub r#type: String,
     pub parent: String,
     pub data: serde_json::Value,
     pub schema_id: String,
@@ -272,6 +273,7 @@ mod test {
                 &service_provider,
                 "user",
                 UpdateEncounter {
+                    r#type: "TestEncounterType".to_string(),
                     data: json!({"enrolment_datetime": true}),
                     schema_id: schema.id.clone(),
                     parent: "invalid".to_string(),
@@ -288,6 +290,7 @@ mod test {
                 &service_provider,
                 "user",
                 UpdateEncounter {
+                    r#type: "TestEncounterType".to_string(),
                     data: json!({"encounter_datetime": true}),
                     schema_id: schema.id.clone(),
                     parent: initial_encounter.id.clone(),
@@ -308,6 +311,7 @@ mod test {
                 &service_provider,
                 "user",
                 UpdateEncounter {
+                    r#type: "TestEncounterType".to_string(),
                     data: serde_json::to_value(encounter.clone()).unwrap(),
                     schema_id: schema.id.clone(),
                     parent: initial_encounter.id.clone(),

--- a/server/service/src/programs/encounter/update.rs
+++ b/server/service/src/programs/encounter/update.rs
@@ -192,7 +192,11 @@ mod test {
     async fn test_encounter_update() {
         let (_, _, connection_manager, _) = setup_all(
             "test_encounter_update",
-            MockDataInserts::none().names().stores().form_schemas(),
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .form_schemas()
+                .name_store_joins(),
         )
         .await;
 

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -118,7 +118,7 @@ mod test {
     async fn test_patient_table_update() {
         let (_, _, connection_manager, _) = setup_all(
             "patient_table_update",
-            MockDataInserts::none().names().stores(),
+            MockDataInserts::none().names().stores().name_store_joins(),
         )
         .await;
 
@@ -148,7 +148,7 @@ mod test {
             zip_code: None,
         };
         let patient = inline_init(|p: &mut SchemaPatient| {
-            p.id = "patient1".to_string();
+            p.id = "testId".to_string();
             p.contact_details = vec![contact_details.clone()];
             p.date_of_birth = Some("2000-03-04".to_string());
             p.first_name = Some("firstname".to_string());

--- a/server/service/src/programs/patient/query.rs
+++ b/server/service/src/programs/patient/query.rs
@@ -21,6 +21,7 @@ pub struct PatientFilter {
     pub address2: Option<SimpleStringFilter>,
     pub country: Option<SimpleStringFilter>,
     pub email: Option<SimpleStringFilter>,
+    pub is_visible: Option<bool>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -106,6 +107,7 @@ impl PatientFilter {
             address2,
             country,
             email,
+            is_visible,
         } = self;
 
         NameFilter {
@@ -117,7 +119,7 @@ impl PatientFilter {
             is_supplier: None,
             is_store: None,
             store_code: None,
-            is_visible: None,
+            is_visible,
             is_system_name: None,
             r#type: None,
             first_name,

--- a/server/service/src/programs/patient/search.rs
+++ b/server/service/src/programs/patient/search.rs
@@ -59,6 +59,7 @@ pub fn patient_search(
             not_equal_all: None,
         });
     }
+    filter.is_visible = Some(true);
 
     let results: Vec<PatientSearchResult> = service_provider
         .patient_service

--- a/server/service/src/programs/program_enrolment/upsert.rs
+++ b/server/service/src/programs/program_enrolment/upsert.rs
@@ -180,7 +180,11 @@ mod test {
     async fn test_program_upsert() {
         let (_, _, connection_manager, _) = setup_all(
             "test_program_upsert",
-            MockDataInserts::none().names().stores().form_schemas(),
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .form_schemas()
+                .name_store_joins(),
         )
         .await;
 


### PR DESCRIPTION
Closes #29 

Note: Might not compile and will need changes from #609 

- [ ] Query and mutation endpoints for documents check the user's context before allowing them to mutate/query endpoints
- [ ] Added r#type to UpdateEncounter... but can remove if this shouldn't be here...
- [ ] Does the insert Json form schema endpoint also need to be locked behind context? 