### PR TITLE
Cache selected language

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -4,6 +4,8 @@ import Backend from 'i18next-chained-backend';
 import LocalStorageBackend from 'i18next-localstorage-backend';
 import HttpApi from 'i18next-http-backend';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import { browserLanguageDetector } from './browserLanguageDetector';
 import { PropsWithChildrenOnly } from '@common/types';
 import { EnvUtils, Platform } from '@common/utils';
 
@@ -11,6 +13,9 @@ const defaultNS = 'common';
 export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   React.useEffect(() => {
     if (i18next.isInitialized) return;
+
+    const languageDetector = new LanguageDetector();
+    languageDetector.addDetector(browserLanguageDetector);
 
     const minuteInMilliseconds = 60 * 1000;
     const isDevelopment = process.env['NODE_ENV'] === 'development';
@@ -29,6 +34,7 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     i18next
       .use(initReactI18next) // passes i18n down to react-i18next
       .use(Backend)
+      .use(languageDetector)
       .init({
         backend: {
           backends: [

--- a/client/packages/common/src/intl/context/browserLanguageDetector.ts
+++ b/client/packages/common/src/intl/context/browserLanguageDetector.ts
@@ -10,11 +10,11 @@ export const browserLanguageDetector: CustomDetector = {
     const found: string[] = [];
     const add = (languageOrLocale?: string) => {
       if (!languageOrLocale) return;
-      if (/^[a-z]{2}$/i.test(languageOrLocale)) {
-        found.push(languageOrLocale);
+      const parsed = /(^[a-z]{2})(-(.*))?/.exec(languageOrLocale);
+      if (parsed) {
+        if (parsed.length > 1 && !!parsed[1]) found.push(parsed[1]);
       } else {
-        const language = languageOrLocale.split('-')[0];
-        if (language) found.push(language);
+        found.push(languageOrLocale);
       }
     };
     if (typeof navigator !== 'undefined') {

--- a/client/packages/common/src/intl/context/browserLanguageDetector.ts
+++ b/client/packages/common/src/intl/context/browserLanguageDetector.ts
@@ -1,0 +1,37 @@
+import { CustomDetector } from 'i18next-browser-languagedetector';
+
+export const browserLanguageDetector: CustomDetector = {
+  name: 'omsBrowserLanguageDetector',
+  // the language is now supplied by the user profile
+  // and set on login, so the below code is not actually needed
+  // Implementing the language detector allows the language
+  // to be cached in the browser and retained on page refresh
+  lookup: () => {
+    const found: string[] = [];
+    const add = (languageOrLocale?: string) => {
+      if (!languageOrLocale) return;
+      if (/^[a-z]{2}$/i.test(languageOrLocale)) {
+        found.push(languageOrLocale);
+      } else {
+        const language = languageOrLocale.split('-')[0];
+        if (language) found.push(language);
+      }
+    };
+    if (typeof navigator !== 'undefined') {
+      if (navigator.languages) {
+        // chrome only; not an array, so can't use .push.apply instead of iterating
+        for (let i = 0; i < navigator.languages.length; i++) {
+          const locale = navigator.languages[i];
+          add(locale);
+        }
+      }
+      if ((navigator as any).userLanguage) {
+        add((navigator as any).userLanguage);
+      }
+      if (navigator.language) {
+        add(navigator.language);
+      }
+    }
+    return found.length > 0 ? found : undefined;
+  },
+};


### PR DESCRIPTION
Fixes #754 

The language detector allows caching of the selected language by i18next. Removing the detector also removes the caching, and the page is reloaded on language change, to allow for LTR <> RTL changes.