### PR TITLE
659.3 graphql sync error mapping

### DIFF
--- a/server/graphql/core/src/standard_graphql_error.rs
+++ b/server/graphql/core/src/standard_graphql_error.rs
@@ -7,6 +7,7 @@ use service::{
     ListError,
 };
 use thiserror::Error;
+use util::format_error;
 
 #[derive(Debug, Error, Clone)]
 pub enum StandardGraphqlError {
@@ -57,11 +58,15 @@ impl StandardGraphqlError {
     }
 
     pub fn from_str(str_slice: &str) -> async_graphql::Error {
-        StandardGraphqlError::InternalError(format!("{}", str_slice)).extend()
+        StandardGraphqlError::InternalError(str_slice.to_string()).extend()
     }
 
-    pub fn from_error<E: std::error::Error>(error: E) -> async_graphql::Error {
-        StandardGraphqlError::InternalError(format!("{}", error)).extend()
+    pub fn from_error<E: std::error::Error>(error: &E) -> async_graphql::Error {
+        StandardGraphqlError::InternalError(format_error(error)).extend()
+    }
+
+    pub fn from_debug<E: std::fmt::Debug>(error: E) -> async_graphql::Error {
+        StandardGraphqlError::InternalError(format!("{:#?}", error)).extend()
     }
 }
 

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -1,5 +1,6 @@
 mod mutations;
 mod queries;
+mod sync_api_error;
 
 pub use self::queries::sync_status::*;
 use self::queries::*;
@@ -15,7 +16,7 @@ use mutations::{
 use queries::{
     initialisation_status::{initialisation_status, InitialisationStatusType},
     requisition_line_chart::{ConsumptionOptionsInput, StockEvolutionOptionsInput},
-    sync_settings::{sync_settings, SyncSettingsResponse},
+    sync_settings::{sync_settings, SyncSettingsNode},
 };
 
 #[derive(Default, Clone)]
@@ -173,7 +174,7 @@ impl GeneralQueries {
         number_of_records_in_push_queue(ctx)
     }
 
-    pub async fn sync_settings(&self, ctx: &Context<'_>) -> Result<SyncSettingsResponse> {
+    pub async fn sync_settings(&self, ctx: &Context<'_>) -> Result<Option<SyncSettingsNode>> {
         sync_settings(ctx, true)
     }
 }
@@ -211,7 +212,7 @@ pub struct InitialisationQueries;
 
 #[Object]
 impl InitialisationQueries {
-    pub async fn sync_settings(&self, ctx: &Context<'_>) -> Result<SyncSettingsResponse> {
+    pub async fn sync_settings(&self, ctx: &Context<'_>) -> Result<Option<SyncSettingsNode>> {
         sync_settings(ctx, false)
     }
     /// Available without authorisation in operational and initialisation states

--- a/server/graphql/general/src/mutations/sync_settings.rs
+++ b/server/graphql/general/src/mutations/sync_settings.rs
@@ -4,18 +4,16 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use service::{
-    auth::{Resource, ResourceAccessRequest},
-    settings_service::UpdateSettingsError,
-};
+use service::auth::{Resource, ResourceAccessRequest};
 
-use crate::queries::sync_settings::SyncSettingsNode;
+use crate::{queries::sync_settings::SyncSettingsNode, sync_api_error::SetSyncSettingErrorNode};
 
 use super::common::SyncSettingsInput;
 
 #[derive(Union)]
 pub enum UpdateSyncSettingsResponse {
     Response(SyncSettingsNode),
+    Error(SetSyncSettingErrorNode),
 }
 
 pub async fn update_sync_settings(
@@ -42,34 +40,24 @@ pub async fn update_sync_settings(
     let sync_settings = input.to_domain();
 
     if sync_settings.core_site_details_changed(&database_sync_settings) {
-        // TODO map to structured error
-        service_provider
+        if let Err(error) = service_provider
             .site_info_service
             .request_and_set_site_info(&service_provider, &sync_settings)
             .await
-            .map_err(StandardGraphqlError::from_error)?;
+        {
+            return Ok(UpdateSyncSettingsResponse::Error(
+                SetSyncSettingErrorNode::map_error(error)?,
+            ));
+        }
     }
 
-    match service_provider
+    // request and set site info above should validate settings, can consider all error in update_sync_settings as interna lerror
+    service_provider
         .settings
         .update_sync_settings(&service_context, &sync_settings)
-    {
-        Ok(sync_settings) => sync_settings,
-        Err(error) => {
-            let formatted_error = format!("{:#?}", error);
-            let graphql_error = match error {
-                UpdateSettingsError::RepositoryError(_) => {
-                    StandardGraphqlError::InternalError(formatted_error)
-                }
-                UpdateSettingsError::InvalidSettings(_) => {
-                    StandardGraphqlError::BadUserInput(formatted_error)
-                }
-            };
-            return Err(graphql_error.extend());
-        }
-    };
+        .map_err(StandardGraphqlError::from_debug)?;
 
     Ok(UpdateSyncSettingsResponse::Response(SyncSettingsNode {
-        settings: Some(sync_settings),
+        settings: sync_settings,
     }))
 }

--- a/server/graphql/general/src/mutations/sync_settings.rs
+++ b/server/graphql/general/src/mutations/sync_settings.rs
@@ -51,7 +51,7 @@ pub async fn update_sync_settings(
         }
     }
 
-    // request and set site info above should validate settings, can consider all error in update_sync_settings as interna lerror
+    // request and set site info above should validate settings, can consider all errors in update_sync_settings as internal errors
     service_provider
         .settings
         .update_sync_settings(&service_context, &sync_settings)

--- a/server/graphql/general/src/queries/sync_status.rs
+++ b/server/graphql/general/src/queries/sync_status.rs
@@ -4,7 +4,12 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use service::auth::{Resource, ResourceAccessRequest};
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    sync::sync_status::status::FullSyncStatus,
+};
+
+use crate::sync_api_error::SyncErrorInterface;
 
 #[derive(SimpleObject)]
 pub struct SyncStatusNode {
@@ -23,7 +28,7 @@ pub struct SyncStatusWithProgressNode {
 #[derive(SimpleObject)]
 pub struct FullSyncStatusNode {
     is_syncing: bool,
-    error: Option<String>,
+    error: Option<SyncErrorInterface>,
     summary: SyncStatusNode,
     prepare_initial: Option<SyncStatusNode>,
     integration: Option<SyncStatusNode>,
@@ -50,38 +55,45 @@ pub fn latest_sync_status(
         None => return Ok(None),
     };
 
+    let FullSyncStatus {
+        is_syncing,
+        error,
+        summary,
+        prepare_initial,
+        integration,
+        pull_central,
+        pull_remote,
+        push,
+    } = sync_status;
+
     let result = FullSyncStatusNode {
-        is_syncing: sync_status.is_syncing,
-        error: sync_status.error,
+        is_syncing,
+        error: error.map(SyncErrorInterface::from_sync_log_error),
         summary: SyncStatusNode {
-            started: sync_status.summary.started,
-            finished: sync_status.summary.finished,
+            started: summary.started,
+            finished: summary.finished,
         },
-        prepare_initial: sync_status.prepare_initial.map(|status| SyncStatusNode {
+        prepare_initial: prepare_initial.map(|status| SyncStatusNode {
             started: status.started,
             finished: status.finished,
         }),
-        integration: sync_status.integration.map(|status| SyncStatusNode {
+        integration: integration.map(|status| SyncStatusNode {
             started: status.started,
             finished: status.finished,
         }),
-        pull_central: sync_status
-            .pull_central
-            .map(|status| SyncStatusWithProgressNode {
-                started: status.started,
-                finished: status.finished,
-                total_progress: status.total_progress,
-                done_progress: status.done_progress,
-            }),
-        pull_remote: sync_status
-            .pull_remote
-            .map(|status| SyncStatusWithProgressNode {
-                started: status.started,
-                finished: status.finished,
-                total_progress: status.total_progress,
-                done_progress: status.done_progress,
-            }),
-        push: sync_status.push.map(|status| SyncStatusWithProgressNode {
+        pull_central: pull_central.map(|status| SyncStatusWithProgressNode {
+            started: status.started,
+            finished: status.finished,
+            total_progress: status.total_progress,
+            done_progress: status.done_progress,
+        }),
+        pull_remote: pull_remote.map(|status| SyncStatusWithProgressNode {
+            started: status.started,
+            finished: status.finished,
+            total_progress: status.total_progress,
+            done_progress: status.done_progress,
+        }),
+        push: push.map(|status| SyncStatusWithProgressNode {
             started: status.started,
             finished: status.finished,
             total_progress: status.total_progress,

--- a/server/graphql/general/src/sync_api_error.rs
+++ b/server/graphql/general/src/sync_api_error.rs
@@ -1,0 +1,312 @@
+use async_graphql::*;
+use graphql_core::standard_graphql_error::StandardGraphqlError;
+use repository::SyncLogRowErrorCode;
+use service::sync::{
+    api::{SyncApiError, SyncApiErrorVariant, SyncApiV5CreatingError, SyncErrorCodeV5},
+    site_info::RequestAndSetSiteInfoError,
+    sync_status::SyncLogError,
+};
+use util::format_error;
+
+#[derive(SimpleObject)]
+pub struct SetSyncSettingErrorNode {
+    pub error: SyncErrorInterface,
+}
+
+impl SetSyncSettingErrorNode {
+    pub fn map_error(error: RequestAndSetSiteInfoError) -> Result<Self> {
+        use RequestAndSetSiteInfoError as from;
+
+        let error = match &error {
+            // Structured error
+            from::RequestSiteInfoError(api_error) => {
+                SyncErrorInterface::from_sync_api_error(api_error)
+            }
+            from::SiteUUIDIsBeingChanged(_, _) => {
+                SyncErrorInterface::from_variant(SyncErrorVariant::SiteUUIDIsBeingChanged, &error)
+            }
+            from::SyncApiV5CreatingError(SyncApiV5CreatingError::CannotParseSyncUrl(_, _)) => {
+                SyncErrorInterface::from_variant(SyncErrorVariant::InvalidUrl, &error)
+            }
+            // Standard Graphql Errors
+            _ => return Err(StandardGraphqlError::from_error(&error)),
+        };
+
+        Ok(Self { error })
+    }
+}
+
+#[derive(Interface)]
+#[graphql(name = "SyncErrorInterface")]
+#[graphql(field(name = "description", type = "String"))]
+#[graphql(field(name = "full_error", type = "String"))]
+pub enum SyncErrorInterface {
+    MappedSyncError(MappedSyncError),
+    UnknownError(UnknownSyncError),
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+#[graphql(rename_items = "camelCase")]
+pub enum SyncErrorVariant {
+    ConnectionError,
+    SiteUUIDIsBeingChanged,
+    SiteNameNotFound,
+    IncorrectPassword,
+    HardwareIdMismatch,
+    SiteHasNoStore,
+    SiteAuthTimeout,
+    IntegrationTimeoutReached,
+    InvalidUrl,
+}
+
+pub struct MappedSyncError(pub SyncErrorVariant, pub String);
+#[Object]
+impl MappedSyncError {
+    pub async fn description(&self) -> &'static str {
+        "Mapped sync error"
+    }
+
+    pub async fn error_variant(&self) -> SyncErrorVariant {
+        self.0
+    }
+
+    pub async fn full_error(&self) -> &str {
+        &self.1
+    }
+}
+
+pub struct UnknownSyncError(pub String);
+#[Object]
+impl UnknownSyncError {
+    pub async fn description(&self) -> &'static str {
+        "Uknown sync error"
+    }
+
+    pub async fn full_error(&self) -> &str {
+        &self.0
+    }
+}
+
+impl SyncErrorInterface {
+    pub fn unknow_error(error: &SyncApiError) -> Self {
+        Self::UnknownError(UnknownSyncError(format_error(error)))
+    }
+
+    pub fn from_variant<E: std::error::Error>(variant: SyncErrorVariant, error: &E) -> Self {
+        Self::MappedSyncError(MappedSyncError(variant, format_error(error)))
+    }
+
+    pub fn from_sync_api_error(error: &SyncApiError) -> Self {
+        let sync_v5_error_code = match &error.source {
+            SyncApiErrorVariant::ParsedError { source, .. } => &source.code,
+            SyncApiErrorVariant::ConnectionError { .. } => {
+                return Self::from_variant(SyncErrorVariant::ConnectionError, error)
+            }
+            _ => return Self::unknow_error(error),
+        };
+
+        use SyncErrorCodeV5 as from;
+        use SyncErrorVariant as to;
+        let variant = match sync_v5_error_code {
+            from::SiteNameNotFound => to::SiteNameNotFound,
+            from::SiteIncorrectPassword => to::IncorrectPassword,
+            from::SiteIncorrectHardwareId => to::HardwareIdMismatch,
+            from::SiteHasNoStore => to::SiteHasNoStore,
+            from::SiteAuthTimeout => to::SiteAuthTimeout,
+            from::Other(_) => return Self::unknow_error(error),
+        };
+
+        Self::from_variant(variant, error)
+    }
+
+    pub fn from_sync_log_error(SyncLogError { message, code }: SyncLogError) -> Self {
+        let code = match code {
+            None => return Self::UnknownError(UnknownSyncError(message)),
+            Some(code) => code,
+        };
+
+        use SyncErrorVariant as to;
+        use SyncLogRowErrorCode as from;
+        let variant = match code {
+            from::SiteNameNotFound => to::SiteNameNotFound,
+            from::IncorrectPassword => to::IncorrectPassword,
+            from::HardwareIdMismatch => to::HardwareIdMismatch,
+            from::SiteHasNoStore => to::SiteHasNoStore,
+            from::SiteAuthTimeout => to::SiteAuthTimeout,
+            from::ConnectionError => to::ConnectionError,
+            from::IntegrationTimeoutReached => to::IntegrationTimeoutReached,
+        };
+
+        Self::MappedSyncError(MappedSyncError(variant, message))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
+    use repository::mock::MockDataInserts;
+    use reqwest::{Client, Url};
+    use serde_json::json;
+    use service::sync::api::ParsedError;
+
+    #[actix_rt::test]
+    async fn graphql_api_error() {
+        #[derive(Clone)]
+        struct TestQuery;
+
+        let (_, _, _, settings) = setup_graphl_test(
+            TestQuery,
+            EmptyMutation,
+            "graphql_api_error",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        async fn sync_api_error_connection() -> SyncApiError {
+            SyncApiError::new_test(reqwest_error().await.into())
+        }
+
+        fn sync_api_error_unknown() -> SyncApiError {
+            SyncApiError::new_test(SyncApiErrorVariant::AsText {
+                text: "n/a".to_string(),
+                status: StatusCode::UNAUTHORIZED,
+            })
+        }
+
+        fn sync_api_error_hardware() -> SyncApiError {
+            SyncApiError::new_test(SyncApiErrorVariant::ParsedError {
+                source: ParsedError {
+                    code: SyncErrorCodeV5::SiteIncorrectHardwareId,
+                    message: "n/a".to_string(),
+                    data: Some("n/a".to_string()),
+                },
+                status: StatusCode::UNAUTHORIZED,
+            })
+        }
+
+        #[Object]
+        impl TestQuery {
+            pub async fn test(&self, r#type: String) -> SyncErrorInterface {
+                match r#type.as_str() {
+                    "from_sync_api_error_connection" => {
+                        SyncErrorInterface::from_sync_api_error(&sync_api_error_connection().await)
+                    }
+                    "from_sync_api_error_unknown" => {
+                        SyncErrorInterface::from_sync_api_error(&sync_api_error_unknown())
+                    }
+                    "from_sync_api_error_hardware" => {
+                        SyncErrorInterface::from_sync_api_error(&sync_api_error_hardware())
+                    }
+                    "from_sync_log_error_connection" => {
+                        SyncErrorInterface::from_sync_log_error(SyncLogError {
+                            message: "n/a".to_string(),
+                            code: Some(SyncLogRowErrorCode::ConnectionError),
+                        })
+                    }
+                    "from_sync_log_error_unknown" => {
+                        SyncErrorInterface::from_sync_log_error(SyncLogError {
+                            message: "Unknown".to_string(),
+                            code: None,
+                        })
+                    }
+                    _ => unreachable!("Invalid type"),
+                }
+            }
+        }
+
+        let query = r#"
+        query($type: String) {
+            test(type: $type) {
+                __typename
+                fullError
+                description
+               ... on MappedSyncError {
+                  errorVariant
+               }
+               ... on UnknownSyncError {
+                  __typename
+               }
+            }
+        }
+        "#;
+
+        let variables = json!({
+            "type": "from_sync_api_error_connection"
+        });
+        let expected = json!({
+            "test": {
+              "__typename": "MappedSyncError",
+              "description": "Mapped sync error",
+              "errorVariant": "connectionError",
+              "fullError": format_error(&sync_api_error_connection().await)
+            }
+          }
+        );
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+
+        let variables = json!({
+            "type": "from_sync_api_error_unknown"
+        });
+        let expected = json!({
+            "test": {
+              "__typename": "UnknownSyncError",
+              "description": "Uknown sync error",
+              "fullError":  format_error(&sync_api_error_unknown())
+            }
+          }
+        );
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+
+        let variables = json!({
+            "type": "from_sync_api_error_hardware"
+        });
+        let expected = json!({
+            "test": {
+              "__typename": "MappedSyncError",
+              "description": "Mapped sync error",
+              "errorVariant": "hardwareIdMismatch",
+              "fullError":  format_error(&sync_api_error_hardware())
+            }
+          }
+        );
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+
+        let variables = json!({
+            "type": "from_sync_log_error_connection"
+        });
+        let expected = json!({
+            "test": {
+              "__typename": "MappedSyncError",
+              "description": "Mapped sync error",
+              "errorVariant": "connectionError",
+              "fullError": "n/a"
+            }
+          }
+        );
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+
+        let variables = json!({
+            "type": "from_sync_log_error_unknown"
+        });
+        let expected = json!({
+            "test": {
+              "__typename": "UnknownSyncError",
+              "description": "Uknown sync error",
+              "fullError": "Unknown"
+            }
+          }
+        );
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+    }
+
+    async fn reqwest_error() -> reqwest::Error {
+        Client::new()
+            .get(Url::parse("http://0.0.0.0:0").unwrap())
+            .send()
+            .await
+            .err()
+            .expect("Must be error")
+    }
+}

--- a/server/graphql/tests/permissions.rs
+++ b/server/graphql/tests/permissions.rs
@@ -12,7 +12,7 @@ mod permission_tests {
     };
 
     use graphql_batch_mutations::BatchMutations;
-    use graphql_general::GeneralQueries;
+    use graphql_general::{GeneralMutations, GeneralQueries};
     use graphql_invoice::{InvoiceMutations, InvoiceQueries};
     use graphql_invoice_line::InvoiceLineMutations;
     use graphql_location::{LocationMutations, LocationQueries};
@@ -45,6 +45,7 @@ mod permission_tests {
         pub BatchMutations,
         pub RequisitionMutations,
         pub RequisitionLineMutations,
+        pub GeneralMutations,
     );
 
     pub fn full_query() -> FullQuery {
@@ -68,6 +69,7 @@ mod permission_tests {
             BatchMutations,
             RequisitionMutations,
             RequisitionLineMutations,
+            GeneralMutations,
         )
     }
 
@@ -239,13 +241,10 @@ mod permission_tests {
                 },
             },
             TestData {
-                name: "serverSettings",
+                name: "syncSettings",
                 query: r#"query Query {
-                serverSettings {
-                  ... on ServerSettingsNode {
+                  syncSettings { 
                     __typename
-                    status
-                  }
                 }
               }"#,
                 expected: ResourceAccessRequest {
@@ -1033,13 +1032,10 @@ mod permission_tests {
                 },
             },
             TestData {
-                name: "updateServerSettings",
+                name: "updateSyncSettings",
                 query: r#"mutation Mutation {
-                updateServerSettings(input: {syncSettings: {url: "test", username: "user", password: "", intervalSec: 10}}) {
-                  ... on ServerSettingsNode {
+                  updateSyncSettings(input: {url: "test", username: "user", password: "", intervalSeconds: 10}) {
                     __typename
-                    status
-                  }
                 }
             }"#,
                 expected: ResourceAccessRequest {


### PR DESCRIPTION
closes #659 (this is to link the issue, there is a series of PR, as described in the issue)


[HEAD PR LINK](https://github.com/openmsupply/open-msupply/pull/679)

### Changes

Instead of returning SyncSettingsResponse with individual sync settings inside this response being optional, return optional sync settings node (much easier in front end to check the parent rather then optional keys)

Mapping from sync api error and sync log error to `SyncErrorInterface` 
