### PR TITLE
Support custom errors, update the format of some physical exam elements

### DIFF
--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -35,12 +35,15 @@ const UIComponent = (props: ControlProps) => {
   if (!props.visible) {
     return null;
   }
+
+  const width = props.uischema?.options?.['width'] ?? '100%';
+
   return (
     <DetailInputWithLabelRow
       label={label}
       inputProps={{
         value: localData ?? '',
-        sx: { margin: 0.5, width: '100%' },
+        sx: { margin: 0.5, width },
         onChange: e => {
           setLatestKey(Date.now());
           setLocalData(e.target.value);

--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -15,7 +15,8 @@ use crate::{
 use chrono::{Duration, Utc};
 use repository::{
     DocumentContext, DocumentRegistryRow, DocumentRegistryRowRepository, EqualFilter, FormSchema,
-    FormSchemaRowRepository, RepositoryError, StoreFilter, StoreRepository, NameStoreJoinRepository, NameStoreJoinRow, NameRowRepository, NameRow, NameType, StorageConnection,
+    FormSchemaRowRepository, NameRow, NameRowRepository, NameStoreJoinRepository, NameStoreJoinRow,
+    NameType, RepositoryError, StorageConnection, StoreFilter, StoreRepository,
 };
 use serde::{Deserialize, Serialize};
 use util::{inline_init, uuid::uuid};
@@ -369,8 +370,8 @@ fn encounter_hiv_care_1() -> hiv_care_encounter::HivcareEncounter {
             .to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some(51.0);
-                exam.blood_pressure = Some(120.0);
+                exam.weight = Some("51.00".to_string());
+                exam.blood_pressure = Some("120/80".to_string());
             },
         ));
     })
@@ -383,8 +384,8 @@ fn encounter_hiv_care_2() -> hiv_care_encounter::HivcareEncounter {
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some(52.0);
-                exam.blood_pressure = Some(125.0);
+                exam.weight = Some("52.00".to_string());
+                exam.blood_pressure = Some("125/90".to_string());
             },
         ));
         e.events = Some(vec![
@@ -421,8 +422,8 @@ fn encounter_hiv_care_3() -> hiv_care_encounter::HivcareEncounter {
             .to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some(52.5);
-                exam.blood_pressure = Some(128.0);
+                exam.weight = Some("52.50".to_string());
+                exam.blood_pressure = Some("128/00".to_string());
             },
         ));
     })
@@ -437,8 +438,8 @@ fn encounter_hiv_care_4() -> hiv_care_encounter::HivcareEncounter {
             .to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some(51.0);
-                exam.blood_pressure = Some(121.0);
+                exam.weight = Some("51.00".to_string());
+                exam.blood_pressure = Some("121/00".to_string());
             },
         ));
     })
@@ -450,41 +451,50 @@ fn encounter_hiv_care_5() -> hiv_care_encounter::HivcareEncounter {
         e.start_datetime = Utc::now().to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some(54.0);
-                exam.blood_pressure = Some(118.0);
+                exam.weight = Some("54.00".to_string());
+                exam.blood_pressure = Some("118/00".to_string());
             },
         ));
     })
 }
 
