### PR TITLE
684 fix item stats with postgres feature

### DIFF
--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -85,6 +85,18 @@ fn get_date_fields() -> Vec<TableAndFieldName> {
     .collect()
 }
 
+#[cfg(test)]
+#[cfg(feature = "postgres")]
+fn get_exclude_date_fields() -> Vec<TableAndFieldName> {
+    vec![("invoice_line_stock_movement", "expiry_date")]
+        .iter()
+        .map(|(table_name, field_name)| TableAndFieldName {
+            table_name,
+            field_name,
+        })
+        .collect()
+}
+
 #[derive(QueryableByName, Debug, PartialEq)]
 struct IdAndTimestamp {
     #[sql_type = "Text"]
@@ -590,7 +602,8 @@ mod tests {
             .load::<TableNameAndFieldRow>(&connection.connection)
             .unwrap();
 
-        let defined_table_and_fields = get_date_fields();
+        let mut defined_table_and_fields = get_date_fields();
+        defined_table_and_fields.append(&mut get_exclude_date_fields());
 
         for schema_row in schema_table_and_fields.iter() {
             assert_eq!(

--- a/server/repository/migrations/postgres/2021-12-25T10-00_item_stats/up.sql
+++ b/server/repository/migrations/postgres/2021-12-25T10-00_item_stats/up.sql
@@ -1,51 +1,54 @@
+CREATE VIEW invoice_line_stock_movement AS 
+SELECT 
+	*,
+	CASE
+	 WHEN type = 'STOCK_IN' THEN (number_of_packs * pack_size)::BIGINT
+	 WHEN type = 'STOCK_OUT' THEN (number_of_packs * pack_size)::BIGINT * -1
+	END as quantity_movement
+FROM invoice_line
+WHERE number_of_packs > 0
+	AND type IN ('STOCK_IN', 'STOCK_OUT');
+
 -- https://github.com/sussol/msupply/blob/master/Project/Sources/Methods/aggregator_stockMovement.4dm
 -- TODO are all of sc, ci, si type transactions synced, and are all of the dates set correctly ?
 CREATE VIEW outbound_shipment_stock_movement AS
 SELECT 
     'n/a' as id,
-    number_of_packs * pack_size * -1 as quantity,
+    quantity_movement as quantity,
 	item_id,
 	store_id,
 	picked_datetime as datetime
-FROM invoice_line 
+FROM invoice_line_stock_movement 
 JOIN invoice
-	ON invoice_line.invoice_id = invoice.id
+	ON invoice_line_stock_movement.invoice_id = invoice.id
 WHERE invoice.type = 'OUTBOUND_SHIPMENT' 
-	AND picked_datetime IS NOT NULL
-	AND invoice_line.number_of_packs > 0
-	AND invoice_line.type = 'STOCK_OUT';
+	AND picked_datetime IS NOT NULL;
 		
 CREATE VIEW inbound_shipment_stock_movement AS
 SELECT 
     'n/a' as id,
-    number_of_packs * pack_size as quantity,
+    quantity_movement as quantity,
 	item_id,
 	store_id,
 	delivered_datetime as datetime
-FROM invoice_line 
+FROM invoice_line_stock_movement 
 JOIN invoice
-	ON invoice_line.invoice_id = invoice.id
+	ON invoice_line_stock_movement.invoice_id = invoice.id
 WHERE invoice.type = 'INBOUND_SHIPMENT' 
-	AND delivered_datetime IS NOT NULL
-	AND invoice_line.number_of_packs > 0
-	AND invoice_line.type = 'STOCK_IN';
+	AND delivered_datetime IS NOT NULL;
 		
 CREATE VIEW inventory_adjustment_stock_movement AS
 SELECT 
     'n/a' as id,
-    CASE
-	 WHEN invoice_line.type = 'STOCK_IN' THEN number_of_packs * pack_size
-	 WHEN invoice_line.type = 'STOCK_OUT' THEN number_of_packs * pack_size * -1
-	END as quantity,
+    quantity_movement as quantity,
 	item_id,
 	store_id,
 	verified_datetime as datetime
-FROM invoice_line 
+FROM invoice_line_stock_movement 
 JOIN invoice
-	ON invoice_line.invoice_id = invoice.id
+	ON invoice_line_stock_movement.invoice_id = invoice.id
 WHERE invoice.type = 'INVENTORY_ADJUSTMENT' 
-	AND verified_datetime IS NOT NULL
-	AND invoice_line.number_of_packs > 0;
+	AND verified_datetime IS NOT NULL;
 		
 CREATE VIEW stock_movement AS
 SELECT * FROM outbound_shipment_stock_movement
@@ -80,7 +83,7 @@ LEFT OUTER JOIN
 	(SELECT 
 	  	item_id, 
 	 	store_id,
-	 	SUM(pack_size * available_number_of_packs) AS available_stock_on_hand
+	 	SUM(pack_size * available_number_of_packs)::BIGINT AS available_stock_on_hand
 	FROM stock_line
 	WHERE stock_line.available_number_of_packs > 0
 	GROUP BY item_id, store_id

--- a/server/repository/src/db_diesel/consumption.rs
+++ b/server/repository/src/db_diesel/consumption.rs
@@ -12,7 +12,7 @@ table! {
         id -> Text,
         item_id -> Text,
         store_id -> Text,
-        quantity -> Integer,
+        quantity -> BigInt,
         date -> Date,
     }
 }
@@ -25,7 +25,7 @@ pub struct ConsumptionRow {
     pub id: String,
     pub item_id: String,
     pub store_id: String,
-    pub quantity: i32,
+    pub quantity: i64,
     pub date: NaiveDate,
 }
 

--- a/server/repository/src/db_diesel/stock_movement.rs
+++ b/server/repository/src/db_diesel/stock_movement.rs
@@ -14,7 +14,7 @@ table! {
         id -> Text,
         item_id -> Text,
         store_id -> Text,
-        quantity -> Integer,
+        quantity -> BigInt,
         datetime -> Timestamp,
     }
 }
@@ -24,7 +24,7 @@ pub struct StockMovementRow {
     pub id: String,
     pub item_id: String,
     pub store_id: String,
-    pub quantity: i32,
+    pub quantity: i64,
     pub datetime: NaiveDateTime,
 }
 

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ops::Neg};
 
-use crate::{i64_to_u32, service_provider::ServiceContext};
+use crate::service_provider::ServiceContext;
 use chrono::Duration;
 use repository::{
     ConsumptionFilter, ConsumptionRepository, ConsumptionRow, DateFilter, EqualFilter,
@@ -112,7 +112,7 @@ impl ItemStats {
         stock_on_hand_rows
             .into_iter()
             .map(|stock_on_hand| ItemStats {
-                available_stock_on_hand: i64_to_u32(stock_on_hand.available_stock_on_hand),
+                available_stock_on_hand: stock_on_hand.available_stock_on_hand as u32,
                 item_id: stock_on_hand.item_id.clone(),
                 average_monthly_consumption: consumption_map
                     .get(&stock_on_hand.item_id)


### PR DESCRIPTION
closes #684 

It turns out that when we switched to decimals for number of packs the aggregate views also changed to use decimals, but db diesel definitions were still expecting integers (so tests were failing in postgres and itemStats query wasn't working)

### Changes

* For postgres changed to cast `quantity` to BigInt (since number_of_pack * pack_size should always be whole pack anyways, if it isn't it's ok to round)
* When I was doing above I saw a lot of duplication so created `invoice_line_stock_movement` view, which is used in other view (shouldn't have any performance drawbacks since views are just aliases for select statements)
* Used i64 vs i32 in in diesel schema (had to actually downcast one to i32 from i64, so decided to change and use bigint i64 everywhere)
* Fixed postgres test in refresh dates cli (excluding the new view expiry_date field from dates to check)

### Tests

Just made sure postgres tests pass, there are quite a few unit tests, trusting them enough not to do manual test