### PR TITLE
#372 Clear selection in "Select" components

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -32,19 +32,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
     },
     ref
   ) => {
-    const CloseComponent = () => (
-      <CloseIcon
-        onClick={e => onChange({ ...e, target: { value: undefined } } as any)}
-        style={{
-          fontSize: '1em',
-          cursor: 'pointer',
-          color: 'rgba(0, 0, 0, 0.54);',
-        }}
-      />
-    );
-
     const SelectProps =
-      clearable && value ? { IconComponent: CloseComponent } : {};
+      clearable && value
+        ? {
+            IconComponent: () => (
+              // Element to clear current selection.
+              <CloseIcon
+                onClick={e =>
+                  onChange({ ...e, target: { value: undefined } } as any)
+                }
+                style={{
+                  fontSize: '1em',
+                  cursor: 'pointer',
+                  color: 'rgba(0, 0, 0, 0.54);',
+                }}
+              />
+            ),
+          }
+        : {};
 
     return (
       <TextField

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { MenuItem, StandardTextFieldProps, TextField } from '@mui/material';
+import { CloseIcon } from '../../../icons/Close';
 
 export type Option = {
   label: string;
@@ -8,6 +9,7 @@ export type Option = {
 export interface SelectProps extends StandardTextFieldProps {
   options: Option[];
   renderOption?: (option: Option) => React.ReactNode;
+  clearable: boolean;
 }
 
 const defaultRenderOption = (option: Option) => (
@@ -17,33 +19,64 @@ const defaultRenderOption = (option: Option) => (
 );
 
 export const Select: FC<SelectProps> = React.forwardRef(
-  ({ options, renderOption, sx, InputProps, ...props }, ref) => (
-    <TextField
-      ref={ref}
-      sx={{
-        '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-        '& .MuiInput-input': { color: theme => theme.palette.gray.dark },
-        ...sx,
-      }}
-      select
-      variant="standard"
-      size="small"
-      InputProps={{
-        disableUnderline: true,
-        ...InputProps,
-        sx: {
-          backgroundColor: theme =>
-            props.disabled
-              ? theme.palette.background.toolbar
-              : theme.palette.background.menu,
-          borderRadius: '8px',
-          padding: '4px 8px',
-          ...InputProps?.sx,
-        },
-      }}
-      {...props}
-    >
-      {options.map(renderOption || defaultRenderOption)}
-    </TextField>
-  )
+  (
+    {
+      options,
+      renderOption,
+      sx,
+      InputProps,
+      clearable = false,
+      value,
+      onChange = () => {},
+      ...props
+    },
+    ref
+  ) => {
+    const CloseComponent = () => (
+      <CloseIcon
+        onClick={e => onChange({ ...e, target: { value: undefined } } as any)}
+        style={{
+          fontSize: '1em',
+          cursor: 'pointer',
+          color: 'rgba(0, 0, 0, 0.54);',
+        }}
+      />
+    );
+
+    const SelectProps =
+      clearable && value ? { IconComponent: CloseComponent } : {};
+
+    return (
+      <TextField
+        ref={ref}
+        sx={{
+          '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+          '& .MuiInput-input': { color: theme => theme.palette.gray.dark },
+          ...sx,
+        }}
+        select
+        variant="standard"
+        size="small"
+        InputProps={{
+          disableUnderline: true,
+          ...InputProps,
+          sx: {
+            backgroundColor: theme =>
+              props.disabled
+                ? theme.palette.background.toolbar
+                : theme.palette.background.menu,
+            borderRadius: '8px',
+            padding: '4px 8px',
+            ...InputProps?.sx,
+          },
+        }}
+        SelectProps={SelectProps}
+        value={value}
+        onChange={onChange}
+        {...props}
+      >
+        {options.map(renderOption || defaultRenderOption)}
+      </TextField>
+    );
+  }
 );

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -9,7 +9,7 @@ export type Option = {
 export interface SelectProps extends StandardTextFieldProps {
   options: Option[];
   renderOption?: (option: Option) => React.ReactNode;
-  clearable: boolean;
+  clearable?: boolean;
 }
 
 const defaultRenderOption = (option: Option) => (

--- a/client/packages/common/src/ui/forms/JsonForms/components/Select.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Select.tsx
@@ -42,6 +42,7 @@ const UIComponent = (props: ControlProps) => {
           value={data ?? ''}
           onChange={e => handleChange(path, e.target.value)}
           error={!!props.errors}
+          clearable
           helperText={props.errors}
         />
       </Box>


### PR DESCRIPTION
Fix #372 

Quite surprised to see there's no built-in "clear" option for Mui "Select" component.

Hopefully this does the trick. Added `clearable` prop to our general "Select" component, and turned "clearable" on for the JSON Forms "Select" widget.

With no selection (unchanged from current):
<img width="237" alt="Screen Shot 2022-09-21 at 2 18 09 PM" src="https://user-images.githubusercontent.com/5456533/191399544-42030b1b-f3f2-4bb1-811d-01191bb55b5b.png">

After selection, drop-down icon becomes "Clear" icon:
<img width="228" alt="Screen Shot 2022-09-21 at 2 18 14 PM" src="https://user-images.githubusercontent.com/5456533/191399593-743e55c8-7d90-4dfe-b8cb-a7bb32f9d20d.png">

