### PR TITLE
currency input issues

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -34,7 +34,6 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   ...restOfProps
 }) => {
   const { c, options, language } = useCurrency();
-
   const prefix = language !== 'fr' ? options.symbol : '';
   const suffix = language === 'fr' ? options.symbol : '';
 
@@ -48,15 +47,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
             : theme.palette.background.menu,
       }}
       defaultValue={defaultValue}
-      onValueChange={newValue => {
-        onChangeNumber(c(newValue ?? '').value);
-      }}
+      onValueChange={newValue => onChangeNumber(c(newValue || '').value)}
       allowNegativeValue={allowNegativeValue}
       prefix={prefix}
       suffix={suffix}
       decimalSeparator={options.decimal}
       groupSeparator={options.separator}
-      decimalsLimit={options.precision}
+      decimalsLimit={2}
       allowDecimals={allowDecimals}
       {...restOfProps}
     />

--- a/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CellProps } from '../../../columns';
 import { CurrencyInput } from '@common/components';
 import { RecordWithId } from '@common/types';
-import { useBufferState, useDebounceCallback } from '@common/hooks';
+import { useDebounceCallback } from '@common/hooks';
 
 export const CurrencyInputCell = <T extends RecordWithId>({
   rowData,
@@ -12,10 +12,6 @@ export const CurrencyInputCell = <T extends RecordWithId>({
   columnIndex,
   isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
-  const [buffer, setBuffer] = useBufferState(
-    Number(Number(column.accessor({ rowData, rows })))
-  );
-
   const updater = useDebounceCallback(column.setter, [column.setter], 250);
 
   const autoFocus = rowIndex === 0 && columnIndex === 0;
@@ -25,11 +21,10 @@ export const CurrencyInputCell = <T extends RecordWithId>({
       disabled={isDisabled}
       autoFocus={autoFocus}
       maxWidth={column.width}
-      value={buffer}
-      onChangeNumber={newNumber => {
-        setBuffer(newNumber);
-        updater({ ...rowData, [column.key]: Number(newNumber) });
-      }}
+      defaultValue={String(column.accessor({ rowData, rows }))}
+      onChangeNumber={newValue =>
+        updater({ ...rowData, [column.key]: newValue })
+      }
     />
   );
 };

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
@@ -12,7 +12,7 @@ export const NonNegativeDecimalCell = <T extends RecordWithId>({
   isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
-    column.accessor({ rowData, rows })
+    column.accessor({ rowData, rows }) || ''
   );
 
   const updater = useDebounceCallback(column.setter, [column.setter], 250);


### PR DESCRIPTION
Fixes #706 

A few issues with the currency input component. I've removed the buffering, as I think it is not required from my reading of the component. The `defaultValue` prop provides what the buffer was. 

The primary issue was the conversion to a `Number` which meant that if you type `0` then `.` the value is set to `0` because the string `0.` is converted to a number. Then if you type `5` you get a value for the input of `5` rather than the `0.5` that you may have wanted.

Have tested using French and English settings, and checked the storybook and the stocktake usage. all working now.