### PR TITLE
Extend PermissionDSL to be able to describe dynamic permissions

### DIFF
--- a/server/graphql/programs/src/mutations/delete_document.rs
+++ b/server/graphql/programs/src/mutations/delete_document.rs
@@ -2,8 +2,7 @@ use async_graphql::*;
 use graphql_core::standard_graphql_error::StandardGraphqlError;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use graphql_types::types::DeleteResponse as GenericDeleteResponse;
-use repository::Permission;
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 use service::document::document_service::{DocumentDelete, DocumentDeleteError};
 
 #[derive(InputObject)]
@@ -29,7 +28,7 @@ pub fn delete_document(
             store_id: Some(store_id),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/mutations/encounter/insert.rs
+++ b/server/graphql/programs/src/mutations/encounter/insert.rs
@@ -3,9 +3,9 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::{EncounterFilter, EqualFilter, Permission};
+use repository::{EncounterFilter, EqualFilter};
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::encounter::{InsertEncounter, InsertEncounterError},
 };
 
@@ -41,7 +41,7 @@ pub fn insert_encounter(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -100,6 +100,6 @@ pub fn insert_encounter(
     Ok(InsertEncounterResponse::Response(EncounterNode {
         store_id,
         encounter_row,
-        allowed_docs,
+        allowed_docs: allowed_docs.clone(),
     }))
 }

--- a/server/graphql/programs/src/mutations/encounter/update.rs
+++ b/server/graphql/programs/src/mutations/encounter/update.rs
@@ -3,9 +3,9 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::{EncounterFilter, EqualFilter, Permission};
+use repository::{EncounterFilter, EqualFilter};
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::encounter::{UpdateEncounter, UpdateEncounterError},
 };
 
@@ -40,7 +40,7 @@ pub fn update_encounter(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -101,6 +101,6 @@ pub fn update_encounter(
     Ok(UpdateEncounterResponse::Response(EncounterNode {
         store_id,
         encounter_row,
-        allowed_docs,
+        allowed_docs: allowed_docs.clone(),
     }))
 }

--- a/server/graphql/programs/src/mutations/insert_document_registry.rs
+++ b/server/graphql/programs/src/mutations/insert_document_registry.rs
@@ -1,7 +1,6 @@
 use async_graphql::*;
-use repository::Permission;
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     document::document_registry::{InsertDocRegistryError, InsertDocumentRegistry},
 };
 
