### PR TITLE
Add settings to actix server

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -220,6 +220,7 @@ pub async fn start_server(
     let closure_settings = settings.clone();
     let mut http_server = HttpServer::new(move || {
         App::new()
+            .app_data(Data::new(closure_settings.clone()))
             .wrap(logger_middleware())
             .wrap(cors_policy(&closure_settings))
             .wrap(compress_middleware())


### PR DESCRIPTION
Fixes #749 

The settings are now required by `static_files::files` but were not added to the request, which causes the handler to throw the error noted in the issue. Since the settings are passed in to the `start_server` I've just cloned them and added in to the app data.