### PR TITLE
Show sync status in menu

### DIFF
--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -1,11 +1,13 @@
 import React, { FC } from 'react';
 import {
+  Badge,
   ListItem,
   ListItemIcon,
   ListItemText,
   ListItemButton,
   Box,
   ListItemProps,
+  BadgeProps,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useMatch, Link } from 'react-router-dom';
@@ -46,6 +48,7 @@ const StyledListItem = styled<
 }));
 
 export interface AppNavLinkProps {
+  badgeProps?: BadgeProps;
   end?: boolean; // denotes lowest level menu item, using terminology from useMatch
   icon?: JSX.Element;
   inactive?: boolean;
@@ -57,6 +60,7 @@ export interface AppNavLinkProps {
 
 export const AppNavLink: FC<AppNavLinkProps> = props => {
   const {
+    badgeProps,
     end,
     inactive,
     icon = <span style={{ width: 2 }} />,
@@ -114,11 +118,13 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         disableGutters
         component={CustomLink}
       >
-        <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
-        <Box className="navLinkText">
-          <Box width={10} />
-          <ListItemText primary={text} />
-        </Box>
+        <Badge {...badgeProps} sx={{ alignItems: 'center', flexGrow: 1 }}>
+          <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
+          <Box className="navLinkText">
+            <Box width={10} />
+            <ListItemText primary={text} />
+          </Box>
+        </Badge>
       </ListItemButton>
     </StyledListItem>
   ) : null;

--- a/client/packages/common/src/ui/icons/Alert.tsx
+++ b/client/packages/common/src/ui/icons/Alert.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
-export const AlertIcon = (props: SvgIconProps): JSX.Element => {
+export const AlertIcon = (
+  props: SvgIconProps & { fill?: string }
+): JSX.Element => {
+  const { fill = 'none', ...rest } = props;
   return (
     <SvgIcon
-      {...props}
+      {...rest}
       viewBox="0 0 24 24"
       stroke="currentColor"
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      style={{ fill: 'none' }}
+      style={{ fill }}
     >
       <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
       <line x1="12" y1="9" x2="12" y2="13"></line>

--- a/client/packages/host/src/api/hooks/sync/useManualSync.ts
+++ b/client/packages/host/src/api/hooks/sync/useManualSync.ts
@@ -1,7 +1,11 @@
-import { useMutation } from '@openmsupply-client/common';
+import { useMutation, useQueryClient } from '@openmsupply-client/common';
 import { useHostApi } from '../utils/useHostApi';
 
 export const useManualSync = () => {
   const api = useHostApi();
-  return useMutation(api.manualSync);
+  const queryClient = useQueryClient();
+
+  return useMutation(api.manualSync, {
+    onSettled: () => queryClient.invalidateQueries(api.keys.syncInfo()),
+  });
 };

--- a/client/packages/host/src/api/hooks/utils/useSyncInfo.ts
+++ b/client/packages/host/src/api/hooks/utils/useSyncInfo.ts
@@ -5,7 +5,6 @@ export const useSyncInfo = (refetchInterval: number | false = false) => {
   const api = useHostApi();
 
   const { data, ...rest } = useQuery(api.keys.syncInfo(), api.get.syncInfo, {
-    cacheTime: 0,
     refetchInterval,
   });
 

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -22,7 +22,6 @@ import {
   useLocation,
   EnvUtils,
   UserPermission,
-  RadioIcon,
 } from '@openmsupply-client/common';
 import { AppRoute, ExternalURL } from '@openmsupply-client/config';
 import {
@@ -32,6 +31,7 @@ import {
   ReplenishmentNav,
 } from '../Navigation';
 import { AppDrawerIcon } from './AppDrawerIcon';
+import { SyncNavLink } from './SyncNavLink';
 
 const ToolbarIconContainer = styled(Box)({
   display: 'flex',
@@ -224,11 +224,7 @@ export const AppDrawer: React.FC = () => {
             text={t('docs')}
             trustedSite={true}
           />
-          <AppNavLink
-            to={AppRoute.Sync}
-            icon={<RadioIcon fontSize="small" color="primary" />}
-            text={t('sync')}
-          />
+          <SyncNavLink />
           <AppNavLink
             to={AppRoute.Admin}
             icon={<SettingsIcon fontSize="small" color="primary" />}

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -1,0 +1,52 @@
+import {
+  AlertIcon,
+  AppNavLink,
+  RadioIcon,
+  Tooltip,
+  useTheme,
+  useTranslation,
+} from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
+import React from 'react';
+import { useHost } from '../../api/hooks';
+
+export const SyncNavLink = () => {
+  const t = useTranslation('app');
+  const theme = useTheme();
+  const { data: syncSettings } = useHost.settings.syncSettings();
+  const { intervalSeconds } = syncSettings || {};
+  const pollingIntervalInSeconds =
+    intervalSeconds && !Number.isNaN(intervalSeconds)
+      ? intervalSeconds / 5
+      : 60;
+  const { syncStatus, numberOfRecordsInPushQueue } = useHost.utils.syncInfo(
+    1000 * pollingIntervalInSeconds
+  );
+
+  const badgeProps = {
+    badgeContent: numberOfRecordsInPushQueue as React.ReactNode,
+    max: 99,
+    color: 'primary' as 'primary' | 'default',
+  };
+
+  if (syncStatus && syncStatus.error) {
+    badgeProps.color = 'default';
+    badgeProps.badgeContent = (
+      <Tooltip title={'syncStatus?.error?.fullError'}>
+        <AlertIcon
+          color="error"
+          fontSize="small"
+          fill={theme.palette.background.drawer}
+        />
+      </Tooltip>
+    );
+  }
+  return (
+    <AppNavLink
+      to={AppRoute.Sync}
+      icon={<RadioIcon fontSize="small" color="primary" />}
+      text={t('sync')}
+      badgeProps={badgeProps}
+    />
+  );
+};


### PR DESCRIPTION
Closes #698 

- Adds a badge to the `AppNavLink` component ( available to all nav links, though only used by sync atm )
- Create a new sync nav link component, which polls for status ( polling interval is 1/5 of the sync interval )
- Show the alert icon if there is an error, or the number of items to push, or no badge if nothing to do

<img width="383" alt="Screen Shot 2022-10-25 at 5 35 34 PM" src="https://user-images.githubusercontent.com/9192912/197685429-41036099-3d9b-412c-b1b5-8615b0f33be4.png">

<img width="205" alt="Screen Shot 2022-10-25 at 5 35 38 PM" src="https://user-images.githubusercontent.com/9192912/197685457-89254df4-4fb8-4c5a-a248-6026573e553a.png">

<img width="277" alt="Screen Shot 2022-10-25 at 5 43 29 PM" src="https://user-images.githubusercontent.com/9192912/197685465-1baa0d4d-66c3-4699-9058-640dc896a385.png">

<img width="130" alt="Screen Shot 2022-10-25 at 5 43 33 PM" src="https://user-images.githubusercontent.com/9192912/197685496-eb55f7af-06ee-4d7e-802c-cf44b9679d32.png">