@@ -38,7 +37,7 @@ pub fn insert_document_registry(
             store_id: None,
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
@@ -49,7 +48,7 @@ pub fn insert_document_registry(
         &allowed_docs,
     ) {
         Ok(document_registry) => InsertDocumentResponse::Response(DocumentRegistryNode {
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
             document_registry,
         }),
         Err(error) => {

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -3,9 +3,8 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::Permission;
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::patient::{UpdatePatient, UpdatePatientError},
 };
 
@@ -36,7 +35,7 @@ pub fn insert_patient(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -55,7 +54,7 @@ pub fn insert_patient(
         Ok(patient) => Ok(InsertPatientResponse::Response(PatientNode {
             store_id,
             patient,
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
         })),
         Err(error) => {
             let formatted_error = format!("{:#?}", error);

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -3,9 +3,8 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::Permission;
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::patient::{UpdatePatient, UpdatePatientError},
 };
 
@@ -37,7 +36,7 @@ pub fn update_patient(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -56,7 +55,7 @@ pub fn update_patient(
         Ok(patient) => Ok(UpdatePatientResponse::Response(PatientNode {
             store_id,
             patient,
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
         })),
         Err(error) => {
             let formatted_error = format!("{:#?}", error);

--- a/server/graphql/programs/src/mutations/program_enrolment/insert.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/insert.rs
@@ -3,9 +3,9 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::{EqualFilter, Permission, ProgramEnrolmentFilter};
+use repository::{EqualFilter, ProgramEnrolmentFilter};
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::program_enrolment::{UpsertProgramEnrolment, UpsertProgramEnrolmentError},
 };
 
@@ -39,7 +39,7 @@ pub fn insert_program_enrolment(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -107,7 +107,7 @@ pub fn insert_program_enrolment(
         ProgramEnrolmentNode {
             store_id,
             program_row,
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
         },
     ))
 }

--- a/server/graphql/programs/src/mutations/program_enrolment/update.rs
+++ b/server/graphql/programs/src/mutations/program_enrolment/update.rs
@@ -3,9 +3,9 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::{EqualFilter, Permission, ProgramEnrolmentFilter};
+use repository::{EqualFilter, ProgramEnrolmentFilter};
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::program_enrolment::{UpsertProgramEnrolment, UpsertProgramEnrolmentError},
 };
 
@@ -40,7 +40,7 @@ pub fn update_program_enrolment(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentMutate, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let service_context = service_provider.basic_context()?;
@@ -108,7 +108,7 @@ pub fn update_program_enrolment(
         ProgramEnrolmentNode {
             store_id,
             program_row,
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
         },
     ))
 }

--- a/server/graphql/programs/src/queries/document.rs
+++ b/server/graphql/programs/src/queries/document.rs
@@ -1,8 +1,8 @@
 use async_graphql::*;
 use graphql_core::generic_filters::EqualFilterStringInput;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
-use repository::{DocumentFilter, EqualFilter, Permission, StringFilter};
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use repository::{DocumentFilter, EqualFilter, StringFilter};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 use service::usize_to_u32;
 
 use crate::types::document::{DocumentConnector, DocumentNode};
@@ -43,7 +43,7 @@ pub fn document(ctx: &Context<'_>, store_id: String, name: String) -> Result<Opt
             store_id: Some(store_id),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
@@ -77,7 +77,7 @@ pub fn documents(
             store_id: Some(store_id),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/document_history.rs
+++ b/server/graphql/programs/src/queries/document_history.rs
@@ -3,8 +3,7 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::Permission;
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 use service::document::document_service::DocumentHistoryError;
 use service::usize_to_u32;
 
@@ -27,7 +26,7 @@ pub fn document_history(
             store_id: Some(store_id),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/document_registry.rs
+++ b/server/graphql/programs/src/queries/document_registry.rs
@@ -7,9 +7,8 @@ use graphql_core::{
 };
 use repository::{
     DocumentRegistryFilter, DocumentRegistrySort, DocumentRegistrySortField, EqualFilter,
-    Permission,
 };
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 use service::usize_to_u32;
 
 use crate::types::document_registry::{
@@ -64,7 +63,7 @@ pub fn document_registries(
             store_id: None,
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/encounter.rs
+++ b/server/graphql/programs/src/queries/encounter.rs
@@ -8,9 +8,9 @@ use graphql_core::{
 };
 use repository::{
     DatetimeFilter, EncounterFilter, EncounterSort, EncounterSortField, EqualFilter,
-    PaginationOption, Permission,
+    PaginationOption,
 };
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
 use crate::types::encounter::{EncounterNode, EncounterNodeStatus};
 
@@ -95,7 +95,7 @@ pub fn encounters(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/encounter_fields.rs
+++ b/server/graphql/programs/src/queries/encounter_fields.rs
@@ -4,9 +4,9 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use repository::{PaginationOption, Permission};
+use repository::PaginationOption;
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::encounter::encounter_fields::{EncounterFields, EncounterFieldsResult},
 };
 
@@ -67,7 +67,7 @@ pub fn encounter_fields(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/patient.rs
+++ b/server/graphql/programs/src/queries/patient.rs
@@ -11,10 +11,10 @@ use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use graphql_general::{EqualFilterGenderInput, GenderInput};
 use graphql_types::types::GenderType;
 use repository::{
-    DateFilter, EqualFilter, Pagination, PaginationOption, Permission, ProgramEnrolmentFilter,
+    DateFilter, EqualFilter, Pagination, PaginationOption, ProgramEnrolmentFilter,
     SimpleStringFilter,
 };
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 use service::programs::patient::{
     main_patient_doc_name, Patient, PatientFilter, PatientSort, PatientSortField,
 };
@@ -267,7 +267,7 @@ pub fn patients(
             store_id: Some(store_id.to_string()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
@@ -307,7 +307,7 @@ pub fn patient(
             store_id: Some(store_id.to_string()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;
@@ -326,7 +326,7 @@ pub fn patient(
         .map(|patient| PatientNode {
             store_id: store_id.clone(),
             patient,
-            allowed_docs,
+            allowed_docs: allowed_docs.clone(),
         });
 
     Ok(node)

--- a/server/graphql/programs/src/queries/patient_search.rs
+++ b/server/graphql/programs/src/queries/patient_search.rs
@@ -2,9 +2,8 @@ use async_graphql::*;
 use chrono::NaiveDate;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use graphql_general::GenderInput;
-use repository::Permission;
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     programs::patient::PatientSearch,
     usize_to_u32,
 };
@@ -63,7 +62,7 @@ pub fn patient_search(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/program_enrolment.rs
+++ b/server/graphql/programs/src/queries/program_enrolment.rs
@@ -5,11 +5,11 @@ use graphql_core::{
     ContextExt,
 };
 use repository::{
-    DatetimeFilter, EqualFilter, Pagination, Permission, ProgramEnrolmentFilter,
-    ProgramEnrolmentSort, ProgramEnrolmentSortField,
+    DatetimeFilter, EqualFilter, Pagination, ProgramEnrolmentFilter, ProgramEnrolmentSort,
+    ProgramEnrolmentSortField,
 };
 use service::{
-    auth::{context_permissions, Resource, ResourceAccessRequest},
+    auth::{CapabilityTag, Resource, ResourceAccessRequest},
     usize_to_u32,
 };
 
@@ -75,7 +75,7 @@ pub fn program_enrolments(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let service_provider = ctx.service_provider();
     let context = service_provider.basic_context()?;

--- a/server/graphql/programs/src/queries/program_event.rs
+++ b/server/graphql/programs/src/queries/program_event.rs
@@ -5,10 +5,9 @@ use graphql_core::{
     ContextExt,
 };
 use repository::{
-    EqualFilter, PaginationOption, Permission, ProgramEventFilter, ProgramEventSort,
-    ProgramEventSortField,
+    EqualFilter, PaginationOption, ProgramEventFilter, ProgramEventSort, ProgramEventSortField,
 };
-use service::auth::{context_permissions, Resource, ResourceAccessRequest};
+use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
 use crate::types::{program_enrolment::ProgramEventFilterInput, program_event::ProgramEventNode};
 
@@ -56,7 +55,7 @@ pub fn program_events(
             store_id: Some(store_id.clone()),
         },
     )?;
-    let allowed_docs = context_permissions(Permission::DocumentQuery, &user.permissions);
+    let allowed_docs = user.capabilities(CapabilityTag::DocumentType);
 
     let mut filter = filter
         .map(|f| f.to_domain())

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -440,7 +440,7 @@ impl<'a> ValidatedUser {
         if let Some(contexts) = self.capabilities.get(&tag) {
             return contexts;
         }
-        // This is really a dev error hand should be caught by minimal testing. Moreover, the panic
+        // This is really a dev error and should be caught by minimal testing. Moreover, the panic
         // only kills the frontend request but doesn't kill the server.
         panic!(
             "Dev error: dynamic permission tag {:?} is not defined in the permission DSL",

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -289,8 +289,9 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
         PermissionDSL::And(vec![
             PermissionDSL::HasStoreAccess,
             PermissionDSL::HasPermission(Permission::PatientMutate),
+            // permission to read the related doc types when reading the mutated patient
             PermissionDSL::HasDynamicPermission(
-                Permission::DocumentMutate,
+                Permission::DocumentQuery,
                 CapabilityTag::DocumentType,
             ),
         ]),


### PR DESCRIPTION
The mapping of user permission to service capabilities is done in a single place now. This de-couples user permissions from what can be done in the service.