-fn insert_patient(connection: &StorageConnection, ctx: &ServiceContext, service_provider: &Arc<ServiceProvider>, patient_schema_id: String, site_id: u32, patient: Patient) {
-    NameRowRepository::new(connection).upsert_one(&NameRow {
-        id: patient.id.clone(),
-        first_name: patient.first_name.clone(),
-        last_name: patient.last_name.clone(),
-        name: "".to_string(),
-        code: "".to_string(),
-        r#type: NameType::Patient,
-        is_customer: true,
-        is_supplier: false,
-        supplying_store_id: None,
-        gender: None,
-        date_of_birth: None,
-        phone: None,
-        charge_code: None,
-        comment: None,
-        country: None,
-        address1: None,
-        address2: None,
-        email: None,
-        website: None,
-        is_manufacturer: false,
-        is_donor: false,
-        on_hold: false,
-        created_datetime: None,
-        is_deceased: false,
-        national_health_number: None,
-    }).unwrap();
+fn insert_patient(
+    connection: &StorageConnection,
+    ctx: &ServiceContext,
+    service_provider: &Arc<ServiceProvider>,
+    patient_schema_id: String,
+    site_id: u32,
+    patient: Patient,
+) {
+    NameRowRepository::new(connection)
+        .upsert_one(&NameRow {
+            id: patient.id.clone(),
+            first_name: patient.first_name.clone(),
+            last_name: patient.last_name.clone(),
+            name: "".to_string(),
+            code: "".to_string(),
+            r#type: NameType::Patient,
+            is_customer: true,
+            is_supplier: false,
+            supplying_store_id: None,
+            gender: None,
+            date_of_birth: None,
+            phone: None,
+            charge_code: None,
+            comment: None,
+            country: None,
+            address1: None,
+            address2: None,
+            email: None,
+            website: None,
+            is_manufacturer: false,
+            is_donor: false,
+            on_hold: false,
+            created_datetime: None,
+            is_deceased: false,
+            national_health_number: None,
+        })
+        .unwrap();
     let store_id = StoreRepository::new(connection)
         .query_one(StoreFilter::new().site_id(EqualFilter::equal_to_i32(site_id as i32)))
         .unwrap()
@@ -492,13 +502,15 @@ fn insert_patient(connection: &StorageConnection, ctx: &ServiceContext, service_
         .store_row
         .id;
     let service = PatientService {};
-    NameStoreJoinRepository::new(connection).upsert_one(&NameStoreJoinRow {
-        id: uuid(),
-        name_id: patient.id.clone(),
-        store_id: store_id.clone(),
-        name_is_customer: true,
-        name_is_supplier: false,
-    }).unwrap();
+    NameStoreJoinRepository::new(connection)
+        .upsert_one(&NameStoreJoinRow {
+            id: uuid(),
+            name_id: patient.id.clone(),
+            store_id: store_id.clone(),
+            name_is_customer: true,
+            name_is_supplier: false,
+        })
+        .unwrap();
 
     service
         .update_patient(
@@ -628,8 +640,22 @@ pub fn init_program_data(
     })?;
 
     // patients
-    insert_patient(connection, ctx, service_provider, patient_schema_id.clone(), site_id, patient_1() );
-    insert_patient(connection, ctx, service_provider, patient_schema_id.clone(), site_id, patient_2() );
+    insert_patient(
+        connection,
+        ctx,
+        service_provider,
+        patient_schema_id.clone(),
+        site_id,
+        patient_1(),
+    );
+    insert_patient(
+        connection,
+        ctx,
+        service_provider,
+        patient_schema_id.clone(),
+        site_id,
+        patient_2(),
+    );
 
     // program
     let service = ProgramEnrolmentService {};

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -54,10 +54,7 @@
               "type": "number"
             },
             "change": {
-              "enum": [
-                "Substitution of ART Regimen",
-                "Switching of ART regimen"
-              ],
+              "enum": ["Substitution of ART Regimen", "Switching of ART regimen"],
               "type": "string"
             },
             "initialWeight": {
@@ -81,18 +78,7 @@
               "type": "array"
             },
             "reason": {
-              "enum": [
-                "101",
-                "102",
-                "103",
-                "104",
-                "105",
-                "106",
-                "107",
-                "108",
-                "109",
-                "151"
-              ],
+              "enum": ["101", "102", "103", "104", "105", "106", "107", "108", "109", "151"],
               "type": "string"
             },
             "reasonFirstToSecondLine": {
@@ -256,7 +242,10 @@
           "properties": {
             "bloodPressure": {
               "description": "75367002\tBlood pressure [mmHg]",
-              "type": "number"
+              "pattern": "^\\d{3}\\/\\d{2}$",
+              "title": "BP in mmHg",
+              "type": "string",
+              "messages": { "pattern": "Format is 000/00" }
             },
             "bodyMassIndex": {
               "description": "60621009\tBody mass index (BMI)",
@@ -264,18 +253,24 @@
             },
             "height": {
               "description": "50373000\tBody height measure [m]",
-              "type": "number"
+              "pattern": "^\\d\\.\\d{2}$",
+              "title": "Height in meters",
+              "type": "string",
+              "messages": { "pattern": "Format is 0.00" }
             },
             "midUpperArmCircumference": {
               "description": "284473002\tMid upper arm circumference (MUAC) [cm]",
-              "type": "number"
+              "pattern": "^\\d+\\.\\d{2}$",
+              "title": "MUAC in cm",
+              "type": "string",
+              "messages": { "pattern": "Format is 0.00" }
             },
             "nutritionalStatus": {
               "description": "366364004  nutritional status",
               "enum": ["Under nourished", "Well nourished", "Overweight"],
               "type": "string"
             },
-            "opportunisticInfection": {
+            "opportunisticInfections": {
               "items": {
                 "enum": [
                   "411 - 1 - (1) Asymptomatic",
@@ -371,11 +366,20 @@
             },
             "weight": {
               "description": "735395000\tCurrent body weight [kg]",
-              "type": "number"
+              "pattern": "^\\d+\\.\\d{2}$",
+              "title": "Weight in kg",
+              "type": "string",
+              "messages": { "pattern": "Format is 0.00" }
             },
             "whoStaging": {
               "description": "420721002 Acquired immunodeficiency syndrome-associated disorder (disorder)",
-              "enum": ["1", "2", "3", "4"],
+              "enum": [
+                "Stage 1 - Asymptomatic",
+                "Stage 2 - Mildly symptomatic",
+                "Stage 3 - Moderately symptomatic",
+                "Stage 4 - Severely symptomatic"
+              ],
+              "title": "WHO Staging",
               "type": "string"
             }
           },
@@ -403,11 +407,7 @@
               "type": "string"
             },
             "tbGeneXpert": {
-              "enum": [
-                "Not Detected",
-                "Positive (Rif-Sensetive)",
-                "Postitive (Rif-Resistant"
-              ],
+              "enum": ["Not Detected", "Positive (Rif-Sensetive)", "Postitive (Rif-Resistant"],
               "type": "string"
             },
             "tbSputum": {

--- a/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
@@ -8,19 +8,23 @@
       "elements": [
         {
           "type": "Control",
-          "scope": "#/properties/physicalExamination/properties/height"
+          "scope": "#/properties/physicalExamination/properties/height",
+          "options": { "width": "100px" }
         },
         {
           "type": "Control",
-          "scope": "#/properties/physicalExamination/properties/midUpperArmCircumference"
+          "scope": "#/properties/physicalExamination/properties/midUpperArmCircumference",
+          "options": { "width": "100px" }
         },
         {
           "type": "Control",
-          "scope": "#/properties/physicalExamination/properties/weight"
+          "scope": "#/properties/physicalExamination/properties/weight",
+          "options": { "width": "100px" }
         },
         {
           "type": "Control",
-          "scope": "#/properties/physicalExamination/properties/bloodPressure"
+          "scope": "#/properties/physicalExamination/properties/bloodPressure",
+          "options": { "width": "100px" }
         },
         {
           "type": "Control",


### PR DESCRIPTION
Closes #645 

Have converted the four properties to be string rather than numeric in order to allow for the customised formatting.
Then had to extend the text control, so that the UI Schema could supply the required width ( otherwise the numeric inputs were too narrow, the text ones too wide 🙄 )
Then had to support custom errors, to override the `must match pattern [regex]` format that ajv outputs. This overriding isn't the best - tried `ajv-errors` and various other options, but nothing was working. Unfortunately it seems that this json forms package doesn't support the options available elsewhere.

Have used a per-keyword mapping for errors, so there is some flexibility.

Unfortunately the programschemas repo is using a generator which doesn't support custom annotations, so these errors need to be added manually after generation.

The result is good though 🤷 

<img width="330" alt="Screen Shot 2022-10-04 at 6 31 10 PM" src="https://user-images.githubusercontent.com/9192912/193744821-eda5a5d4-cdc4-4e8a-a53b-281d7ae54cdb.png">
