### PR TITLE
Testing feedback issues #2

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1,14 +1,8 @@
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -84,7 +78,7 @@ export enum ActivityLogNodeType {
   StocktakeCreated = 'STOCKTAKE_CREATED',
   StocktakeDeleted = 'STOCKTAKE_DELETED',
   StocktakeStatusFinalised = 'STOCKTAKE_STATUS_FINALISED',
-  UserLoggedIn = 'USER_LOGGED_IN',
+  UserLoggedIn = 'USER_LOGGED_IN'
 }
 
 export type ActivityLogResponse = ActivityLogConnector;
@@ -93,7 +87,7 @@ export enum ActivityLogSortFieldInput {
   ActivityLogType = 'activityLogType',
   Id = 'id',
   RecordId = 'recordId',
-  UserId = 'userId',
+  UserId = 'userId'
 }
 
 export type ActivityLogSortInput = {
@@ -120,9 +114,7 @@ export type AddFromMasterListInput = {
   requestRequisitionId: Scalars['String'];
 };
 
-export type AddFromMasterListResponse =
-  | AddFromMasterListError
-  | RequisitionLineConnector;
+export type AddFromMasterListResponse = AddFromMasterListError | RequisitionLineConnector;
 
 export type AddToInboundShipmentFromMasterListError = {
   __typename: 'AddToInboundShipmentFromMasterListError';
@@ -133,9 +125,7 @@ export type AddToInboundShipmentFromMasterListErrorInterface = {
   description: Scalars['String'];
 };
 
-export type AddToInboundShipmentFromMasterListResponse =
-  | AddToInboundShipmentFromMasterListError
-  | InvoiceLineConnector;
+export type AddToInboundShipmentFromMasterListResponse = AddToInboundShipmentFromMasterListError | InvoiceLineConnector;
 
 export type AddToOutboundShipmentFromMasterListError = {
   __typename: 'AddToOutboundShipmentFromMasterListError';
@@ -146,9 +136,7 @@ export type AddToOutboundShipmentFromMasterListErrorInterface = {
   description: Scalars['String'];
 };
 
-export type AddToOutboundShipmentFromMasterListResponse =
-  | AddToOutboundShipmentFromMasterListError
-  | InvoiceLineConnector;
+export type AddToOutboundShipmentFromMasterListResponse = AddToOutboundShipmentFromMasterListError | InvoiceLineConnector;
 
 export type AddToShipmentFromMasterListInput = {
   masterListId: Scalars['String'];
@@ -174,9 +162,7 @@ export type AllocateOutboundShipmentUnallocatedLineNode = {
   updates: InvoiceLineConnector;
 };
 
-export type AllocateOutboundShipmentUnallocatedLineResponse =
-  | AllocateOutboundShipmentUnallocatedLineError
-  | AllocateOutboundShipmentUnallocatedLineNode;
+export type AllocateOutboundShipmentUnallocatedLineResponse = AllocateOutboundShipmentUnallocatedLineError | AllocateOutboundShipmentUnallocatedLineNode;
 
 export type AllocateOutboundShipmentUnallocatedLineResponseWithId = {
   __typename: 'AllocateOutboundShipmentUnallocatedLineResponseWithId';
@@ -203,170 +189,87 @@ export type AuthTokenResponse = AuthToken | AuthTokenError;
 
 export type BatchInboundShipmentInput = {
   continueOnError?: InputMaybe<Scalars['Boolean']>;
-  deleteInboundShipmentLines?: InputMaybe<
-    Array<DeleteInboundShipmentLineInput>
-  >;
-  deleteInboundShipmentServiceLines?: InputMaybe<
-    Array<DeleteInboundShipmentServiceLineInput>
-  >;
+  deleteInboundShipmentLines?: InputMaybe<Array<DeleteInboundShipmentLineInput>>;
+  deleteInboundShipmentServiceLines?: InputMaybe<Array<DeleteInboundShipmentServiceLineInput>>;
   deleteInboundShipments?: InputMaybe<Array<DeleteInboundShipmentInput>>;
-  insertInboundShipmentLines?: InputMaybe<
-    Array<InsertInboundShipmentLineInput>
-  >;
-  insertInboundShipmentServiceLines?: InputMaybe<
-    Array<InsertInboundShipmentServiceLineInput>
-  >;
+  insertInboundShipmentLines?: InputMaybe<Array<InsertInboundShipmentLineInput>>;
+  insertInboundShipmentServiceLines?: InputMaybe<Array<InsertInboundShipmentServiceLineInput>>;
   insertInboundShipments?: InputMaybe<Array<InsertInboundShipmentInput>>;
-  updateInboundShipmentLines?: InputMaybe<
-    Array<UpdateInboundShipmentLineInput>
-  >;
-  updateInboundShipmentServiceLines?: InputMaybe<
-    Array<UpdateInboundShipmentServiceLineInput>
-  >;
+  updateInboundShipmentLines?: InputMaybe<Array<UpdateInboundShipmentLineInput>>;
+  updateInboundShipmentServiceLines?: InputMaybe<Array<UpdateInboundShipmentServiceLineInput>>;
   updateInboundShipments?: InputMaybe<Array<UpdateInboundShipmentInput>>;
 };
 
 export type BatchInboundShipmentResponse = {
   __typename: 'BatchInboundShipmentResponse';
-  deleteInboundShipmentLines?: Maybe<
-    Array<DeleteInboundShipmentLineResponseWithId>
-  >;
-  deleteInboundShipmentServiceLines?: Maybe<
-    Array<DeleteInboundShipmentServiceLineResponseWithId>
-  >;
+  deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineResponseWithId>>;
+  deleteInboundShipmentServiceLines?: Maybe<Array<DeleteInboundShipmentServiceLineResponseWithId>>;
   deleteInboundShipments?: Maybe<Array<DeleteInboundShipmentResponseWithId>>;
-  insertInboundShipmentLines?: Maybe<
-    Array<InsertInboundShipmentLineResponseWithId>
-  >;
-  insertInboundShipmentServiceLines?: Maybe<
-    Array<InsertInboundShipmentServiceLineResponseWithId>
-  >;
+  insertInboundShipmentLines?: Maybe<Array<InsertInboundShipmentLineResponseWithId>>;
+  insertInboundShipmentServiceLines?: Maybe<Array<InsertInboundShipmentServiceLineResponseWithId>>;
   insertInboundShipments?: Maybe<Array<InsertInboundShipmentResponseWithId>>;
-  updateInboundShipmentLines?: Maybe<
-    Array<UpdateInboundShipmentLineResponseWithId>
-  >;
-  updateInboundShipmentServiceLines?: Maybe<
-    Array<UpdateInboundShipmentServiceLineResponseWithId>
-  >;
+  updateInboundShipmentLines?: Maybe<Array<UpdateInboundShipmentLineResponseWithId>>;
+  updateInboundShipmentServiceLines?: Maybe<Array<UpdateInboundShipmentServiceLineResponseWithId>>;
   updateInboundShipments?: Maybe<Array<UpdateInboundShipmentResponseWithId>>;
 };
 
-export type BatchIsReserved = DeleteInboundShipmentLineErrorInterface &
-  UpdateInboundShipmentLineErrorInterface & {
-    __typename: 'BatchIsReserved';
-    description: Scalars['String'];
-  };
+export type BatchIsReserved = DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & {
+  __typename: 'BatchIsReserved';
+  description: Scalars['String'];
+};
 
 export type BatchOutboundShipmentInput = {
-  allocatedOutboundShipmentUnallocatedLines?: InputMaybe<
-    Array<Scalars['String']>
-  >;
+  allocatedOutboundShipmentUnallocatedLines?: InputMaybe<Array<Scalars['String']>>;
   continueOnError?: InputMaybe<Scalars['Boolean']>;
-  deleteOutboundShipmentLines?: InputMaybe<
-    Array<DeleteOutboundShipmentLineInput>
-  >;
-  deleteOutboundShipmentServiceLines?: InputMaybe<
-    Array<DeleteOutboundShipmentServiceLineInput>
-  >;
-  deleteOutboundShipmentUnallocatedLines?: InputMaybe<
-    Array<DeleteOutboundShipmentUnallocatedLineInput>
-  >;
+  deleteOutboundShipmentLines?: InputMaybe<Array<DeleteOutboundShipmentLineInput>>;
+  deleteOutboundShipmentServiceLines?: InputMaybe<Array<DeleteOutboundShipmentServiceLineInput>>;
+  deleteOutboundShipmentUnallocatedLines?: InputMaybe<Array<DeleteOutboundShipmentUnallocatedLineInput>>;
   deleteOutboundShipments?: InputMaybe<Array<Scalars['String']>>;
-  insertOutboundShipmentLines?: InputMaybe<
-    Array<InsertOutboundShipmentLineInput>
-  >;
-  insertOutboundShipmentServiceLines?: InputMaybe<
-    Array<InsertOutboundShipmentServiceLineInput>
-  >;
-  insertOutboundShipmentUnallocatedLines?: InputMaybe<
-    Array<InsertOutboundShipmentUnallocatedLineInput>
-  >;
+  insertOutboundShipmentLines?: InputMaybe<Array<InsertOutboundShipmentLineInput>>;
+  insertOutboundShipmentServiceLines?: InputMaybe<Array<InsertOutboundShipmentServiceLineInput>>;
+  insertOutboundShipmentUnallocatedLines?: InputMaybe<Array<InsertOutboundShipmentUnallocatedLineInput>>;
   insertOutboundShipments?: InputMaybe<Array<InsertOutboundShipmentInput>>;
-  updateOutboundShipmentLines?: InputMaybe<
-    Array<UpdateOutboundShipmentLineInput>
-  >;
-  updateOutboundShipmentServiceLines?: InputMaybe<
-    Array<UpdateOutboundShipmentServiceLineInput>
-  >;
-  updateOutboundShipmentUnallocatedLines?: InputMaybe<
-    Array<UpdateOutboundShipmentUnallocatedLineInput>
-  >;
+  updateOutboundShipmentLines?: InputMaybe<Array<UpdateOutboundShipmentLineInput>>;
+  updateOutboundShipmentServiceLines?: InputMaybe<Array<UpdateOutboundShipmentServiceLineInput>>;
+  updateOutboundShipmentUnallocatedLines?: InputMaybe<Array<UpdateOutboundShipmentUnallocatedLineInput>>;
   updateOutboundShipments?: InputMaybe<Array<UpdateOutboundShipmentInput>>;
 };
 
 export type BatchOutboundShipmentResponse = {
   __typename: 'BatchOutboundShipmentResponse';
-  allocateOutboundShipmentUnallocatedLines?: Maybe<
-    Array<AllocateOutboundShipmentUnallocatedLineResponseWithId>
-  >;
-  deleteOutboundShipmentLines?: Maybe<
-    Array<DeleteOutboundShipmentLineResponseWithId>
-  >;
-  deleteOutboundShipmentServiceLines?: Maybe<
-    Array<DeleteOutboundShipmentServiceLineResponseWithId>
-  >;
-  deleteOutboundShipmentUnallocatedLines?: Maybe<
-    Array<DeleteOutboundShipmentUnallocatedLineResponseWithId>
-  >;
+  allocateOutboundShipmentUnallocatedLines?: Maybe<Array<AllocateOutboundShipmentUnallocatedLineResponseWithId>>;
+  deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineResponseWithId>>;
+  deleteOutboundShipmentServiceLines?: Maybe<Array<DeleteOutboundShipmentServiceLineResponseWithId>>;
+  deleteOutboundShipmentUnallocatedLines?: Maybe<Array<DeleteOutboundShipmentUnallocatedLineResponseWithId>>;
   deleteOutboundShipments?: Maybe<Array<DeleteOutboundShipmentResponseWithId>>;
-  insertOutboundShipmentLines?: Maybe<
-    Array<InsertOutboundShipmentLineResponseWithId>
-  >;
-  insertOutboundShipmentServiceLines?: Maybe<
-    Array<InsertOutboundShipmentServiceLineResponseWithId>
-  >;
-  insertOutboundShipmentUnallocatedLines?: Maybe<
-    Array<InsertOutboundShipmentUnallocatedLineResponseWithId>
-  >;
+  insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineResponseWithId>>;
+  insertOutboundShipmentServiceLines?: Maybe<Array<InsertOutboundShipmentServiceLineResponseWithId>>;
+  insertOutboundShipmentUnallocatedLines?: Maybe<Array<InsertOutboundShipmentUnallocatedLineResponseWithId>>;
   insertOutboundShipments?: Maybe<Array<InsertOutboundShipmentResponseWithId>>;
-  updateOutboundShipmentLines?: Maybe<
-    Array<UpdateOutboundShipmentLineResponseWithId>
-  >;
-  updateOutboundShipmentServiceLines?: Maybe<
-    Array<UpdateOutboundShipmentServiceLineResponseWithId>
-  >;
-  updateOutboundShipmentUnallocatedLines?: Maybe<
-    Array<UpdateOutboundShipmentUnallocatedLineResponseWithId>
-  >;
+  updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineResponseWithId>>;
+  updateOutboundShipmentServiceLines?: Maybe<Array<UpdateOutboundShipmentServiceLineResponseWithId>>;
+  updateOutboundShipmentUnallocatedLines?: Maybe<Array<UpdateOutboundShipmentUnallocatedLineResponseWithId>>;
   updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentResponseWithId>>;
 };
 
 export type BatchRequestRequisitionInput = {
   continueOnError?: InputMaybe<Scalars['Boolean']>;
-  deleteRequestRequisitionLines?: InputMaybe<
-    Array<DeleteRequestRequisitionLineInput>
-  >;
+  deleteRequestRequisitionLines?: InputMaybe<Array<DeleteRequestRequisitionLineInput>>;
   deleteRequestRequisitions?: InputMaybe<Array<DeleteRequestRequisitionInput>>;
-  insertRequestRequisitionLines?: InputMaybe<
-    Array<InsertRequestRequisitionLineInput>
-  >;
+  insertRequestRequisitionLines?: InputMaybe<Array<InsertRequestRequisitionLineInput>>;
   insertRequestRequisitions?: InputMaybe<Array<InsertRequestRequisitionInput>>;
-  updateRequestRequisitionLines?: InputMaybe<
-    Array<UpdateRequestRequisitionLineInput>
-  >;
+  updateRequestRequisitionLines?: InputMaybe<Array<UpdateRequestRequisitionLineInput>>;
   updateRequestRequisitions?: InputMaybe<Array<UpdateRequestRequisitionInput>>;
 };
 
 export type BatchRequestRequisitionResponse = {
   __typename: 'BatchRequestRequisitionResponse';
-  deleteRequestRequisitionLines?: Maybe<
-    Array<DeleteRequestRequisitionLineResponseWithId>
-  >;
-  deleteRequestRequisitions?: Maybe<
-    Array<DeleteRequestRequisitionResponseWithId>
-  >;
-  insertRequestRequisitionLines?: Maybe<
-    Array<InsertRequestRequisitionLineResponseWithId>
-  >;
-  insertRequestRequisitions?: Maybe<
-    Array<InsertRequestRequisitionResponseWithId>
-  >;
-  updateRequestRequisitionLines?: Maybe<
-    Array<UpdateRequestRequisitionLineResponseWithId>
-  >;
-  updateRequestRequisitions?: Maybe<
-    Array<UpdateRequestRequisitionResponseWithId>
-  >;
+  deleteRequestRequisitionLines?: Maybe<Array<DeleteRequestRequisitionLineResponseWithId>>;
+  deleteRequestRequisitions?: Maybe<Array<DeleteRequestRequisitionResponseWithId>>;
+  insertRequestRequisitionLines?: Maybe<Array<InsertRequestRequisitionLineResponseWithId>>;
+  insertRequestRequisitions?: Maybe<Array<InsertRequestRequisitionResponseWithId>>;
+  updateRequestRequisitionLines?: Maybe<Array<UpdateRequestRequisitionLineResponseWithId>>;
+  updateRequestRequisitions?: Maybe<Array<UpdateRequestRequisitionResponseWithId>>;
 };
 
 export type BatchStocktakeInput = {
@@ -389,83 +292,47 @@ export type BatchStocktakeResponse = {
   updateStocktakes?: Maybe<Array<UpdateStocktakeResponseWithId>>;
 };
 
-export type CanOnlyChangeToAllocatedWhenNoUnallocatedLines =
-  UpdateErrorInterface & {
-    __typename: 'CanOnlyChangeToAllocatedWhenNoUnallocatedLines';
-    description: Scalars['String'];
-    invoiceLines: InvoiceLineConnector;
-  };
+export type CanOnlyChangeToAllocatedWhenNoUnallocatedLines = UpdateErrorInterface & {
+  __typename: 'CanOnlyChangeToAllocatedWhenNoUnallocatedLines';
+  description: Scalars['String'];
+  invoiceLines: InvoiceLineConnector;
+};
 
-export type CannotChangeStatusOfInvoiceOnHold = UpdateErrorInterface &
-  UpdateInboundShipmentErrorInterface & {
-    __typename: 'CannotChangeStatusOfInvoiceOnHold';
-    description: Scalars['String'];
-  };
+export type CannotChangeStatusOfInvoiceOnHold = UpdateErrorInterface & UpdateInboundShipmentErrorInterface & {
+  __typename: 'CannotChangeStatusOfInvoiceOnHold';
+  description: Scalars['String'];
+};
 
-export type CannotDeleteInvoiceWithLines = DeleteErrorInterface &
-  DeleteInboundShipmentErrorInterface & {
-    __typename: 'CannotDeleteInvoiceWithLines';
-    description: Scalars['String'];
-    lines: InvoiceLineConnector;
-  };
+export type CannotDeleteInvoiceWithLines = DeleteErrorInterface & DeleteInboundShipmentErrorInterface & {
+  __typename: 'CannotDeleteInvoiceWithLines';
+  description: Scalars['String'];
+  lines: InvoiceLineConnector;
+};
 
-export type CannotDeleteRequisitionWithLines =
-  DeleteRequestRequisitionErrorInterface & {
-    __typename: 'CannotDeleteRequisitionWithLines';
-    description: Scalars['String'];
-  };
+export type CannotDeleteRequisitionWithLines = DeleteRequestRequisitionErrorInterface & {
+  __typename: 'CannotDeleteRequisitionWithLines';
+  description: Scalars['String'];
+};
 
-export type CannotEditInvoice =
-  AddToInboundShipmentFromMasterListErrorInterface &
-    AddToOutboundShipmentFromMasterListErrorInterface &
-    DeleteErrorInterface &
-    DeleteInboundShipmentErrorInterface &
-    DeleteInboundShipmentLineErrorInterface &
-    DeleteInboundShipmentServiceLineErrorInterface &
-    DeleteOutboundShipmentLineErrorInterface &
-    DeleteOutboundShipmentServiceLineErrorInterface &
-    InsertInboundShipmentLineErrorInterface &
-    InsertInboundShipmentServiceLineErrorInterface &
-    InsertOutboundShipmentLineErrorInterface &
-    InsertOutboundShipmentServiceLineErrorInterface &
-    UpdateInboundShipmentErrorInterface &
-    UpdateInboundShipmentLineErrorInterface &
-    UpdateInboundShipmentServiceLineErrorInterface &
-    UpdateOutboundShipmentLineErrorInterface &
-    UpdateOutboundShipmentServiceLineErrorInterface & {
-      __typename: 'CannotEditInvoice';
-      description: Scalars['String'];
-    };
+export type CannotEditInvoice = AddToInboundShipmentFromMasterListErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & DeleteErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
+  __typename: 'CannotEditInvoice';
+  description: Scalars['String'];
+};
 
-export type CannotEditRequisition = AddFromMasterListErrorInterface &
-  CreateRequisitionShipmentErrorInterface &
-  DeleteRequestRequisitionErrorInterface &
-  DeleteRequestRequisitionLineErrorInterface &
-  InsertRequestRequisitionLineErrorInterface &
-  SupplyRequestedQuantityErrorInterface &
-  UpdateRequestRequisitionErrorInterface &
-  UpdateRequestRequisitionLineErrorInterface &
-  UpdateResponseRequisitionErrorInterface &
-  UpdateResponseRequisitionLineErrorInterface &
-  UseSuggestedQuantityErrorInterface & {
-    __typename: 'CannotEditRequisition';
-    description: Scalars['String'];
-  };
+export type CannotEditRequisition = AddFromMasterListErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & InsertRequestRequisitionLineErrorInterface & SupplyRequestedQuantityErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface & {
+  __typename: 'CannotEditRequisition';
+  description: Scalars['String'];
+};
 
-export type CannotEditStocktake = DeleteStocktakeErrorInterface &
-  DeleteStocktakeLineErrorInterface &
-  InsertStocktakeLineErrorInterface &
-  UpdateStocktakeErrorInterface &
-  UpdateStocktakeLineErrorInterface & {
-    __typename: 'CannotEditStocktake';
-    description: Scalars['String'];
-  };
+export type CannotEditStocktake = DeleteStocktakeErrorInterface & DeleteStocktakeLineErrorInterface & InsertStocktakeLineErrorInterface & UpdateStocktakeErrorInterface & UpdateStocktakeLineErrorInterface & {
+  __typename: 'CannotEditStocktake';
+  description: Scalars['String'];
+};
 
-export type CannotReverseInvoiceStatus = UpdateErrorInterface &
-  UpdateInboundShipmentErrorInterface & {
-    __typename: 'CannotReverseInvoiceStatus';
-    description: Scalars['String'];
-  };
+export type CannotReverseInvoiceStatus = UpdateErrorInterface & UpdateInboundShipmentErrorInterface & {
+  __typename: 'CannotReverseInvoiceStatus';
+  description: Scalars['String'];
+};
 
 export type ConsumptionHistoryConnector = {
   __typename: 'ConsumptionHistoryConnector';
@@ -502,19 +369,13 @@ export type CreateRequisitionShipmentInput = {
   responseRequisitionId: Scalars['String'];
 };
 
-export type CreateRequisitionShipmentResponse =
-  | CreateRequisitionShipmentError
-  | InvoiceNode;
+export type CreateRequisitionShipmentResponse = CreateRequisitionShipmentError | InvoiceNode;
 
-export type DatabaseError = DeleteLocationErrorInterface &
-  InsertLocationErrorInterface &
-  NodeErrorInterface &
-  RefreshTokenErrorInterface &
-  UpdateLocationErrorInterface & {
-    __typename: 'DatabaseError';
-    description: Scalars['String'];
-    fullError: Scalars['String'];
-  };
+export type DatabaseError = DeleteLocationErrorInterface & InsertLocationErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & {
+  __typename: 'DatabaseError';
+  description: Scalars['String'];
+  fullError: Scalars['String'];
+};
 
 export type DateFilterInput = {
   afterOrEqualTo?: InputMaybe<Scalars['NaiveDate']>;
@@ -558,9 +419,7 @@ export type DeleteInboundShipmentLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteInboundShipmentLineResponse =
-  | DeleteInboundShipmentLineError
-  | DeleteResponse;
+export type DeleteInboundShipmentLineResponse = DeleteInboundShipmentLineError | DeleteResponse;
 
 export type DeleteInboundShipmentLineResponseWithId = {
   __typename: 'DeleteInboundShipmentLineResponseWithId';
@@ -568,9 +427,7 @@ export type DeleteInboundShipmentLineResponseWithId = {
   response: DeleteInboundShipmentLineResponse;
 };
 
-export type DeleteInboundShipmentResponse =
-  | DeleteInboundShipmentError
-  | DeleteResponse;
+export type DeleteInboundShipmentResponse = DeleteInboundShipmentError | DeleteResponse;
 
 export type DeleteInboundShipmentResponseWithId = {
   __typename: 'DeleteInboundShipmentResponseWithId';
@@ -591,9 +448,7 @@ export type DeleteInboundShipmentServiceLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteInboundShipmentServiceLineResponse =
-  | DeleteInboundShipmentServiceLineError
-  | DeleteResponse;
+export type DeleteInboundShipmentServiceLineResponse = DeleteInboundShipmentServiceLineError | DeleteResponse;
 
 export type DeleteInboundShipmentServiceLineResponseWithId = {
   __typename: 'DeleteInboundShipmentServiceLineResponseWithId';
@@ -634,9 +489,7 @@ export type DeleteOutboundShipmentLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteOutboundShipmentLineResponse =
-  | DeleteOutboundShipmentLineError
-  | DeleteResponse;
+export type DeleteOutboundShipmentLineResponse = DeleteOutboundShipmentLineError | DeleteResponse;
 
 export type DeleteOutboundShipmentLineResponseWithId = {
   __typename: 'DeleteOutboundShipmentLineResponseWithId';
@@ -644,9 +497,7 @@ export type DeleteOutboundShipmentLineResponseWithId = {
   response: DeleteOutboundShipmentLineResponse;
 };
 
-export type DeleteOutboundShipmentResponse =
-  | DeleteOutboundShipmentError
-  | DeleteResponse;
+export type DeleteOutboundShipmentResponse = DeleteOutboundShipmentError | DeleteResponse;
 
 export type DeleteOutboundShipmentResponseWithId = {
   __typename: 'DeleteOutboundShipmentResponseWithId';
@@ -667,9 +518,7 @@ export type DeleteOutboundShipmentServiceLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteOutboundShipmentServiceLineResponse =
-  | DeleteOutboundShipmentServiceLineError
-  | DeleteResponse;
+export type DeleteOutboundShipmentServiceLineResponse = DeleteOutboundShipmentServiceLineError | DeleteResponse;
 
 export type DeleteOutboundShipmentServiceLineResponseWithId = {
   __typename: 'DeleteOutboundShipmentServiceLineResponseWithId';
@@ -690,9 +539,7 @@ export type DeleteOutboundShipmentUnallocatedLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteOutboundShipmentUnallocatedLineResponse =
-  | DeleteOutboundShipmentUnallocatedLineError
-  | DeleteResponse;
+export type DeleteOutboundShipmentUnallocatedLineResponse = DeleteOutboundShipmentUnallocatedLineError | DeleteResponse;
 
 export type DeleteOutboundShipmentUnallocatedLineResponseWithId = {
   __typename: 'DeleteOutboundShipmentUnallocatedLineResponseWithId';
@@ -726,9 +573,7 @@ export type DeleteRequestRequisitionLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteRequestRequisitionLineResponse =
-  | DeleteRequestRequisitionLineError
-  | DeleteResponse;
+export type DeleteRequestRequisitionLineResponse = DeleteRequestRequisitionLineError | DeleteResponse;
 
 export type DeleteRequestRequisitionLineResponseWithId = {
   __typename: 'DeleteRequestRequisitionLineResponseWithId';
@@ -736,9 +581,7 @@ export type DeleteRequestRequisitionLineResponseWithId = {
   response: DeleteRequestRequisitionLineResponse;
 };
 
-export type DeleteRequestRequisitionResponse =
-  | DeleteRequestRequisitionError
-  | DeleteResponse;
+export type DeleteRequestRequisitionResponse = DeleteRequestRequisitionError | DeleteResponse;
 
 export type DeleteRequestRequisitionResponseWithId = {
   __typename: 'DeleteRequestRequisitionResponseWithId';
@@ -777,9 +620,7 @@ export type DeleteStocktakeLineInput = {
   id: Scalars['String'];
 };
 
-export type DeleteStocktakeLineResponse =
-  | DeleteResponse
-  | DeleteStocktakeLineError;
+export type DeleteStocktakeLineResponse = DeleteResponse | DeleteStocktakeLineError;
 
 export type DeleteStocktakeLineResponseWithId = {
   __typename: 'DeleteStocktakeLineResponseWithId';
@@ -883,6 +724,12 @@ export type EqualFilterStringInput = {
   notEqualTo?: InputMaybe<Scalars['String']>;
 };
 
+export type EqualFilterTypeInput = {
+  equalAny?: InputMaybe<Array<NameNodeType>>;
+  equalTo?: InputMaybe<NameNodeType>;
+  notEqualTo?: InputMaybe<NameNodeType>;
+};
+
 export type FailedToFetchReportData = PrintReportErrorInterface & {
   __typename: 'FailedToFetchReportData';
   description: Scalars['String'];
@@ -895,31 +742,14 @@ export enum ForeignKey {
   LocationId = 'locationId',
   OtherPartyId = 'otherPartyId',
   RequisitionId = 'requisitionId',
-  StockLineId = 'stockLineId',
+  StockLineId = 'stockLineId'
 }
 
-export type ForeignKeyError = DeleteInboundShipmentLineErrorInterface &
-  DeleteInboundShipmentServiceLineErrorInterface &
-  DeleteOutboundShipmentLineErrorInterface &
-  DeleteOutboundShipmentServiceLineErrorInterface &
-  DeleteOutboundShipmentUnallocatedLineErrorInterface &
-  InsertInboundShipmentLineErrorInterface &
-  InsertInboundShipmentServiceLineErrorInterface &
-  InsertOutboundShipmentLineErrorInterface &
-  InsertOutboundShipmentServiceLineErrorInterface &
-  InsertOutboundShipmentUnallocatedLineErrorInterface &
-  InsertRequestRequisitionLineErrorInterface &
-  UpdateInboundShipmentLineErrorInterface &
-  UpdateInboundShipmentServiceLineErrorInterface &
-  UpdateOutboundShipmentLineErrorInterface &
-  UpdateOutboundShipmentServiceLineErrorInterface &
-  UpdateOutboundShipmentUnallocatedLineErrorInterface &
-  UpdateRequestRequisitionLineErrorInterface &
-  UpdateResponseRequisitionLineErrorInterface & {
-    __typename: 'ForeignKeyError';
-    description: Scalars['String'];
-    key: ForeignKey;
-  };
+export type ForeignKeyError = DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & {
+  __typename: 'ForeignKeyError';
+  description: Scalars['String'];
+  key: ForeignKey;
+};
 
 export type FullSyncStatusNode = {
   __typename: 'FullSyncStatusNode';
@@ -943,7 +773,7 @@ export enum GenderType {
   TransgenderMale = 'TRANSGENDER_MALE',
   TransgenderMaleHormone = 'TRANSGENDER_MALE_HORMONE',
   TransgenderMaleSurgical = 'TRANSGENDER_MALE_SURGICAL',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type InboundInvoiceCounts = {
@@ -954,7 +784,7 @@ export type InboundInvoiceCounts = {
 export enum InitialisationStatusType {
   Initialised = 'INITIALISED',
   Initialising = 'INITIALISING',
-  PreInitialisation = 'PRE_INITIALISATION',
+  PreInitialisation = 'PRE_INITIALISATION'
 }
 
 export type InitialiseSiteResponse = SyncErrorNode | SyncSettingsNode;
@@ -1005,9 +835,7 @@ export type InsertInboundShipmentLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type InsertInboundShipmentLineResponse =
-  | InsertInboundShipmentLineError
-  | InvoiceLineNode;
+export type InsertInboundShipmentLineResponse = InsertInboundShipmentLineError | InvoiceLineNode;
 
 export type InsertInboundShipmentLineResponseWithId = {
   __typename: 'InsertInboundShipmentLineResponseWithId';
@@ -1015,9 +843,7 @@ export type InsertInboundShipmentLineResponseWithId = {
   response: InsertInboundShipmentLineResponse;
 };
 
-export type InsertInboundShipmentResponse =
-  | InsertInboundShipmentError
-  | InvoiceNode;
+export type InsertInboundShipmentResponse = InsertInboundShipmentError | InvoiceNode;
 
 export type InsertInboundShipmentResponseWithId = {
   __typename: 'InsertInboundShipmentResponseWithId';
@@ -1044,9 +870,7 @@ export type InsertInboundShipmentServiceLineInput = {
   totalBeforeTax: Scalars['Float'];
 };
 
-export type InsertInboundShipmentServiceLineResponse =
-  | InsertInboundShipmentServiceLineError
-  | InvoiceLineNode;
+export type InsertInboundShipmentServiceLineResponse = InsertInboundShipmentServiceLineError | InvoiceLineNode;
 
 export type InsertInboundShipmentServiceLineResponseWithId = {
   __typename: 'InsertInboundShipmentServiceLineResponseWithId';
@@ -1107,9 +931,7 @@ export type InsertOutboundShipmentLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type InsertOutboundShipmentLineResponse =
-  | InsertOutboundShipmentLineError
-  | InvoiceLineNode;
+export type InsertOutboundShipmentLineResponse = InsertOutboundShipmentLineError | InvoiceLineNode;
 
 export type InsertOutboundShipmentLineResponseWithId = {
   __typename: 'InsertOutboundShipmentLineResponseWithId';
@@ -1117,10 +939,7 @@ export type InsertOutboundShipmentLineResponseWithId = {
   response: InsertOutboundShipmentLineResponse;
 };
 
-export type InsertOutboundShipmentResponse =
-  | InsertOutboundShipmentError
-  | InvoiceNode
-  | NodeError;
+export type InsertOutboundShipmentResponse = InsertOutboundShipmentError | InvoiceNode | NodeError;
 
 export type InsertOutboundShipmentResponseWithId = {
   __typename: 'InsertOutboundShipmentResponseWithId';
@@ -1147,9 +966,7 @@ export type InsertOutboundShipmentServiceLineInput = {
   totalBeforeTax: Scalars['Float'];
 };
 
-export type InsertOutboundShipmentServiceLineResponse =
-  | InsertOutboundShipmentServiceLineError
-  | InvoiceLineNode;
+export type InsertOutboundShipmentServiceLineResponse = InsertOutboundShipmentServiceLineError | InvoiceLineNode;
 
 export type InsertOutboundShipmentServiceLineResponseWithId = {
   __typename: 'InsertOutboundShipmentServiceLineResponseWithId';
@@ -1173,9 +990,7 @@ export type InsertOutboundShipmentUnallocatedLineInput = {
   quantity: Scalars['Int'];
 };
 
-export type InsertOutboundShipmentUnallocatedLineResponse =
-  | InsertOutboundShipmentUnallocatedLineError
-  | InvoiceLineNode;
+export type InsertOutboundShipmentUnallocatedLineResponse = InsertOutboundShipmentUnallocatedLineError | InvoiceLineNode;
 
 export type InsertOutboundShipmentUnallocatedLineResponseWithId = {
   __typename: 'InsertOutboundShipmentUnallocatedLineResponseWithId';
@@ -1221,9 +1036,7 @@ export type InsertRequestRequisitionLineInput = {
   requisitionId: Scalars['String'];
 };
 
-export type InsertRequestRequisitionLineResponse =
-  | InsertRequestRequisitionLineError
-  | RequisitionLineNode;
+export type InsertRequestRequisitionLineResponse = InsertRequestRequisitionLineError | RequisitionLineNode;
 
 export type InsertRequestRequisitionLineResponseWithId = {
   __typename: 'InsertRequestRequisitionLineResponseWithId';
@@ -1231,9 +1044,7 @@ export type InsertRequestRequisitionLineResponseWithId = {
   response: InsertRequestRequisitionLineResponse;
 };
 
-export type InsertRequestRequisitionResponse =
-  | InsertRequestRequisitionError
-  | RequisitionNode;
+export type InsertRequestRequisitionResponse = InsertRequestRequisitionError | RequisitionNode;
 
 export type InsertRequestRequisitionResponseWithId = {
   __typename: 'InsertRequestRequisitionResponseWithId';
@@ -1274,9 +1085,7 @@ export type InsertStocktakeLineInput = {
   stocktakeId: Scalars['String'];
 };
 
-export type InsertStocktakeLineResponse =
-  | InsertStocktakeLineError
-  | StocktakeLineNode;
+export type InsertStocktakeLineResponse = InsertStocktakeLineError | StocktakeLineNode;
 
 export type InsertStocktakeLineResponseWithId = {
   __typename: 'InsertStocktakeLineResponseWithId';
@@ -1292,13 +1101,11 @@ export type InsertStocktakeResponseWithId = {
   response: InsertStocktakeResponse;
 };
 
-export type InternalError = InsertLocationErrorInterface &
-  RefreshTokenErrorInterface &
-  UpdateLocationErrorInterface & {
-    __typename: 'InternalError';
-    description: Scalars['String'];
-    fullError: Scalars['String'];
-  };
+export type InternalError = InsertLocationErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & {
+  __typename: 'InternalError';
+  description: Scalars['String'];
+  fullError: Scalars['String'];
+};
 
 export type InvalidCredentials = AuthTokenErrorInterface & {
   __typename: 'InvalidCredentials';
@@ -1394,7 +1201,7 @@ export enum InvoiceLineNodeType {
   Service = 'SERVICE',
   StockIn = 'STOCK_IN',
   StockOut = 'STOCK_OUT',
-  UnallocatedStock = 'UNALLOCATED_STOCK',
+  UnallocatedStock = 'UNALLOCATED_STOCK'
 }
 
 export type InvoiceNode = {
@@ -1435,6 +1242,7 @@ export type InvoiceNode = {
   verifiedDatetime?: Maybe<Scalars['DateTime']>;
 };
 
+
 export type InvoiceNodeOtherPartyArgs = {
   storeId: Scalars['String'];
 };
@@ -1445,13 +1253,13 @@ export enum InvoiceNodeStatus {
   New = 'NEW',
   Picked = 'PICKED',
   Shipped = 'SHIPPED',
-  Verified = 'VERIFIED',
+  Verified = 'VERIFIED'
 }
 
 export enum InvoiceNodeType {
   InboundShipment = 'INBOUND_SHIPMENT',
   InventoryAdjustment = 'INVENTORY_ADJUSTMENT',
-  OutboundShipment = 'OUTBOUND_SHIPMENT',
+  OutboundShipment = 'OUTBOUND_SHIPMENT'
 }
 
 export type InvoiceResponse = InvoiceNode | NodeError;
@@ -1469,7 +1277,7 @@ export enum InvoiceSortFieldInput {
   TheirReference = 'theirReference',
   TransportReference = 'transportReference',
   Type = 'type',
-  VerifiedDatetime = 'verifiedDatetime',
+  VerifiedDatetime = 'verifiedDatetime'
 }
 
 export type InvoiceSortInput = {
@@ -1531,9 +1339,11 @@ export type ItemNode = {
   weight: Scalars['Float'];
 };
 
+
 export type ItemNodeAvailableBatchesArgs = {
   storeId: Scalars['String'];
 };
+
 
 export type ItemNodeStatsArgs = {
   amcLookbackMonths?: InputMaybe<Scalars['Int']>;
@@ -1543,13 +1353,13 @@ export type ItemNodeStatsArgs = {
 export enum ItemNodeType {
   NonStock = 'NON_STOCK',
   Service = 'SERVICE',
-  Stock = 'STOCK',
+  Stock = 'STOCK'
 }
 
 export enum ItemSortFieldInput {
   Code = 'code',
   Name = 'name',
-  Type = 'type',
+  Type = 'type'
 }
 
 export type ItemSortInput = {
@@ -1578,7 +1388,7 @@ export enum LanguageType {
   Laos = 'LAOS',
   Portuguese = 'PORTUGUESE',
   Russian = 'RUSSIAN',
-  Spanish = 'SPANISH',
+  Spanish = 'SPANISH'
 }
 
 export type LocationConnector = {
@@ -1601,11 +1411,10 @@ export type LocationInUse = DeleteLocationErrorInterface & {
   stockLines: StockLineConnector;
 };
 
-export type LocationIsOnHold = InsertOutboundShipmentLineErrorInterface &
-  UpdateOutboundShipmentLineErrorInterface & {
-    __typename: 'LocationIsOnHold';
-    description: Scalars['String'];
-  };
+export type LocationIsOnHold = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+  __typename: 'LocationIsOnHold';
+  description: Scalars['String'];
+};
 
 export type LocationNode = {
   __typename: 'LocationNode';
@@ -1616,15 +1425,14 @@ export type LocationNode = {
   stock: StockLineConnector;
 };
 
-export type LocationNotFound = InsertOutboundShipmentLineErrorInterface &
-  UpdateOutboundShipmentLineErrorInterface & {
-    __typename: 'LocationNotFound';
-    description: Scalars['String'];
-  };
+export type LocationNotFound = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+  __typename: 'LocationNotFound';
+  description: Scalars['String'];
+};
 
 export enum LocationSortFieldInput {
   Code = 'code',
-  Name = 'name',
+  Name = 'name'
 }
 
 export type LocationSortInput = {
@@ -1685,22 +1493,20 @@ export type MasterListNode = {
   name: Scalars['String'];
 };
 
-export type MasterListNotFoundForThisName =
-  AddToOutboundShipmentFromMasterListErrorInterface & {
-    __typename: 'MasterListNotFoundForThisName';
-    description: Scalars['String'];
-  };
+export type MasterListNotFoundForThisName = AddToOutboundShipmentFromMasterListErrorInterface & {
+  __typename: 'MasterListNotFoundForThisName';
+  description: Scalars['String'];
+};
 
-export type MasterListNotFoundForThisStore = AddFromMasterListErrorInterface &
-  AddToInboundShipmentFromMasterListErrorInterface & {
-    __typename: 'MasterListNotFoundForThisStore';
-    description: Scalars['String'];
-  };
+export type MasterListNotFoundForThisStore = AddFromMasterListErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & {
+  __typename: 'MasterListNotFoundForThisStore';
+  description: Scalars['String'];
+};
 
 export enum MasterListSortFieldInput {
   Code = 'code',
   Description = 'description',
-  Name = 'name',
+  Name = 'name'
 }
 
 export type MasterListSortInput = {
@@ -1782,257 +1588,309 @@ export type Mutations = {
   useSuggestedQuantity: UseSuggestedQuantityResponse;
 };
 
+
 export type MutationsAddFromMasterListArgs = {
   input: AddFromMasterListInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsAddToInboundShipmentFromMasterListArgs = {
   input: AddToShipmentFromMasterListInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsAddToOutboundShipmentFromMasterListArgs = {
   input: AddToShipmentFromMasterListInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsAllocateOutboundShipmentUnallocatedLineArgs = {
   lineId: Scalars['String'];
   storeId: Scalars['String'];
 };
 
+
 export type MutationsBatchInboundShipmentArgs = {
   input: BatchInboundShipmentInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsBatchOutboundShipmentArgs = {
   input: BatchOutboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsBatchRequestRequisitionArgs = {
   input: BatchRequestRequisitionInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsBatchStocktakeArgs = {
   input: BatchStocktakeInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsCreateRequisitionShipmentArgs = {
   input: CreateRequisitionShipmentInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteInboundShipmentArgs = {
   input: DeleteInboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteInboundShipmentLineArgs = {
   input: DeleteInboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteInboundShipmentServiceLineArgs = {
   input: DeleteInboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteLocationArgs = {
   input: DeleteLocationInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteOutboundShipmentArgs = {
   id: Scalars['String'];
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteOutboundShipmentLineArgs = {
   input: DeleteOutboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteOutboundShipmentServiceLineArgs = {
   input: DeleteOutboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteOutboundShipmentUnallocatedLineArgs = {
   input: DeleteOutboundShipmentUnallocatedLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteRequestRequisitionArgs = {
   input: DeleteRequestRequisitionInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteRequestRequisitionLineArgs = {
   input: DeleteRequestRequisitionLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsDeleteStocktakeArgs = {
   input: DeleteStocktakeInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsDeleteStocktakeLineArgs = {
   input: DeleteStocktakeLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInitialiseSiteArgs = {
   input: SyncSettingsInput;
 };
+
 
 export type MutationsInsertInboundShipmentArgs = {
   input: InsertInboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertInboundShipmentLineArgs = {
   input: InsertInboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsInsertInboundShipmentServiceLineArgs = {
   input: InsertInboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertLocationArgs = {
   input: InsertLocationInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsInsertOutboundShipmentArgs = {
   input: InsertOutboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertOutboundShipmentLineArgs = {
   input: InsertOutboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsInsertOutboundShipmentServiceLineArgs = {
   input: InsertOutboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertOutboundShipmentUnallocatedLineArgs = {
   input: InsertOutboundShipmentUnallocatedLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsInsertRequestRequisitionArgs = {
   input: InsertRequestRequisitionInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertRequestRequisitionLineArgs = {
   input: InsertRequestRequisitionLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsInsertStocktakeArgs = {
   input: InsertStocktakeInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsInsertStocktakeLineArgs = {
   input: InsertStocktakeLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsSupplyRequestedQuantityArgs = {
   input: SupplyRequestedQuantityInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateDisplaySettingsArgs = {
   input: DisplaySettingsInput;
 };
+
 
 export type MutationsUpdateInboundShipmentArgs = {
   input: UpdateInboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateInboundShipmentLineArgs = {
   input: UpdateInboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateInboundShipmentServiceLineArgs = {
   input: UpdateInboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateLocationArgs = {
   input: UpdateLocationInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateOutboundShipmentArgs = {
   input: UpdateOutboundShipmentInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateOutboundShipmentLineArgs = {
   input: UpdateOutboundShipmentLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateOutboundShipmentServiceLineArgs = {
   input: UpdateOutboundShipmentServiceLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateOutboundShipmentUnallocatedLineArgs = {
   input: UpdateOutboundShipmentUnallocatedLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateRequestRequisitionArgs = {
   input: UpdateRequestRequisitionInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateRequestRequisitionLineArgs = {
   input: UpdateRequestRequisitionLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateResponseRequisitionArgs = {
   input: UpdateResponseRequisitionInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateResponseRequisitionLineArgs = {
   input: UpdateResponseRequisitionLineInput;
   storeId: Scalars['String'];
 };
+
 
 export type MutationsUpdateStocktakeArgs = {
   input: UpdateStocktakeInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateStocktakeLineArgs = {
   input: UpdateStocktakeLineInput;
   storeId: Scalars['String'];
 };
 
+
 export type MutationsUpdateSyncSettingsArgs = {
   input: SyncSettingsInput;
 };
+
 
 export type MutationsUseSuggestedQuantityArgs = {
   input: UseSuggestedQuantityInput;
@@ -2061,12 +1919,14 @@ export type NameFilterInput = {
    * if is_visible is set to true and is_system_name is also true no system names will be returned
    */
   isSystemName?: InputMaybe<Scalars['Boolean']>;
-  /** Visibility in current store (based on store_id parameter and existance of name_store_join record) */
+  /** Visibility in current store (based on store_id parameter and existence of name_store_join record) */
   isVisible?: InputMaybe<Scalars['Boolean']>;
   /** Filter by name */
   name?: InputMaybe<SimpleStringFilterInput>;
   /** Code of the store if store is linked to name */
   storeCode?: InputMaybe<SimpleStringFilterInput>;
+  /** Filter by the name type */
+  type?: InputMaybe<EqualFilterTypeInput>;
 };
 
 export type NameNode = {
@@ -2104,12 +1964,12 @@ export enum NameNodeType {
   Others = 'OTHERS',
   Patient = 'PATIENT',
   Repack = 'REPACK',
-  Store = 'STORE',
+  Store = 'STORE'
 }
 
 export enum NameSortFieldInput {
   Code = 'code',
-  Name = 'name',
+  Name = 'name'
 }
 
 export type NameSortInput = {
@@ -2154,44 +2014,32 @@ export type NotAnOutboundShipmentError = UpdateErrorInterface & {
   description: Scalars['String'];
 };
 
-export type NotEnoughStockForReduction =
-  InsertOutboundShipmentLineErrorInterface &
-    UpdateOutboundShipmentLineErrorInterface & {
-      __typename: 'NotEnoughStockForReduction';
-      batch: StockLineResponse;
-      description: Scalars['String'];
-      line?: Maybe<InvoiceLineNode>;
-    };
+export type NotEnoughStockForReduction = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+  __typename: 'NotEnoughStockForReduction';
+  batch: StockLineResponse;
+  description: Scalars['String'];
+  line?: Maybe<InvoiceLineNode>;
+};
 
-export type NothingRemainingToSupply =
-  CreateRequisitionShipmentErrorInterface & {
-    __typename: 'NothingRemainingToSupply';
-    description: Scalars['String'];
-  };
+export type NothingRemainingToSupply = CreateRequisitionShipmentErrorInterface & {
+  __typename: 'NothingRemainingToSupply';
+  description: Scalars['String'];
+};
 
-export type OtherPartyNotACustomer = InsertErrorInterface &
-  UpdateErrorInterface & {
-    __typename: 'OtherPartyNotACustomer';
-    description: Scalars['String'];
-  };
+export type OtherPartyNotACustomer = InsertErrorInterface & UpdateErrorInterface & {
+  __typename: 'OtherPartyNotACustomer';
+  description: Scalars['String'];
+};
 
-export type OtherPartyNotASupplier = InsertInboundShipmentErrorInterface &
-  InsertRequestRequisitionErrorInterface &
-  UpdateInboundShipmentErrorInterface &
-  UpdateRequestRequisitionErrorInterface & {
-    __typename: 'OtherPartyNotASupplier';
-    description: Scalars['String'];
-  };
+export type OtherPartyNotASupplier = InsertInboundShipmentErrorInterface & InsertRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & {
+  __typename: 'OtherPartyNotASupplier';
+  description: Scalars['String'];
+};
 
-export type OtherPartyNotVisible = InsertErrorInterface &
-  InsertInboundShipmentErrorInterface &
-  InsertRequestRequisitionErrorInterface &
-  UpdateErrorInterface &
-  UpdateInboundShipmentErrorInterface &
-  UpdateRequestRequisitionErrorInterface & {
-    __typename: 'OtherPartyNotVisible';
-    description: Scalars['String'];
-  };
+export type OtherPartyNotVisible = InsertErrorInterface & InsertInboundShipmentErrorInterface & InsertRequestRequisitionErrorInterface & UpdateErrorInterface & UpdateInboundShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & {
+  __typename: 'OtherPartyNotVisible';
+  description: Scalars['String'];
+};
 
 export type OutboundInvoiceCounts = {
   __typename: 'OutboundInvoiceCounts';
@@ -2225,7 +2073,7 @@ export type PricingNode = {
 
 export enum PrintFormat {
   Html = 'HTML',
-  Pdf = 'PDF',
+  Pdf = 'PDF'
 }
 
 export type PrintReportError = {
@@ -2305,25 +2153,30 @@ export type Queries = {
   syncSettings?: Maybe<SyncSettingsNode>;
 };
 
+
 export type QueriesActivityLogsArgs = {
   filter?: InputMaybe<ActivityLogFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<ActivityLogSortInput>>;
 };
 
+
 export type QueriesAuthTokenArgs = {
   password: Scalars['String'];
   username: Scalars['String'];
 };
 
+
 export type QueriesDisplaySettingsArgs = {
   input: DisplaySettingsHash;
 };
+
 
 export type QueriesInvoiceArgs = {
   id: Scalars['String'];
   storeId: Scalars['String'];
 };
+
 
 export type QueriesInvoiceByNumberArgs = {
   invoiceNumber: Scalars['Int'];
@@ -2331,10 +2184,12 @@ export type QueriesInvoiceByNumberArgs = {
   type: InvoiceNodeType;
 };
 
+
 export type QueriesInvoiceCountsArgs = {
   storeId: Scalars['String'];
   timezoneOffset?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type QueriesInvoicesArgs = {
   filter?: InputMaybe<InvoiceFilterInput>;
@@ -2343,12 +2198,14 @@ export type QueriesInvoicesArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesItemsArgs = {
   filter?: InputMaybe<ItemFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<ItemSortInput>>;
   storeId: Scalars['String'];
 };
+
 
 export type QueriesLocationsArgs = {
   filter?: InputMaybe<LocationFilterInput>;
@@ -2357,12 +2214,14 @@ export type QueriesLocationsArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesMasterListsArgs = {
   filter?: InputMaybe<MasterListFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<MasterListSortInput>>;
   storeId: Scalars['String'];
 };
+
 
 export type QueriesNamesArgs = {
   filter?: InputMaybe<NameFilterInput>;
@@ -2371,12 +2230,14 @@ export type QueriesNamesArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesPrintReportArgs = {
   dataId: Scalars['String'];
   format?: InputMaybe<PrintFormat>;
   reportId: Scalars['String'];
   storeId: Scalars['String'];
 };
+
 
 export type QueriesPrintReportDefinitionArgs = {
   dataId: Scalars['String'];
@@ -2385,6 +2246,7 @@ export type QueriesPrintReportDefinitionArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesReportsArgs = {
   filter?: InputMaybe<ReportFilterInput>;
   page?: InputMaybe<PaginationInput>;
@@ -2392,16 +2254,19 @@ export type QueriesReportsArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesRequisitionArgs = {
   id: Scalars['String'];
   storeId: Scalars['String'];
 };
+
 
 export type QueriesRequisitionByNumberArgs = {
   requisitionNumber: Scalars['Int'];
   storeId: Scalars['String'];
   type: RequisitionNodeType;
 };
+
 
 export type QueriesRequisitionLineChartArgs = {
   consumptionOptionsInput?: InputMaybe<ConsumptionOptionsInput>;
@@ -2410,6 +2275,7 @@ export type QueriesRequisitionLineChartArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesRequisitionsArgs = {
   filter?: InputMaybe<RequisitionFilterInput>;
   page?: InputMaybe<PaginationInput>;
@@ -2417,21 +2283,25 @@ export type QueriesRequisitionsArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesStockCountsArgs = {
   daysTillExpired?: InputMaybe<Scalars['Int']>;
   storeId: Scalars['String'];
   timezoneOffset?: InputMaybe<Scalars['Int']>;
 };
 
+
 export type QueriesStocktakeArgs = {
   id: Scalars['String'];
   storeId: Scalars['String'];
 };
 
+
 export type QueriesStocktakeByNumberArgs = {
   stocktakeNumber: Scalars['Int'];
   storeId: Scalars['String'];
 };
+
 
 export type QueriesStocktakesArgs = {
   filter?: InputMaybe<StocktakeFilterInput>;
@@ -2440,9 +2310,11 @@ export type QueriesStocktakesArgs = {
   storeId: Scalars['String'];
 };
 
+
 export type QueriesStoreArgs = {
   id: Scalars['String'];
 };
+
 
 export type QueriesStoresArgs = {
   filter?: InputMaybe<StoreFilterInput>;
@@ -2455,46 +2327,15 @@ export type RecordAlreadyExist = InsertLocationErrorInterface & {
   description: Scalars['String'];
 };
 
-export type RecordBelongsToAnotherStore = DeleteLocationErrorInterface &
-  UpdateLocationErrorInterface & {
-    __typename: 'RecordBelongsToAnotherStore';
-    description: Scalars['String'];
-  };
+export type RecordBelongsToAnotherStore = DeleteLocationErrorInterface & UpdateLocationErrorInterface & {
+  __typename: 'RecordBelongsToAnotherStore';
+  description: Scalars['String'];
+};
 
-export type RecordNotFound = AddFromMasterListErrorInterface &
-  AddToInboundShipmentFromMasterListErrorInterface &
-  AddToOutboundShipmentFromMasterListErrorInterface &
-  AllocateOutboundShipmentUnallocatedLineErrorInterface &
-  CreateRequisitionShipmentErrorInterface &
-  DeleteErrorInterface &
-  DeleteInboundShipmentErrorInterface &
-  DeleteInboundShipmentLineErrorInterface &
-  DeleteInboundShipmentServiceLineErrorInterface &
-  DeleteLocationErrorInterface &
-  DeleteOutboundShipmentLineErrorInterface &
-  DeleteOutboundShipmentServiceLineErrorInterface &
-  DeleteOutboundShipmentUnallocatedLineErrorInterface &
-  DeleteRequestRequisitionErrorInterface &
-  DeleteRequestRequisitionLineErrorInterface &
-  NodeErrorInterface &
-  RequisitionLineChartErrorInterface &
-  SupplyRequestedQuantityErrorInterface &
-  UpdateErrorInterface &
-  UpdateInboundShipmentErrorInterface &
-  UpdateInboundShipmentLineErrorInterface &
-  UpdateInboundShipmentServiceLineErrorInterface &
-  UpdateLocationErrorInterface &
-  UpdateOutboundShipmentLineErrorInterface &
-  UpdateOutboundShipmentServiceLineErrorInterface &
-  UpdateOutboundShipmentUnallocatedLineErrorInterface &
-  UpdateRequestRequisitionErrorInterface &
-  UpdateRequestRequisitionLineErrorInterface &
-  UpdateResponseRequisitionErrorInterface &
-  UpdateResponseRequisitionLineErrorInterface &
-  UseSuggestedQuantityErrorInterface & {
-    __typename: 'RecordNotFound';
-    description: Scalars['String'];
-  };
+export type RecordNotFound = AddFromMasterListErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & AllocateOutboundShipmentUnallocatedLineErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & NodeErrorInterface & RequisitionLineChartErrorInterface & SupplyRequestedQuantityErrorInterface & UpdateErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface & {
+  __typename: 'RecordNotFound';
+  description: Scalars['String'];
+};
 
 export type RefreshToken = {
   __typename: 'RefreshToken';
@@ -2524,7 +2365,7 @@ export enum ReportContext {
   OutboundShipment = 'OUTBOUND_SHIPMENT',
   Requisition = 'REQUISITION',
   Resource = 'RESOURCE',
-  Stocktake = 'STOCKTAKE',
+  Stocktake = 'STOCKTAKE'
 }
 
 export type ReportFilterInput = {
@@ -2543,7 +2384,7 @@ export type ReportNode = {
 
 export enum ReportSortFieldInput {
   Id = 'id',
-  Name = 'name',
+  Name = 'name'
 }
 
 export type ReportSortInput = {
@@ -2590,9 +2431,7 @@ export type RequisitionLineChartErrorInterface = {
   description: Scalars['String'];
 };
 
-export type RequisitionLineChartResponse =
-  | ItemChartNode
-  | RequisitionLineChartError;
+export type RequisitionLineChartResponse = ItemChartNode | RequisitionLineChartError;
 
 export type RequisitionLineConnector = {
   __typename: 'RequisitionLineConnector';
@@ -2633,15 +2472,15 @@ export type RequisitionLineNode = {
   supplyQuantity: Scalars['Int'];
 };
 
+
 export type RequisitionLineNodeItemStatsArgs = {
   amcLookbackMonths?: InputMaybe<Scalars['Int']>;
 };
 
-export type RequisitionLineWithItemIdExists =
-  InsertRequestRequisitionLineErrorInterface & {
-    __typename: 'RequisitionLineWithItemIdExists';
-    description: Scalars['String'];
-  };
+export type RequisitionLineWithItemIdExists = InsertRequestRequisitionLineErrorInterface & {
+  __typename: 'RequisitionLineWithItemIdExists';
+  description: Scalars['String'];
+};
 
 export type RequisitionNode = {
   __typename: 'RequisitionNode';
@@ -2689,6 +2528,7 @@ export type RequisitionNode = {
   user?: Maybe<UserNode>;
 };
 
+
 export type RequisitionNodeOtherPartyArgs = {
   storeId: Scalars['String'];
 };
@@ -2697,12 +2537,12 @@ export enum RequisitionNodeStatus {
   Draft = 'DRAFT',
   Finalised = 'FINALISED',
   New = 'NEW',
-  Sent = 'SENT',
+  Sent = 'SENT'
 }
 
 export enum RequisitionNodeType {
   Request = 'REQUEST',
-  Response = 'RESPONSE',
+  Response = 'RESPONSE'
 }
 
 export type RequisitionResponse = RecordNotFound | RequisitionNode;
@@ -2717,7 +2557,7 @@ export enum RequisitionSortFieldInput {
   SentDatetime = 'sentDatetime',
   Status = 'status',
   TheirReference = 'theirReference',
-  Type = 'type',
+  Type = 'type'
 }
 
 export type RequisitionSortInput = {
@@ -2739,12 +2579,11 @@ export type SimpleStringFilterInput = {
   like?: InputMaybe<Scalars['String']>;
 };
 
-export type SnapshotCountCurrentCountMismatch =
-  UpdateStocktakeErrorInterface & {
-    __typename: 'SnapshotCountCurrentCountMismatch';
-    description: Scalars['String'];
-    lines: StocktakeLineConnector;
-  };
+export type SnapshotCountCurrentCountMismatch = UpdateStocktakeErrorInterface & {
+  __typename: 'SnapshotCountCurrentCountMismatch';
+  description: Scalars['String'];
+  lines: StocktakeLineConnector;
+};
 
 export type StockCounts = {
   __typename: 'StockCounts';
@@ -2775,13 +2614,11 @@ export type StockEvolutionOptionsInput = {
   numberOfProjectedDataPoints?: InputMaybe<Scalars['Int']>;
 };
 
-export type StockLineAlreadyExistsInInvoice =
-  InsertOutboundShipmentLineErrorInterface &
-    UpdateOutboundShipmentLineErrorInterface & {
-      __typename: 'StockLineAlreadyExistsInInvoice';
-      description: Scalars['String'];
-      line: InvoiceLineNode;
-    };
+export type StockLineAlreadyExistsInInvoice = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+  __typename: 'StockLineAlreadyExistsInInvoice';
+  description: Scalars['String'];
+  line: InvoiceLineNode;
+};
 
 export type StockLineConnector = {
   __typename: 'StockLineConnector';
@@ -2789,11 +2626,10 @@ export type StockLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type StockLineIsOnHold = InsertOutboundShipmentLineErrorInterface &
-  UpdateOutboundShipmentLineErrorInterface & {
-    __typename: 'StockLineIsOnHold';
-    description: Scalars['String'];
-  };
+export type StockLineIsOnHold = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+  __typename: 'StockLineIsOnHold';
+  description: Scalars['String'];
+};
 
 export type StockLineNode = {
   __typename: 'StockLineNode';
@@ -2888,7 +2724,7 @@ export type StocktakeNode = {
 
 export enum StocktakeNodeStatus {
   Finalised = 'FINALISED',
-  New = 'NEW',
+  New = 'NEW'
 }
 
 export type StocktakeResponse = NodeError | StocktakeNode;
@@ -2900,7 +2736,7 @@ export enum StocktakeSortFieldInput {
   FinalisedDatetime = 'finalisedDatetime',
   Status = 'status',
   StocktakeDate = 'stocktakeDate',
-  StocktakeNumber = 'stocktakeNumber',
+  StocktakeNumber = 'stocktakeNumber'
 }
 
 export type StocktakeSortInput = {
@@ -2938,6 +2774,7 @@ export type StoreNode = {
   storeName: Scalars['String'];
 };
 
+
 export type StoreNodeNameArgs = {
   storeId: Scalars['String'];
 };
@@ -2947,7 +2784,7 @@ export type StoreResponse = NodeError | StoreNode;
 export enum StoreSortFieldInput {
   Code = 'code',
   Name = 'name',
-  NameCode = 'nameCode',
+  NameCode = 'nameCode'
 }
 
 export type StoreSortInput = {
@@ -2984,9 +2821,7 @@ export type SupplyRequestedQuantityInput = {
   responseRequisitionId: Scalars['String'];
 };
 
-export type SupplyRequestedQuantityResponse =
-  | RequisitionLineConnector
-  | SupplyRequestedQuantityError;
+export type SupplyRequestedQuantityResponse = RequisitionLineConnector | SupplyRequestedQuantityError;
 
 export type SyncErrorNode = {
   __typename: 'SyncErrorNode';
@@ -3004,7 +2839,7 @@ export enum SyncErrorVariant {
   SiteHasNoStore = 'SITE_HAS_NO_STORE',
   SiteNameNotFound = 'SITE_NAME_NOT_FOUND',
   SiteUuidIsBeingChanged = 'SITE_UUID_IS_BEING_CHANGED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type SyncSettingsInput = {
@@ -3050,37 +2885,32 @@ export type TokenExpired = RefreshTokenErrorInterface & {
   description: Scalars['String'];
 };
 
-export type UnallocatedLineForItemAlreadyExists =
-  InsertOutboundShipmentUnallocatedLineErrorInterface & {
-    __typename: 'UnallocatedLineForItemAlreadyExists';
-    description: Scalars['String'];
-  };
+export type UnallocatedLineForItemAlreadyExists = InsertOutboundShipmentUnallocatedLineErrorInterface & {
+  __typename: 'UnallocatedLineForItemAlreadyExists';
+  description: Scalars['String'];
+};
 
-export type UnallocatedLinesOnlyEditableInNewInvoice =
-  InsertOutboundShipmentUnallocatedLineErrorInterface & {
-    __typename: 'UnallocatedLinesOnlyEditableInNewInvoice';
-    description: Scalars['String'];
-  };
+export type UnallocatedLinesOnlyEditableInNewInvoice = InsertOutboundShipmentUnallocatedLineErrorInterface & {
+  __typename: 'UnallocatedLinesOnlyEditableInNewInvoice';
+  description: Scalars['String'];
+};
 
 export enum UniqueValueKey {
-  Code = 'code',
+  Code = 'code'
 }
 
-export type UniqueValueViolation = InsertLocationErrorInterface &
-  UpdateLocationErrorInterface & {
-    __typename: 'UniqueValueViolation';
-    description: Scalars['String'];
-    field: UniqueValueKey;
-  };
+export type UniqueValueViolation = InsertLocationErrorInterface & UpdateLocationErrorInterface & {
+  __typename: 'UniqueValueViolation';
+  description: Scalars['String'];
+  field: UniqueValueKey;
+};
 
 export type UpdateDisplaySettingsError = {
   __typename: 'UpdateDisplaySettingsError';
   error: Scalars['String'];
 };
 
-export type UpdateDisplaySettingsResponse =
-  | UpdateDisplaySettingsError
-  | UpdateResult;
+export type UpdateDisplaySettingsResponse = UpdateDisplaySettingsError | UpdateResult;
 
 export type UpdateErrorInterface = {
   description: Scalars['String'];
@@ -3128,9 +2958,7 @@ export type UpdateInboundShipmentLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type UpdateInboundShipmentLineResponse =
-  | InvoiceLineNode
-  | UpdateInboundShipmentLineError;
+export type UpdateInboundShipmentLineResponse = InvoiceLineNode | UpdateInboundShipmentLineError;
 
 export type UpdateInboundShipmentLineResponseWithId = {
   __typename: 'UpdateInboundShipmentLineResponseWithId';
@@ -3138,9 +2966,7 @@ export type UpdateInboundShipmentLineResponseWithId = {
   response: UpdateInboundShipmentLineResponse;
 };
 
-export type UpdateInboundShipmentResponse =
-  | InvoiceNode
-  | UpdateInboundShipmentError;
+export type UpdateInboundShipmentResponse = InvoiceNode | UpdateInboundShipmentError;
 
 export type UpdateInboundShipmentResponseWithId = {
   __typename: 'UpdateInboundShipmentResponseWithId';
@@ -3166,9 +2992,7 @@ export type UpdateInboundShipmentServiceLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type UpdateInboundShipmentServiceLineResponse =
-  | InvoiceLineNode
-  | UpdateInboundShipmentServiceLineError;
+export type UpdateInboundShipmentServiceLineResponse = InvoiceLineNode | UpdateInboundShipmentServiceLineError;
 
 export type UpdateInboundShipmentServiceLineResponseWithId = {
   __typename: 'UpdateInboundShipmentServiceLineResponseWithId';
@@ -3178,7 +3002,7 @@ export type UpdateInboundShipmentServiceLineResponseWithId = {
 
 export enum UpdateInboundShipmentStatusInput {
   Delivered = 'DELIVERED',
-  Verified = 'VERIFIED',
+  Verified = 'VERIFIED'
 }
 
 export type UpdateLocationError = {
@@ -3243,9 +3067,7 @@ export type UpdateOutboundShipmentLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type UpdateOutboundShipmentLineResponse =
-  | InvoiceLineNode
-  | UpdateOutboundShipmentLineError;
+export type UpdateOutboundShipmentLineResponse = InvoiceLineNode | UpdateOutboundShipmentLineError;
 
 export type UpdateOutboundShipmentLineResponseWithId = {
   __typename: 'UpdateOutboundShipmentLineResponseWithId';
@@ -3253,10 +3075,7 @@ export type UpdateOutboundShipmentLineResponseWithId = {
   response: UpdateOutboundShipmentLineResponse;
 };
 
-export type UpdateOutboundShipmentResponse =
-  | InvoiceNode
-  | NodeError
-  | UpdateOutboundShipmentError;
+export type UpdateOutboundShipmentResponse = InvoiceNode | NodeError | UpdateOutboundShipmentError;
 
 export type UpdateOutboundShipmentResponseWithId = {
   __typename: 'UpdateOutboundShipmentResponseWithId';
@@ -3282,9 +3101,7 @@ export type UpdateOutboundShipmentServiceLineInput = {
   totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
-export type UpdateOutboundShipmentServiceLineResponse =
-  | InvoiceLineNode
-  | UpdateOutboundShipmentServiceLineError;
+export type UpdateOutboundShipmentServiceLineResponse = InvoiceLineNode | UpdateOutboundShipmentServiceLineError;
 
 export type UpdateOutboundShipmentServiceLineResponseWithId = {
   __typename: 'UpdateOutboundShipmentServiceLineResponseWithId';
@@ -3295,7 +3112,7 @@ export type UpdateOutboundShipmentServiceLineResponseWithId = {
 export enum UpdateOutboundShipmentStatusInput {
   Allocated = 'ALLOCATED',
   Picked = 'PICKED',
-  Shipped = 'SHIPPED',
+  Shipped = 'SHIPPED'
 }
 
 export type UpdateOutboundShipmentUnallocatedLineError = {
@@ -3312,9 +3129,7 @@ export type UpdateOutboundShipmentUnallocatedLineInput = {
   quantity: Scalars['Int'];
 };
 
-export type UpdateOutboundShipmentUnallocatedLineResponse =
-  | InvoiceLineNode
-  | UpdateOutboundShipmentUnallocatedLineError;
+export type UpdateOutboundShipmentUnallocatedLineResponse = InvoiceLineNode | UpdateOutboundShipmentUnallocatedLineError;
 
 export type UpdateOutboundShipmentUnallocatedLineResponseWithId = {
   __typename: 'UpdateOutboundShipmentUnallocatedLineResponseWithId';
@@ -3358,9 +3173,7 @@ export type UpdateRequestRequisitionLineInput = {
   requestedQuantity?: InputMaybe<Scalars['Int']>;
 };
 
-export type UpdateRequestRequisitionLineResponse =
-  | RequisitionLineNode
-  | UpdateRequestRequisitionLineError;
+export type UpdateRequestRequisitionLineResponse = RequisitionLineNode | UpdateRequestRequisitionLineError;
 
 export type UpdateRequestRequisitionLineResponseWithId = {
   __typename: 'UpdateRequestRequisitionLineResponseWithId';
@@ -3368,9 +3181,7 @@ export type UpdateRequestRequisitionLineResponseWithId = {
   response: UpdateRequestRequisitionLineResponse;
 };
 
-export type UpdateRequestRequisitionResponse =
-  | RequisitionNode
-  | UpdateRequestRequisitionError;
+export type UpdateRequestRequisitionResponse = RequisitionNode | UpdateRequestRequisitionError;
 
 export type UpdateRequestRequisitionResponseWithId = {
   __typename: 'UpdateRequestRequisitionResponseWithId';
@@ -3379,7 +3190,7 @@ export type UpdateRequestRequisitionResponseWithId = {
 };
 
 export enum UpdateRequestRequisitionStatusInput {
-  Sent = 'SENT',
+  Sent = 'SENT'
 }
 
 export type UpdateResponseRequisitionError = {
@@ -3414,16 +3225,12 @@ export type UpdateResponseRequisitionLineInput = {
   supplyQuantity?: InputMaybe<Scalars['Int']>;
 };
 
-export type UpdateResponseRequisitionLineResponse =
-  | RequisitionLineNode
-  | UpdateResponseRequisitionLineError;
+export type UpdateResponseRequisitionLineResponse = RequisitionLineNode | UpdateResponseRequisitionLineError;
 
-export type UpdateResponseRequisitionResponse =
-  | RequisitionNode
-  | UpdateResponseRequisitionError;
+export type UpdateResponseRequisitionResponse = RequisitionNode | UpdateResponseRequisitionError;
 
 export enum UpdateResponseRequisitionStatusInput {
-  Finalised = 'FINALISED',
+  Finalised = 'FINALISED'
 }
 
 export type UpdateResult = {
@@ -3473,9 +3280,7 @@ export type UpdateStocktakeLineInput = {
   snapshotNumberOfPacks?: InputMaybe<Scalars['Float']>;
 };
 
-export type UpdateStocktakeLineResponse =
-  | StocktakeLineNode
-  | UpdateStocktakeLineError;
+export type UpdateStocktakeLineResponse = StocktakeLineNode | UpdateStocktakeLineError;
 
 export type UpdateStocktakeLineResponseWithId = {
   __typename: 'UpdateStocktakeLineResponseWithId';
@@ -3492,7 +3297,7 @@ export type UpdateStocktakeResponseWithId = {
 };
 
 export enum UpdateStocktakeStatusInput {
-  Finalised = 'FINALISED',
+  Finalised = 'FINALISED'
 }
 
 export type UpdateSyncSettingsResponse = SyncErrorNode | SyncSettingsNode;
@@ -3510,9 +3315,7 @@ export type UseSuggestedQuantityInput = {
   requestRequisitionId: Scalars['String'];
 };
 
-export type UseSuggestedQuantityResponse =
-  | RequisitionLineConnector
-  | UseSuggestedQuantityError;
+export type UseSuggestedQuantityResponse = RequisitionLineConnector | UseSuggestedQuantityError;
 
 export type UserNode = {
   __typename: 'UserNode';
@@ -3526,6 +3329,7 @@ export type UserNode = {
   userId: Scalars['String'];
   username: Scalars['String'];
 };
+
 
 export type UserNodePermissionsArgs = {
   storeId?: InputMaybe<Scalars['String']>;
@@ -3545,7 +3349,7 @@ export enum UserPermission {
   StocktakeMutate = 'STOCKTAKE_MUTATE',
   StocktakeQuery = 'STOCKTAKE_QUERY',
   StockLineQuery = 'STOCK_LINE_QUERY',
-  StoreAccess = 'STORE_ACCESS',
+  StoreAccess = 'STORE_ACCESS'
 }
 
 export type UserResponse = UserNode;

--- a/client/packages/host/src/CommandK.tsx
+++ b/client/packages/host/src/CommandK.tsx
@@ -158,7 +158,8 @@ export const CommandK: FC<PropsWithChildrenOnly> = ({ children }) => {
     },
     {
       id: 'navigation:internal-order',
-      name: `${t('cmdk.goto-internal-order')}`,
+      name: `${t('cmdk.goto-internal-order')} (g+o)`,
+      shortcut: ['g', 'o'],
       keywords: 'replenishment',
       perform: () =>
         navigate(
@@ -181,7 +182,8 @@ export const CommandK: FC<PropsWithChildrenOnly> = ({ children }) => {
     },
     {
       id: 'navigation:stock',
-      name: t('cmdk.goto-stock'),
+      name: `${t('cmdk.goto-stock')} (s)`,
+      shortcut: ['s'],
       keywords: 'stock',
       perform: () =>
         navigate(
@@ -192,7 +194,8 @@ export const CommandK: FC<PropsWithChildrenOnly> = ({ children }) => {
     },
     {
       id: 'navigation:stocktakes',
-      name: t('cmdk.goto-stocktakes'),
+      name: `${t('cmdk.goto-stocktakes')} (g+t)`,
+      shortcut: ['g', 't'],
       keywords: 'stocktakes',
       perform: () =>
         navigate(

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -2,7 +2,6 @@ import {
   AlertIcon,
   AppNavLink,
   RadioIcon,
-  Tooltip,
   useTheme,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -28,13 +27,11 @@ export const SyncNavLink = () => {
   if (syncStatus && syncStatus.error) {
     badgeProps.color = 'default';
     badgeProps.badgeContent = (
-      <Tooltip title={'syncStatus?.error?.fullError'}>
-        <AlertIcon
-          color="error"
-          fontSize="small"
-          fill={theme.palette.background.drawer}
-        />
-      </Tooltip>
+      <AlertIcon
+        color="error"
+        fontSize="small"
+        fill={theme.palette.background.drawer}
+      />
     );
   }
   return (

--- a/client/packages/host/src/components/Sync/Sync.tsx
+++ b/client/packages/host/src/components/Sync/Sync.tsx
@@ -87,7 +87,7 @@ export const Sync: React.FC = () => {
           {t('heading.synchronise-status')}
         </Typography>
         <Row title={t('sync-info.number-to-push')}>
-          {numberOfRecordsInPushQueue}
+          <Typography>{numberOfRecordsInPushQueue}</Typography>
         </Row>
         <Row title={t('sync-info.last-sync')}>{formattedLatestSyncDate}</Row>
         <Row>
@@ -118,7 +118,7 @@ const Row: React.FC<PropsWithChildren<RowProps>> = ({ title, children }) => (
       <Typography fontWeight={700}>{title}</Typography>
     </Grid>
     <Grid item flex={1}>
-      <Typography>{children}</Typography>
+      {children}
     </Grid>
   </Grid>
 );

--- a/client/packages/system/src/Name/api/api.ts
+++ b/client/packages/system/src/Name/api/api.ts
@@ -1,4 +1,8 @@
-import { SortBy, NameSortFieldInput } from '@openmsupply-client/common';
+import {
+  SortBy,
+  NameSortFieldInput,
+  NameNodeType,
+} from '@openmsupply-client/common';
 import { Sdk, NameRowFragment } from './operations.generated';
 
 export type ListParams = {
@@ -49,7 +53,10 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         key,
         desc: !!sortBy?.isDesc,
         storeId,
-        filter: { isSupplier: true },
+        filter: {
+          isSupplier: true,
+          type: { equalAny: [NameNodeType.Facility, NameNodeType.Store] },
+        },
         first: 1000,
       });
 
@@ -62,7 +69,10 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         key,
         desc: !!sortBy?.isDesc,
         storeId,
-        filter: { isCustomer: true },
+        filter: {
+          isCustomer: true,
+          type: { equalAny: [NameNodeType.Facility, NameNodeType.Store] },
+        },
         first: 1000,
       });
 
@@ -91,6 +101,7 @@ export const getNameQueries = (sdk: Sdk, storeId: string) => ({
         storeId,
         filter: {
           [type === 'customer' ? 'isCustomer' : 'isSupplier']: true,
+          type: { equalAny: [NameNodeType.Facility, NameNodeType.Store] },
         },
       });
 

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -9,7 +9,7 @@ mod graphql {
             mock_name_a, mock_name_linked_to_store, mock_name_not_linked_to_store,
             mock_store_linked_to_name, MockDataInserts,
         },
-        EqualFilter, Name, NameFilter, NameSort, NameSortField, PaginationOption,
+        EqualFilter, Name, NameFilter, NameSort, NameSortField, NameType, PaginationOption,
         SimpleStringFilter, StorageConnectionManager,
     };
     use serde_json::json;
@@ -162,7 +162,7 @@ mod graphql {
                 store_code,
                 is_visible,
                 is_system_name,
-                r#type: _,
+                r#type,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
@@ -177,10 +177,10 @@ mod graphql {
             );
             assert_eq!(is_visible, Some(false));
             assert_eq!(is_system_name, Some(true));
-            // assert_eq!(
-            //     r#type,
-            //     Some(EqualFilter::equal_to(NameType::Store))
-            // );
+            assert_eq!(
+                r#type,
+                Some(EqualFilter::equal_to_name_type(&NameType::Store))
+            );
 
             Ok(ListResult {
                 rows: vec![Name {

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -121,7 +121,8 @@ mod graphql {
               "like": "store code like"
             },
             "isVisible": false,
-            "isSystemName": true
+            "isSystemName": true,
+            "type": { "equalTo": "STORE" },
           }
         });
 
@@ -161,6 +162,7 @@ mod graphql {
                 store_code,
                 is_visible,
                 is_system_name,
+                r#type: _,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
@@ -175,6 +177,10 @@ mod graphql {
             );
             assert_eq!(is_visible, Some(false));
             assert_eq!(is_system_name, Some(true));
+            // assert_eq!(
+            //     r#type,
+            //     Some(EqualFilter::equal_to(NameType::Store))
+            // );
 
             Ok(ListResult {
                 rows: vec![Name {

--- a/server/graphql/types/src/types/name.rs
+++ b/server/graphql/types/src/types/name.rs
@@ -31,6 +31,17 @@ impl NameNodeType {
             NameType::Others => NameNodeType::Others,
         }
     }
+    pub fn to_domain(self) -> NameType {
+        match self {
+            NameNodeType::Facility => NameType::Facility,
+            NameNodeType::Patient => NameType::Patient,
+            NameNodeType::Build => NameType::Build,
+            NameNodeType::Invad => NameType::Invad,
+            NameNodeType::Repack => NameType::Repack,
+            NameNodeType::Store => NameType::Store,
+            NameNodeType::Others => NameType::Others,
+        }
+    }
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
     repository_error::RepositoryError,
-    EqualFilter, Pagination, SimpleStringFilter, Sort,
+    EqualFilter, NameType, Pagination, SimpleStringFilter, Sort,
 };
 
 use diesel::{
@@ -36,6 +36,7 @@ pub struct NameFilter {
     pub store_code: Option<SimpleStringFilter>,
     pub is_visible: Option<bool>,
     pub is_system_name: Option<bool>,
+    pub r#type: Option<EqualFilter<NameType>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -166,12 +167,14 @@ fn create_filtered_query(store_id: String, filter: Option<NameFilter>) -> BoxedN
             store_code,
             is_visible,
             is_system_name,
+            r#type,
         } = f;
 
         apply_equal_filter!(query, id, name_dsl::id);
         apply_simple_string_filter!(query, code, name_dsl::code);
         apply_simple_string_filter!(query, name, name_dsl::name_);
         apply_simple_string_filter!(query, store_code, store_dsl::code);
+        apply_equal_filter!(query, r#type, name_dsl::type_);
 
         if let Some(is_customer) = is_customer {
             query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
@@ -249,6 +252,11 @@ impl NameFilter {
 
     pub fn is_customer(mut self, value: bool) -> Self {
         self.is_customer = Some(value);
+        self
+    }
+
+    pub fn r#type(mut self, filter: EqualFilter<NameType>) -> Self {
+        self.r#type = Some(filter);
         self
     }
 }

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -16,7 +16,7 @@ use diesel::{
     prelude::*,
     query_source::joins::OnClauseWrapper,
 };
-use util::constants::SYSTEM_NAME_CODES;
+use util::{constants::SYSTEM_NAME_CODES, inline_init};
 
 #[derive(PartialEq, Debug, Clone, Default)]
 pub struct Name {
@@ -37,6 +37,12 @@ pub struct NameFilter {
     pub is_visible: Option<bool>,
     pub is_system_name: Option<bool>,
     pub r#type: Option<EqualFilter<NameType>>,
+}
+
+impl EqualFilter<NameType> {
+    pub fn equal_to_name_type(value: &NameType) -> Self {
+        inline_init(|r: &mut Self| r.equal_to = Some(value.to_owned()))
+    }
 }
 
 #[derive(PartialEq, Debug)]

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -137,7 +137,7 @@ type BatchInboundShipmentResponse {
 	updateInboundShipments: [UpdateInboundShipmentResponseWithId!]
 	deleteInboundShipments: [DeleteInboundShipmentResponseWithId!]
 }
-type BatchIsReserved implements DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface {
+type BatchIsReserved implements UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface {
 	description: String!
 }
 input BatchOutboundShipmentInput {
@@ -209,26 +209,26 @@ type CanOnlyChangeToAllocatedWhenNoUnallocatedLines implements UpdateErrorInterf
 	description: String!
 	invoiceLines: InvoiceLineConnector!
 }
-type CannotChangeStatusOfInvoiceOnHold implements UpdateInboundShipmentErrorInterface & UpdateErrorInterface {
+type CannotChangeStatusOfInvoiceOnHold implements UpdateErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 }
-type CannotDeleteInvoiceWithLines implements DeleteErrorInterface & DeleteInboundShipmentErrorInterface {
+type CannotDeleteInvoiceWithLines implements DeleteInboundShipmentErrorInterface & DeleteErrorInterface {
 	description: String!
 	lines: InvoiceLineConnector!
 }
 type CannotDeleteRequisitionWithLines implements DeleteRequestRequisitionErrorInterface {
 	description: String!
 }
-type CannotEditInvoice implements DeleteInboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface {
+type CannotEditInvoice implements DeleteErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & UpdateInboundShipmentLineErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface {
 	description: String!
 }
-type CannotEditRequisition implements UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & AddFromMasterListErrorInterface & UpdateRequestRequisitionErrorInterface & InsertRequestRequisitionLineErrorInterface & CreateRequisitionShipmentErrorInterface & UpdateRequestRequisitionLineErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface & SupplyRequestedQuantityErrorInterface {
+type CannotEditRequisition implements CreateRequisitionShipmentErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & DeleteRequestRequisitionLineErrorInterface & DeleteRequestRequisitionErrorInterface & UseSuggestedQuantityErrorInterface & UpdateRequestRequisitionErrorInterface & AddFromMasterListErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & SupplyRequestedQuantityErrorInterface {
 	description: String!
 }
-type CannotEditStocktake implements UpdateStocktakeLineErrorInterface & InsertStocktakeLineErrorInterface & DeleteStocktakeLineErrorInterface & UpdateStocktakeErrorInterface & DeleteStocktakeErrorInterface {
+type CannotEditStocktake implements UpdateStocktakeErrorInterface & InsertStocktakeLineErrorInterface & DeleteStocktakeErrorInterface & UpdateStocktakeLineErrorInterface & DeleteStocktakeLineErrorInterface {
 	description: String!
 }
-type CannotReverseInvoiceStatus implements UpdateInboundShipmentErrorInterface & UpdateErrorInterface {
+type CannotReverseInvoiceStatus implements UpdateErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 }
 type ConsumptionHistoryConnector {
@@ -262,7 +262,7 @@ input CreateRequisitionShipmentInput {
 	responseRequisitionId: String!
 }
 union CreateRequisitionShipmentResponse = | CreateRequisitionShipmentError | InvoiceNode
-type DatabaseError implements RefreshTokenErrorInterface & UpdateLocationErrorInterface & NodeErrorInterface & DeleteLocationErrorInterface & InsertLocationErrorInterface {
+type DatabaseError implements NodeErrorInterface & UpdateLocationErrorInterface & RefreshTokenErrorInterface & InsertLocationErrorInterface & DeleteLocationErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -517,6 +517,11 @@ input EqualFilterStringInput {
 	equalAny: [String!]
 	notEqualTo: String
 }
+input EqualFilterTypeInput {
+	equalTo: NameNodeType
+	equalAny: [NameNodeType!]
+	notEqualTo: NameNodeType
+}
 type FailedToFetchReportData implements PrintReportErrorInterface {
 	description: String!
 	errors: JSON!
@@ -529,7 +534,7 @@ enum ForeignKey {
 	locationId
 	requisitionId
 }
-type ForeignKeyError implements UpdateOutboundShipmentUnallocatedLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertRequestRequisitionLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface {
+type ForeignKeyError implements InsertOutboundShipmentUnallocatedLineErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface {
 	description: String!
 	key: ForeignKey!
 }
@@ -803,7 +808,7 @@ type InsertStocktakeResponseWithId {
 	id: String!
 	response: InsertStocktakeResponse!
 }
-type InternalError implements RefreshTokenErrorInterface & UpdateLocationErrorInterface & InsertLocationErrorInterface {
+type InternalError implements UpdateLocationErrorInterface & InsertLocationErrorInterface & RefreshTokenErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -1040,7 +1045,7 @@ enum LanguageType {
 	ENGLISH
 	FRENCH
 	SPANISH
-	LATIN
+	LAOS
 	KHMER
 	PORTUGUESE
 	RUSSIAN
@@ -1060,7 +1065,7 @@ type LocationInUse implements DeleteLocationErrorInterface {
 	stockLines: StockLineConnector!
 	invoiceLines: InvoiceLineConnector!
 }
-type LocationIsOnHold implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
+type LocationIsOnHold implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
 }
 type LocationNode {
@@ -1070,7 +1075,7 @@ type LocationNode {
 	onHold: Boolean!
 	stock: StockLineConnector!
 }
-type LocationNotFound implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
+type LocationNotFound implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
 }
 enum LocationSortFieldInput {
@@ -1128,7 +1133,7 @@ type MasterListNode {
 type MasterListNotFoundForThisName implements AddToOutboundShipmentFromMasterListErrorInterface {
 	description: String!
 }
-type MasterListNotFoundForThisStore implements AddToInboundShipmentFromMasterListErrorInterface & AddFromMasterListErrorInterface {
+type MasterListNotFoundForThisStore implements AddFromMasterListErrorInterface & AddToInboundShipmentFromMasterListErrorInterface {
 	description: String!
 }
 enum MasterListSortFieldInput {
@@ -1270,7 +1275,7 @@ input NameFilterInput {
 	"""
 	storeCode: SimpleStringFilterInput
 	"""
-	Visibility in current store (based on store_id parameter and existance of name_store_join record)
+	Visibility in current store (based on store_id parameter and existence of name_store_join record)
 	"""
 	isVisible: Boolean
 	"""
@@ -1279,6 +1284,10 @@ System names don't have name_store_join thus if queried with true filter, is_vis
 if is_visible is set to true and is_system_name is also true no system names will be returned
 	"""
 	isSystemName: Boolean
+	"""
+	Filter by the name type
+	"""
+	type: EqualFilterTypeInput
 }
 type NameNode {
 	id: String!
@@ -1352,7 +1361,7 @@ type NotAnInboundShipment implements UpdateInboundShipmentLineErrorInterface {
 type NotAnOutboundShipmentError implements UpdateErrorInterface {
 	description: String!
 }
-type NotEnoughStockForReduction implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
+type NotEnoughStockForReduction implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
 	description: String!
 	line: InvoiceLineNode
 	batch: StockLineResponse!
@@ -1360,13 +1369,13 @@ type NotEnoughStockForReduction implements InsertOutboundShipmentLineErrorInterf
 type NothingRemainingToSupply implements CreateRequisitionShipmentErrorInterface {
 	description: String!
 }
-type OtherPartyNotACustomer implements UpdateErrorInterface & InsertErrorInterface {
+type OtherPartyNotACustomer implements InsertErrorInterface & UpdateErrorInterface {
 	description: String!
 }
-type OtherPartyNotASupplier implements InsertRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & InsertInboundShipmentErrorInterface {
+type OtherPartyNotASupplier implements InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & InsertRequestRequisitionErrorInterface {
 	description: String!
 }
-type OtherPartyNotVisible implements InsertErrorInterface & InsertRequestRequisitionErrorInterface & UpdateErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateInboundShipmentErrorInterface & InsertInboundShipmentErrorInterface {
+type OtherPartyNotVisible implements InsertErrorInterface & InsertRequestRequisitionErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateErrorInterface & InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 }
 type OutboundInvoiceCounts {
@@ -1491,7 +1500,7 @@ type RecordAlreadyExist implements InsertLocationErrorInterface {
 type RecordBelongsToAnotherStore implements DeleteLocationErrorInterface & UpdateLocationErrorInterface {
 	description: String!
 }
-type RecordNotFound implements UseSuggestedQuantityErrorInterface & UpdateResponseRequisitionErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateErrorInterface & DeleteInboundShipmentErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateLocationErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & DeleteRequestRequisitionErrorInterface & AddFromMasterListErrorInterface & UpdateInboundShipmentErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteLocationErrorInterface & DeleteErrorInterface & RequisitionLineChartErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & SupplyRequestedQuantityErrorInterface & AllocateOutboundShipmentUnallocatedLineErrorInterface & DeleteRequestRequisitionLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & NodeErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateRequestRequisitionErrorInterface {
+type RecordNotFound implements DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UseSuggestedQuantityErrorInterface & CreateRequisitionShipmentErrorInterface & AddToInboundShipmentFromMasterListErrorInterface & UpdateLocationErrorInterface & AddToOutboundShipmentFromMasterListErrorInterface & DeleteInboundShipmentErrorInterface & UpdateResponseRequisitionLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & SupplyRequestedQuantityErrorInterface & AllocateOutboundShipmentUnallocatedLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteRequestRequisitionErrorInterface & AddFromMasterListErrorInterface & DeleteInboundShipmentServiceLineErrorInterface & UpdateInboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & NodeErrorInterface & UpdateRequestRequisitionErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & RequisitionLineChartErrorInterface & DeleteErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteRequestRequisitionLineErrorInterface {
 	description: String!
 }
 type RefreshToken {
@@ -1747,7 +1756,7 @@ input StockEvolutionOptionsInput {
 	"""
 	numberOfProjectedDataPoints: Int
 }
-type StockLineAlreadyExistsInInvoice implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
+type StockLineAlreadyExistsInInvoice implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
 	line: InvoiceLineNode!
 }
@@ -1755,7 +1764,7 @@ type StockLineConnector {
 	totalCount: Int!
 	nodes: [StockLineNode!]!
 }
-type StockLineIsOnHold implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
+type StockLineIsOnHold implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
 	description: String!
 }
 type StockLineNode {
@@ -1986,7 +1995,7 @@ type UnallocatedLinesOnlyEditableInNewInvoice implements InsertOutboundShipmentU
 enum UniqueValueKey {
 	code
 }
-type UniqueValueViolation implements UpdateLocationErrorInterface & InsertLocationErrorInterface {
+type UniqueValueViolation implements InsertLocationErrorInterface & UpdateLocationErrorInterface {
 	description: String!
 	field: UniqueValueKey!
 }


### PR DESCRIPTION
Closes #756 

The outbound shipments allow zero stock quantity lines, so that you can specify placeholder rows. So that one should remain. Couldn't repro the tab issue - for me, the `Details` is underlined.

Also have removed two console errors that have popped in:

```Failed prop type: Invalid prop `children` supplied to `ForwardRef(Tooltip)`. Expected an element that can hold a ref. Did you accidentally use a plain function component for an element instead?```

and another one about invalid DOM nesting

### Testing
- [ ] Shortcuts for stock (s), stocktake (g+s) and internal orders (g+o)
- [ ] The customer list shows only facilities and stores
- [ ] The supplier list shows only facilities and stores
- [ ] The customer select input and the customer modal show only facilities and stores
- [ ] The supplier select input and the customer modal show only facilities and stores
- [ ] no more console errors shown ( one on every page and one on sync page )