### PR TITLE
659.1 sync api error improvements

### DIFF
--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -12,7 +12,7 @@ repository = { path = "../repository" }
 util = { path = "../util" }
 
 anymap = "0.12"
-anyhow = "1.0.44"
+anyhow = "1.0.56"
 async-trait = "0.1.57"
 thiserror = "1"
 bcrypt = "0.12.0"
@@ -20,6 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 jsonwebtoken = "8.0.1"
 log = "0.4.14"
 reqwest = { version = "0.11.10", features = ["json"] }
+url = "2.2"
 serde = "1.0.126"
 serde_json = "1.0.66"
 serde_yaml = "0.8.24"

--- a/server/service/src/sync/api/common_records.rs
+++ b/server/service/src/sync/api/common_records.rs
@@ -61,7 +61,7 @@ impl SyncActionV5 {
 }
 
 #[derive(Error, Debug)]
-#[error("Failed to parse V5 remote record into sync buffer row: {source:?} {record:?}")]
+#[error("Failed to parse V5 remote record into sync buffer row, record: '{record:?}'")]
 pub(crate) struct ParsingV5RecordError {
     source: serde_json::Error,
     record: serde_json::Value,

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -2,8 +2,6 @@ use crate::{
     service_provider::ServiceProvider,
     sync::{settings::SyncSettings, sync_api_credentials::SyncCredentials},
 };
-
-use anyhow::Context;
 use reqwest::{
     header::{HeaderMap, HeaderName},
     Client, Response, Url,
@@ -11,6 +9,7 @@ use reqwest::{
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
 use thiserror::Error;
+use url::ParseError;
 
 use super::*;
 
@@ -40,15 +39,28 @@ fn generate_headers(hardware_id: &str) -> HeaderMap {
     headers
 }
 
+#[derive(Error, Debug)]
+pub enum SyncApiV5CreatingError {
+    #[error("Cannot parse url while creating SyncApiV5 instance url: '{0}'")]
+    CannotParseSyncUrl(String, #[source] ParseError),
+    #[error("Error while creating SyncApiV5 instance")]
+    Other(#[source] anyhow::Error),
+}
+
 impl SyncApiV5 {
-    pub(crate) fn new(
+    pub fn new(
         settings: &SyncSettings,
         service_provider: &ServiceProvider,
-    ) -> anyhow::Result<Self> {
-        let hardware_id = service_provider.app_data_service.get_hardware_id()?;
+    ) -> Result<Self, SyncApiV5CreatingError> {
+        use SyncApiV5CreatingError as Error;
+        let hardware_id = service_provider
+            .app_data_service
+            .get_hardware_id()
+            .map_err(|error| Error::Other(error.into()))?;
 
         Ok(SyncApiV5 {
-            server_url: Url::parse(&settings.url)?,
+            server_url: Url::parse(&settings.url)
+                .map_err(|error| Error::CannotParseSyncUrl(settings.url.clone(), error))?,
             credentials: SyncCredentials {
                 username: settings.username.clone(),
                 password_sha256: settings.password_sha256.clone(),
@@ -75,7 +87,10 @@ impl SyncApiV5 {
     where
         T: Serialize + ?Sized,
     {
-        let url = self.server_url.join(route).context("Failed to parse url")?;
+        let url = self
+            .server_url
+            .join(route)
+            .map_err(|error| self.api_error(route, error.into()))?;
         let result = Client::new()
             .get(url.clone())
             .basic_auth(
@@ -87,7 +102,9 @@ impl SyncApiV5 {
             .send()
             .await;
 
-        response_or_err(url, result).await
+        response_or_err(result)
+            .await
+            .map_err(|error| self.api_error(route, error))
     }
 
     pub(crate) async fn do_get_no_query(&self, route: &str) -> Result<Response, SyncApiError> {
@@ -98,7 +115,10 @@ impl SyncApiV5 {
     where
         T: Serialize,
     {
-        let url = self.server_url.join(route).context("Failed to parse url")?;
+        let url = self
+            .server_url
+            .join(route)
+            .map_err(|error| self.api_error(route, error.into()))?;
         let result = Client::new()
             .post(url.clone())
             .basic_auth(
@@ -112,7 +132,9 @@ impl SyncApiV5 {
             .send()
             .await;
 
-        response_or_err(url, result).await
+        response_or_err(result)
+            .await
+            .map_err(|error| self.api_error(route, error))
     }
 
     pub(crate) async fn do_empty_post(&self, route: &str) -> Result<Response, SyncApiError> {
@@ -122,9 +144,9 @@ impl SyncApiV5 {
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {
-    #[error("Cannot retreive response body: {0}")]
-    CannotGetTextReponse(reqwest::Error),
-    #[error("Could not parse response body, error: ({source}) reponse; ({response_text}) ")]
+    #[error("Cannot retreive response body")]
+    CannotGetTextReponse(#[from] reqwest::Error),
+    #[error("Could not parse response body, response: '{response_text}'")]
     ParseError {
         source: serde_json::Error,
         response_text: String,
@@ -135,10 +157,7 @@ pub(crate) async fn to_json<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ParsingResponseError> {
     // TODO not owned (to avoid double parsing)
-    let response_text = response
-        .text()
-        .await
-        .map_err(ParsingResponseError::CannotGetTextReponse)?;
+    let response_text = response.text().await?;
     let result = serde_json::from_str(&response_text).map_err(|source| {
         ParsingResponseError::ParseError {
             source,
@@ -149,16 +168,15 @@ pub(crate) async fn to_json<T: DeserializeOwned>(
 }
 
 async fn response_or_err(
-    url: Url,
     result: Result<Response, reqwest::Error>,
-) -> Result<Response, SyncApiError> {
+) -> Result<Response, SyncApiErrorVariant> {
     let response = match result {
         Ok(result) => result,
         Err(error) => {
             if error.is_connect() {
-                return Err(SyncApiError::ConnectionError { source: error, url });
+                return Err(SyncApiErrorVariant::ConnectionError(error));
             } else {
-                return Err(SyncApiError::Other(error.into()));
+                return Err(SyncApiErrorVariant::Other(error.into()));
             }
         }
     };
@@ -167,7 +185,7 @@ async fn response_or_err(
         return Ok(response);
     }
 
-    Err(SyncErrorV5::from_response_and_status(response.status(), response).await)
+    Err(SyncApiErrorVariant::from_response_and_status(response.status(), response).await)
 }
 
 #[cfg(test)]

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -144,7 +144,7 @@ impl SyncApiV5 {
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {
-    #[error("Cannot retreive response body")]
+    #[error("Cannot retrieve response body")]
     CannotGetTextReponse(#[from] reqwest::Error),
     #[error("Could not parse response body, response: '{response_text}'")]
     ParseError {

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -179,7 +179,7 @@ mod test {
             }
         );
 
-        // Service Unavailable`
+        // Service Unavailable
         let mock_server = MockServer::start();
         let url = mock_server.base_url();
 

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -1,58 +1,128 @@
 use super::*;
 use reqwest::{Response, StatusCode, Url};
-use serde::Deserialize;
+use serde::{
+    de::{value::StrDeserializer, IntoDeserializer},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use thiserror::Error;
+use url::ParseError;
 
 #[derive(Error, Debug)]
-pub enum SyncApiError {
-    #[error("status: ({status}) error: {source}")]
-    MappedError {
-        source: SyncErrorV5,
-        status: StatusCode,
-    },
-    #[error("Error connecting to server: ({url})")]
-    ConnectionError { source: reqwest::Error, url: Url },
-    #[error("{0}")]
-    ResponseParsingError(ParsingResponseError),
-    #[error("{0}")]
-    Other(#[from] anyhow::Error),
+#[error("Sync api error, url: '{url}', route: '{route}'")]
+pub struct SyncApiError {
+    pub source: SyncApiErrorVariant,
+    pub(crate) url: Url,
+    pub(crate) route: String,
 }
 
-#[derive(Error, Debug, Deserialize)]
-pub enum SyncErrorV5 {
-    #[error("code: ({code}) message: ({message})")]
-    #[serde(rename = "error")]
+#[derive(Error, Debug)]
+pub enum SyncApiErrorVariant {
+    #[error("status: '{status}'")]
     ParsedError {
-        code: String,
-        message: String,
-        data: Option<String>,
+        status: StatusCode,
+        source: ParsedError,
     },
-    #[error("{0}")]
-    FullText(String),
+    #[error("status: '{status}' text: '{text}'")]
+    AsText { status: StatusCode, text: String },
+    #[error("Cannot parse error, status: '{status}'")]
+    ErrorParsingError {
+        status: StatusCode,
+        source: reqwest::Error,
+    },
+    #[error("Connection problem")]
+    ConnectionError(#[from] reqwest::Error),
+    #[error("Could not parse respose")]
+    ResponseParsingError(#[from] ParsingResponseError),
+    #[error("Could not parse url")]
+    FailToParseUrl(#[from] ParseError),
+    #[error("Unknown api error")]
+    Other(#[source] anyhow::Error),
 }
 
-impl SyncErrorV5 {
-    pub(crate) async fn from_response_and_status(
-        status: StatusCode,
-        response: Response,
-    ) -> SyncApiError {
-        let error = match to_json::<SyncErrorV5>(response).await {
-            Ok(source) => return SyncApiError::MappedError { source, status },
+#[derive(Error, Debug, Serialize, Deserialize)]
+#[error("code: '{code:?}' message: '{message}' data: '{data:?}")]
+pub struct ParsedError {
+    #[serde(serialize_with = "sync_error_code_v5_se")]
+    #[serde(deserialize_with = "sync_error_code_v5_de")]
+    pub code: SyncErrorCodeV5,
+    pub message: String,
+    pub data: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncErrorCodeV5 {
+    SiteNameNotFound,
+    SiteIncorrectPassword,
+    SiteIncorrectHardwareId,
+    SiteHasNoStore,
+    SiteAuthTimeout,
+    Other(String),
+}
+
+// Below helps serialise and deserialise the Other variant
+pub fn sync_error_code_v5_de<'de, D: Deserializer<'de>>(d: D) -> Result<SyncErrorCodeV5, D::Error> {
+    // Deserialize to string, try to deserialize string to the num, if fail use string
+    let as_string = String::deserialize(d)?;
+    let str_d: StrDeserializer<D::Error> = as_string.as_str().into_deserializer();
+    SyncErrorCodeV5::deserialize(str_d).or(Ok(SyncErrorCodeV5::Other(as_string)))
+}
+pub fn sync_error_code_v5_se<S: Serializer>(
+    value: &SyncErrorCodeV5,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    if let SyncErrorCodeV5::Other(string) = value {
+        string.serialize(s)
+    } else {
+        value.serialize(s)
+    }
+}
+/// Error is under 'error' field, want to reduce nesting in SyncApiErrorVariant and serialize error
+/// to this struct first and then extract ParsedError to be passed to SyncApiErrorVariant
+#[derive(Deserialize)]
+struct ErrorWrapper {
+    error: ParsedError,
+}
+
+impl SyncApiErrorVariant {
+    pub(crate) async fn from_response_and_status(status: StatusCode, response: Response) -> Self {
+        let error = match to_json::<ErrorWrapper>(response).await {
+            Ok(ErrorWrapper { error: source }) => {
+                return SyncApiErrorVariant::ParsedError { source, status }
+            }
             Err(error) => error,
         };
 
         use ParsingResponseError::*;
-        let source = match error {
-            CannotGetTextReponse(_) => {
-                SyncErrorV5::FullText("Cannot retreive error body".to_string())
+        match error {
+            CannotGetTextReponse(source) => {
+                SyncApiErrorVariant::ErrorParsingError { status, source }
             }
             ParseError {
-                source: _,
-                response_text,
-            } => SyncErrorV5::FullText(response_text),
-        };
+                response_text: text,
+                ..
+            } => SyncApiErrorVariant::AsText { status, text },
+        }
+    }
+}
 
-        SyncApiError::MappedError { source, status }
+impl SyncApiV5 {
+    pub(crate) fn api_error(&self, route: &str, source: SyncApiErrorVariant) -> SyncApiError {
+        SyncApiError {
+            url: self.server_url.clone(),
+            route: route.to_string(),
+            source,
+        }
+    }
+}
+
+impl SyncApiError {
+    pub fn new_test(error: SyncApiErrorVariant) -> Self {
+        SyncApiError {
+            source: error,
+            url: Url::parse("http://localhost").unwrap(),
+            route: "".to_string(),
+        }
     }
 }
 
@@ -68,11 +138,20 @@ mod test {
         // "http://localhost:9999" = unreachable url
         let result = create_api("http://localhost:9999", "", "")
             .post_initialise()
-            .await;
-        assert_matches!(result, Err(SyncApiError::ConnectionError { .. }));
+            .await
+            .err()
+            .expect("Should result in error");
+
+        assert_matches!(
+            result,
+            SyncApiError {
+                source: SyncApiErrorVariant::ConnectionError { .. },
+                ..
+            }
+        );
         assert_eq!(
-            format!("{}", result.err().unwrap()),
-            "Error connecting to server: (http://localhost:9999/sync/v5/initialise)"
+            result.to_string(),
+            "Sync api error, url: 'http://localhost:9999/', route: '/sync/v5/initialise'"
         );
 
         // Service Unavailable (empty string result)
@@ -84,20 +163,23 @@ mod test {
             then.status(503);
         });
 
-        let result = create_api(&url, "", "").post_initialise().await;
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .err()
+            .expect("Should result in error");
         assert_matches!(
             result,
-            Err(SyncApiError::MappedError {
-                source: SyncErrorV5::FullText(_),
-                status: StatusCode::SERVICE_UNAVAILABLE
-            })
-        );
-        assert_eq!(
-            format!("{}", result.err().unwrap()),
-            "status: (503 Service Unavailable) error: "
+            SyncApiError {
+                source: SyncApiErrorVariant::AsText {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    ..
+                },
+                ..
+            }
         );
 
-        // Service Unavailableg
+        // Service Unavailable`
         let mock_server = MockServer::start();
         let url = mock_server.base_url();
 
@@ -114,17 +196,23 @@ mod test {
             );
         });
 
-        let result = create_api(&url, "", "").post_initialise().await;
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .err()
+            .expect("Should result in error");
 
         mock.assert();
         assert_matches!(
             result,
-            Err(SyncApiError::MappedError {
-                source: SyncErrorV5::ParsedError { .. },
-                status: StatusCode::SERVICE_UNAVAILABLE
-            })
+            SyncApiError {
+                source: SyncApiErrorVariant::ParsedError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    ..
+                },
+                ..
+            }
         );
-        assert_eq!(format!("{}", result.err().unwrap()), "status: (503 Service Unavailable) error: code: (sync_is_running) message: (Sync is already running - try again later)");
 
         // Service Unavailable (can't parse error)
         let mock_server = MockServer::start();
@@ -135,19 +223,22 @@ mod test {
             then.status(503).body(r#"some plain text error"#);
         });
 
-        let result = create_api(&url, "", "").post_initialise().await;
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .err()
+            .expect("Should result in error");
 
         mock.assert();
         assert_matches!(
             result,
-            Err(SyncApiError::MappedError {
-                source: SyncErrorV5::FullText(_),
-                status: StatusCode::SERVICE_UNAVAILABLE
-            })
-        );
-        assert_eq!(
-            format!("{}", result.err().unwrap()),
-            "status: (503 Service Unavailable) error: some plain text error"
+            SyncApiError {
+                source: SyncApiErrorVariant::AsText {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    ..
+                },
+                ..
+            }
         );
 
         // Incorrect hardware id
@@ -168,17 +259,23 @@ mod test {
             );
         });
 
-        let result = create_api(&url, "", "").post_initialise().await;
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .err()
+            .expect("Should result in error");
 
         mock.assert();
 
         assert_matches!(
             result,
-            Err(SyncApiError::MappedError {
-                source: SyncErrorV5::ParsedError { .. },
-                status: StatusCode::UNAUTHORIZED
-            })
+            SyncApiError {
+                source: SyncApiErrorVariant::ParsedError {
+                    status: StatusCode::UNAUTHORIZED,
+                    ..
+                },
+                ..
+            }
         );
-        assert_eq!(format!("{}", result.err().unwrap()), "status: (401 Unauthorized) error: code: (site_incorrect_hardware_id) message: (Site hardware ID does not match)");
     }
 }

--- a/server/service/src/sync/api/get_central_records.rs
+++ b/server/service/src/sync/api/get_central_records.rs
@@ -26,15 +26,16 @@ impl SyncApiV5 {
         limit: u32,
     ) -> Result<CentralSyncBatchV5, SyncApiError> {
         // TODO: add constants for query parameters.
+        let route = "/sync/v5/central_records";
         let query = [
             ("cursor", &cursor.to_string()),
             ("limit", &limit.to_string()),
         ];
-        let response = self.do_get("/sync/v5/central_records", &query).await?;
+        let response = self.do_get(route, &query).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/api/get_queued_records.rs
+++ b/server/service/src/sync/api/get_queued_records.rs
@@ -6,12 +6,13 @@ impl SyncApiV5 {
         &self,
         batch_size: u32,
     ) -> Result<RemoteSyncBatchV5, SyncApiError> {
+        let route = "/sync/v5/queued_records";
         let query = [("limit", &batch_size.to_string())];
-        let response = self.do_get("/sync/v5/queued_records", &query).await?;
+        let response = self.do_get(route, &query).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -12,11 +12,12 @@ pub struct SiteInfoV5 {
 impl SyncApiV5 {
     // Get site status
     pub(crate) async fn get_site_info(&self) -> Result<SiteInfoV5, SyncApiError> {
-        let response = self.do_get_no_query("/sync/v5/site").await?;
+        let route = "/sync/v5/site";
+        let response = self.do_get_no_query(route).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/api/get_site_status.rs
+++ b/server/service/src/sync/api/get_site_status.rs
@@ -20,11 +20,12 @@ pub(crate) enum SiteStatusCodeV5 {
 impl SyncApiV5 {
     // Get site status
     pub(crate) async fn get_site_status(&self) -> Result<SiteStatusV5, SyncApiError> {
-        let response = self.do_get_no_query("/sync/v5/site_status").await?;
+        let route = "/sync/v5/site_status";
+        let response = self.do_get_no_query(route).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/api/mod.rs
+++ b/server/service/src/sync/api/mod.rs
@@ -10,8 +10,8 @@ mod post_initialise;
 mod post_queued_records;
 
 pub(crate) use self::common_records::*;
-pub(crate) use self::core::*;
-pub(crate) use self::error::*;
+pub use self::core::*;
+pub use self::error::*;
 pub(crate) use get_central_records::*;
 pub(crate) use get_site_info::*;
 pub(crate) use get_site_status::*;

--- a/server/service/src/sync/api/post_initialise.rs
+++ b/server/service/src/sync/api/post_initialise.rs
@@ -4,11 +4,12 @@ impl SyncApiV5 {
     // Initialize remote sync queue.
     // Should only be called on initial sync or when re-initializing an existing data file.
     pub(crate) async fn post_initialise(&self) -> Result<RemoteSyncBatchV5, SyncApiError> {
-        let response = self.do_empty_post("/sync/v5/initialise").await?;
+        let route = "/sync/v5/initialise";
+        let response = self.do_empty_post(route).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/api/post_queued_records.rs
+++ b/server/service/src/sync/api/post_queued_records.rs
@@ -15,16 +15,17 @@ impl SyncApiV5 {
         queue_length: u64,
         records: Vec<RemoteSyncRecordV5>,
     ) -> Result<RemotePushResponseV5, SyncApiError> {
+        let route = "/sync/v5/queued_records";
         let body = RemoteSyncBatchV5 {
             queue_length,
             data: records,
         };
 
-        let response = self.do_post("/sync/v5/queued_records", &body).await?;
+        let response = self.do_post(route, &body).await?;
 
         to_json(response)
             .await
-            .map_err(SyncApiError::ResponseParsingError)
+            .map_err(|error| self.api_error(route, error.into()))
     }
 }
 

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 pub(crate) mod test;
 
-pub(crate) mod api;
+pub mod api;
 pub(crate) mod central_data_synchroniser;
 pub(crate) mod remote_data_synchroniser;
 pub mod settings;
-pub(crate) mod site_info;
+pub mod site_info;
 mod sync_api_credentials;
 mod sync_buffer;
 mod sync_serde;
@@ -48,7 +48,7 @@ pub(crate) fn get_active_records_on_site_filter(
 
 #[derive(Error, Debug)]
 pub(crate) enum GetActiveStoresOnSiteError {
-    #[error("Database error while getting active store on site {0:?}")]
+    #[error("Database error while getting active store on site")]
     DatabaseError(RepositoryError),
     #[error("Site id is not set in database")]
     SiteIdNotSet,

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -21,39 +21,42 @@ use serde_json::json;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-#[error("Failed to send initialisation request: {0:?}")]
-pub(crate) struct PostInitialisationError(pub(crate) SyncApiError);
-#[derive(Error, Debug)]
-#[error("Failed to set initialised state: {0:?}")]
-pub(crate) struct SetInitialisedError(RepositoryError);
+#[error(transparent)]
+pub(crate) struct PostInitialisationError(#[from] pub(crate) SyncApiError);
 #[derive(Error, Debug)]
 pub(crate) enum RemotePullError {
-    #[error("Api error while pulling remote records: {0}")]
-    PullError(SyncApiError),
-    #[error("Failed to acknowledge sync records: {0}")]
-    AcknowledgedError(SyncApiError),
-    #[error("Failed to save sync buffer rows {0:?}")]
-    SaveSyncBufferError(RepositoryError),
-    #[error("{0}")]
-    ParsingV5RecordError(ParsingV5RecordError),
-    #[error("{0}")]
-    SyncLoggerError(SyncLoggerError),
+    #[error(transparent)]
+    SyncApiError(#[from] SyncApiError),
+    #[error("Failed to save sync buffer rows")]
+    SaveSyncBufferError(#[from] RepositoryError),
+    #[error(transparent)]
+    ParsingV5RecordError(#[from] ParsingV5RecordError),
+    #[error(transparent)]
+    SyncLoggerError(#[from] SyncLoggerError),
 }
 
 #[derive(Error, Debug)]
 pub(crate) enum RemotePushError {
-    #[error("Api error while pushing remote records: {0}")]
-    PushError(SyncApiError),
-    #[error("Database error while pushing remote records {0:?}")]
-    DatabaseError(RepositoryError),
-    #[error("Problem translation remote records during push {0:?}")]
-    TranslationError(anyhow::Error),
+    #[error(transparent)]
+    SyncApiError(#[from] SyncApiError),
+    #[error("Database error")]
+    DatabaseError(#[from] RepositoryError),
+    #[error("Problem translation remote records during push")]
+    TranslationError(#[from] anyhow::Error),
     #[error("Total remaining sent to server is 0 but integration not started")]
     IntegrationNotStarter,
-    #[error("Problem getting active stores on site during remote push {0}")]
-    GetActiveStoresOnSiteError(GetActiveStoresOnSiteError),
-    #[error("{0}")]
-    SyncLoggerError(SyncLoggerError),
+    #[error("Problem getting active stores on site during remote push")]
+    GetActiveStoresOnSiteError(#[from] GetActiveStoresOnSiteError),
+    #[error(transparent)]
+    SyncLoggerError(#[from] SyncLoggerError),
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum WaitForIntegrationError {
+    #[error(transparent)]
+    SyncApiError(#[from] SyncApiError),
+    #[error("Integration timeout was reached")]
+    IntegrationTimeoutReached,
 }
 
 pub struct RemoteDataSynchroniser {
@@ -63,10 +66,7 @@ pub struct RemoteDataSynchroniser {
 impl RemoteDataSynchroniser {
     /// Request initialisation
     pub(crate) async fn request_initialisation(&self) -> Result<(), PostInitialisationError> {
-        self.sync_api_v5
-            .post_initialise()
-            .await
-            .map_err(PostInitialisationError)?;
+        self.sync_api_v5.post_initialise().await?;
 
         Ok(())
     }
@@ -76,12 +76,10 @@ impl RemoteDataSynchroniser {
     pub(crate) fn advance_push_cursor(
         &self,
         connection: &StorageConnection,
-    ) -> Result<(), SetInitialisedError> {
-        let cursor = ChangelogRepository::new(connection)
-            .latest_cursor()
-            .map_err(SetInitialisedError)?;
+    ) -> Result<(), RepositoryError> {
+        let cursor = ChangelogRepository::new(connection).latest_cursor()?;
 
-        update_push_cursor(connection, cursor + 1).map_err(SetInitialisedError)?;
+        update_push_cursor(connection, cursor + 1)?;
         Ok(())
     }
 
@@ -92,47 +90,31 @@ impl RemoteDataSynchroniser {
         batch_size: u32,
         logger: &mut SyncLogger<'a>,
     ) -> Result<(), RemotePullError> {
-        use RemotePullError::*;
         let step_progress = SyncStepProgress::PullRemote;
         let sync_buffer_repository = SyncBufferRowRepository::new(connection);
 
         loop {
-            let sync_batch = self
-                .sync_api_v5
-                .get_queued_records(batch_size)
-                .await
-                .map_err(PullError)?;
+            let sync_batch = self.sync_api_v5.get_queued_records(batch_size).await?;
 
             // queued_length is number of remote pull records awaiting acknowledgement
             // at this point it's number of records waiting to be pulled including records in this pull batch
             let remaining = sync_batch.queue_length;
             let sync_ids = sync_batch.extract_sync_ids();
-            let sync_buffer_rows = sync_batch
-                .to_sync_buffer_rows()
-                .map_err(ParsingV5RecordError)?;
+            let sync_buffer_rows = sync_batch.to_sync_buffer_rows()?;
 
             let number_of_pulled_records = sync_buffer_rows.len() as u64;
 
-            logger
-                .progress(step_progress.clone(), remaining)
-                .map_err(SyncLoggerError)?;
+            logger.progress(step_progress.clone(), remaining)?;
 
             if number_of_pulled_records > 0 {
-                sync_buffer_repository
-                    .upsert_many(&sync_buffer_rows)
-                    .map_err(SaveSyncBufferError)?;
+                sync_buffer_repository.upsert_many(&sync_buffer_rows)?;
 
-                self.sync_api_v5
-                    .post_acknowledged_records(sync_ids)
-                    .await
-                    .map_err(AcknowledgedError)?;
+                self.sync_api_v5.post_acknowledged_records(sync_ids).await?;
             } else {
                 break;
             }
 
-            logger
-                .progress(step_progress.clone(), remaining - number_of_pulled_records)
-                .map_err(SyncLoggerError)?;
+            logger.progress(step_progress.clone(), remaining - number_of_pulled_records)?;
         }
 
         Ok(())
@@ -145,45 +127,35 @@ impl RemoteDataSynchroniser {
         batch_size: u32,
         logger: &mut SyncLogger<'a>,
     ) -> Result<(), RemotePushError> {
-        use RemotePushError as Error;
         let changelog_repo = ChangelogRepository::new(connection);
-        let change_log_filter = get_active_records_on_site_filter(connection)
-            .map_err(Error::GetActiveStoresOnSiteError)?;
+        let change_log_filter = get_active_records_on_site_filter(connection)?;
 
         loop {
             // TODO inside transaction
-            let cursor = get_push_cursor(connection).map_err(Error::DatabaseError)?;
-            let changelogs = changelog_repo
-                .changelogs(cursor, batch_size, change_log_filter.clone())
-                .map_err(Error::DatabaseError)?;
-            let change_logs_total = changelog_repo
-                .count(cursor, change_log_filter.clone())
-                .map_err(Error::DatabaseError)?;
+            let cursor = get_push_cursor(connection)?;
+            let changelogs =
+                changelog_repo.changelogs(cursor, batch_size, change_log_filter.clone())?;
+            let change_logs_total = changelog_repo.count(cursor, change_log_filter.clone())?;
 
-            logger
-                .progress(SyncStepProgress::Push, change_logs_total)
-                .map_err(Error::SyncLoggerError)?;
+            logger.progress(SyncStepProgress::Push, change_logs_total)?;
 
             let last_pushed_cursor = changelogs.last().map(|log| log.cursor);
 
-            let records = translate_changelogs_to_push_records(connection, changelogs)
-                .map_err(Error::TranslationError)?;
+            let records = translate_changelogs_to_push_records(connection, changelogs)?;
 
             let response = self
                 .sync_api_v5
                 .post_queued_records(change_logs_total, records)
-                .await
-                .map_err(Error::PushError)?;
+                .await?;
 
             // Update cursor only if record for that cursor has been pushed/processed
             if let Some(last_pushed_cursor_id) = last_pushed_cursor {
-                update_push_cursor(connection, last_pushed_cursor_id as u64 + 1)
-                    .map_err(Error::DatabaseError)?;
+                update_push_cursor(connection, last_pushed_cursor_id as u64 + 1)?;
             };
 
             match (response.integration_started, change_logs_total) {
                 (true, 0) => break,
-                (false, 0) => return Err(Error::IntegrationNotStarter),
+                (false, 0) => return Err(RemotePushError::IntegrationNotStarter),
                 _ => continue,
             };
         }
@@ -196,7 +168,7 @@ impl RemoteDataSynchroniser {
         &self,
         poll_period_seconds: u64,
         timeout_seconds: u64,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), WaitForIntegrationError> {
         let start = SystemTime::now();
         let poll_period = Duration::from_secs(poll_period_seconds);
         let timeout = Duration::from_secs(timeout_seconds);
@@ -214,7 +186,7 @@ impl RemoteDataSynchroniser {
             let elapsed = start.elapsed().unwrap_or(timeout);
 
             if elapsed >= timeout {
-                return Err(anyhow::anyhow!("Integration timeout reached"));
+                return Err(WaitForIntegrationError::IntegrationTimeoutReached);
             }
         }
 

--- a/server/service/src/sync/site_info.rs
+++ b/server/service/src/sync/site_info.rs
@@ -11,17 +11,19 @@ use crate::{
     },
 };
 
-use super::api::SyncApiError;
+use super::api::{SyncApiError, SyncApiV5CreatingError};
 
 #[derive(Error, Debug)]
 pub enum RequestAndSetSiteInfoError {
-    #[error("Api error while requesting site info: {0:?}")]
-    RequestSiteInfoError(SyncApiError),
-    #[error("Database error whie requistin site info: {0:?}")]
+    #[error("Api error while requesting site info")]
+    RequestSiteInfoError(#[source] SyncApiError),
+    #[error("Database error whie requistin site info")]
     DatabaseError(RepositoryError),
     #[error("Attempt to change initialised site, UUID does not match: current ({0}) new ({1}")]
     SiteUUIDIsBeingChanged(String, String),
-    #[error("Unknown error while requesting and setting site info: {0:?}")]
+    #[error("Error while requesting and setting site info")]
+    SyncApiV5CreatingError(#[from] SyncApiV5CreatingError),
+    #[error("Unknown error while requesting and setting site info")]
     Other(#[from] anyhow::Error),
 }
 

--- a/server/service/src/sync/site_info.rs
+++ b/server/service/src/sync/site_info.rs
@@ -17,7 +17,7 @@ use super::api::{SyncApiError, SyncApiV5CreatingError};
 pub enum RequestAndSetSiteInfoError {
     #[error("Api error while requesting site info")]
     RequestSiteInfoError(#[source] SyncApiError),
-    #[error("Database error whie requistin site info")]
+    #[error("Database error while requesting site info")]
     DatabaseError(RepositoryError),
     #[error("Attempt to change initialised site, UUID does not match: current ({0}) new ({1}")]
     SiteUUIDIsBeingChanged(String, String),

--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use repository::{mock::MockDataInserts, StorageConnectionManager};
+    use repository::{mock::MockDataInserts, StorageConnectionManager, SyncLogRowErrorCode};
     use reqwest::StatusCode;
     use serde_json::json;
     use std::{io::Error, path::PathBuf, sync::Arc};
@@ -10,10 +10,11 @@ mod tests {
         app_data::{AppData, AppDataServiceTrait},
         service_provider::ServiceProvider,
         sync::{
-            api::{SyncApiError, SyncErrorV5},
+            api::{SyncApiError, SyncApiErrorVariant},
             remote_data_synchroniser::RemotePushError,
             settings::SyncSettings,
-            synchroniser::Synchroniser,
+            sync_status::SyncLogError,
+            synchroniser::{SyncError, Synchroniser},
             test::integration::central_server_configurations::{
                 ConfigureCentralServer, SiteConfiguration,
             },
@@ -51,6 +52,7 @@ mod tests {
     }
     #[actix_rt::test]
     async fn integration_sync_parsed_error() {
+        // util::init_logger(util::LogLevel::Warn);
         let SiteConfiguration { sync_settings, .. } = ConfigureCentralServer::from_env()
             .create_sync_site(vec![])
             .await
@@ -59,6 +61,7 @@ mod tests {
         let ServiceTestContext {
             connection_manager,
             service_provider,
+            service_context,
             ..
         } = setup_all_and_service_provider(
             "sync_integration_test_parsed_error",
@@ -79,20 +82,36 @@ mod tests {
         let synchroniser =
             get_synchroniser_with_hardware_id(&connection_manager, &sync_settings, "id2");
 
-        let error = match synchroniser.sync().await {
-            Ok(_) => panic!("Should result in error"),
-            Err(e) => e,
-        };
-
-        println!("{:?}", error);
+        let error = synchroniser
+            .sync()
+            .await
+            .err()
+            .expect("Should result in error");
 
         assert_matches!(
-            error.downcast_ref::<RemotePushError>(),
-            Some(RemotePushError::PushError(SyncApiError::MappedError {
-                source: SyncErrorV5::ParsedError { .. },
-                status: StatusCode::UNAUTHORIZED,
+            error,
+            SyncError::RemotePushError(RemotePushError::SyncApiError(SyncApiError {
+                source: SyncApiErrorVariant::ParsedError {
+                    status: StatusCode::UNAUTHORIZED,
+                    ..
+                },
+                ..
             }))
         );
+        // Check that error is recorded in logs
+        let status = service_provider
+            .sync_status_service
+            .get_latest_sync_status(&service_context)
+            .unwrap()
+            .expect("Sync log row should exist");
+
+        assert_matches!(
+            status.error,
+            Some(SyncLogError {
+                code: Some(SyncLogRowErrorCode::HardwareIdMismatch),
+                ..
+            })
+        )
     }
 
     #[actix_rt::test]
@@ -111,11 +130,14 @@ mod tests {
         };
 
         assert_matches!(
-            error.downcast_ref::<SyncApiError>(),
-            Some(SyncApiError::MappedError {
-                source: SyncErrorV5::FullText(_),
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-            })
+            error,
+            SyncApiError {
+                source: SyncApiErrorVariant::AsText {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    ..
+                },
+                ..
+            }
         );
     }
 }

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -12,3 +12,6 @@ uuid = { version = "0.8", features = ["v4"] }
 chrono = "0.4.19"
 env_logger = "0.8.3"
 serde_json = "1.0.66"
+
+[dev-dependencies]
+thiserror = "1"

--- a/server/util/src/error.rs
+++ b/server/util/src/error.rs
@@ -1,0 +1,49 @@
+use std::error::Error as StandardError;
+
+/// Formats error for display, including sources using similar logic to anyhow::Error (debug)
+/// ```
+/// #[derive(thiserror::Error, Debug)]
+/// #[error("e1 msg {msg}")]
+/// struct E1 {
+///     msg: String,
+///     source: E2,
+/// }
+///
+/// #[derive(thiserror::Error, Debug)]
+/// enum E2 {
+///     #[error("e2")]
+///     E3(#[source] E3),
+/// }
+///
+/// #[derive(thiserror::Error, Debug)]
+/// enum E3 {
+///     #[error("e3 {0}")]
+///     Text(String),
+/// }
+///
+/// let err = E1 {
+///     msg: "e1msg".to_string(),
+///     source: E2::E3(E3::Text("e3msg".to_string())),
+/// };
+/// let result =
+/// r#"e1 msg e1msg -> [
+///     "e2",
+///     "e3 e3msg",
+/// ]"#;
+/// assert_eq!(util::format_error(&err), result)
+/// ```
+
+pub fn format_error(error: &impl StandardError) -> String {
+    let mut sources = Vec::new();
+    let mut current: &dyn StandardError = error;
+    while let Some(next) = current.source() {
+        sources.push(format!("{}", next));
+        current = next;
+    }
+
+    if sources.is_empty() {
+        format!("{}", error)
+    } else {
+        format!("{} -> {:#?}", error, sources)
+    }
+}

--- a/server/util/src/lib.rs
+++ b/server/util/src/lib.rs
@@ -20,3 +20,6 @@ pub use test_helpers::*;
 
 mod json;
 pub use json::*;
+
+mod error;
+pub use error::*;


### PR DESCRIPTION
closes #659 (this is to link the issue, there is a series of PR, as described in the issue)

[HEAD PR LINK](https://github.com/openmsupply/open-msupply/pull/679)

### Changes

Tidy up thiserror derives/annotation
* Previously was constantly stringifying source error, this is not needed since we can print source errors automatically (anyhow actually does this, but also added generic error formatter), see comment in self review
* Flatten Mapped error straight into sync api error
* Wanted url in SyncApiError, thus made it a wrapper around SyncApiErrorVariant
* Adde SyncErrorCodeV5 to map to expected central server error (this can be tested in the future

Used `from` and `?` to make sync code more readable (this is a pattern we've gone away from, instead using `map_err`, I would like to reinstate it, might need further discussions, but I think it's pretty clear, and in VS code you can just hover over methods to see what they return and deduce what `?` does)

Added generic error formatter (see doc tests)




