### PR TITLE
Use schema examples if there is a pattern error

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -46,6 +46,7 @@
   "error.something-wrong": "Oops! Something's gone wrong.",
   "error.unable-to-load-data": "An error has occurred: there was a problem loading the data.",
   "error.problem-saving": "An error occurred: there was a problem saving the data.",
+  "error.json-bad-format-with-examples": "Incorrect format. Use: \"{{examples}}\"",
   "filename.inbounds": "inbound-shipments",
   "filename.locations": "locations",
   "filename.master-lists": "master-lists",

--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -14,12 +14,15 @@ const UIComponent = (props: ControlProps) => {
   const [localData, setLocalData] = useState<string | undefined>(data);
   // timestamp of the last key stroke
   const [latestKey, setLatestKey] = useState<number>(0);
+  const error = !!errors;
   // debounce avoid rerendering the form on every key stroke which becomes a performance issue
   const onChange = useDebounceCallback(
-    (value: string) => handleChange(path, value),
-    [path]
+    (value: string) =>
+      handleChange(path, error && value === '' ? undefined : value),
+    [path, error]
   );
-  const error = !!errors;
+
+  const examples = (props.schema as Record<string, string[]>)['examples'];
 
   useEffect(() => {
     // Using debounce, the actual data is set after 500ms after the last key stroke (localDataTime).
@@ -51,7 +54,8 @@ const UIComponent = (props: ControlProps) => {
         },
         disabled: !props.enabled,
         error,
-        helperText: errors,
+        helperText:
+          errors && examples ? `Use e.g.: "${examples.join('", "')}"` : errors,
         FormHelperTextProps: error
           ? { sx: { color: 'error.main' } }
           : undefined,

--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -4,6 +4,7 @@ import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
   DetailInputWithLabelRow,
   useDebounceCallback,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../styleConstants';
 
@@ -21,8 +22,15 @@ const UIComponent = (props: ControlProps) => {
       handleChange(path, error && value === '' ? undefined : value),
     [path, error]
   );
+  const t = useTranslation('common');
 
   const examples = (props.schema as Record<string, string[]>)['examples'];
+  const helperText =
+    error && examples && Array.isArray(examples)
+      ? t('error.json-bad-format-with-examples', {
+          examples: examples.join('", "'),
+        })
+      : errors;
 
   useEffect(() => {
     // Using debounce, the actual data is set after 500ms after the last key stroke (localDataTime).
@@ -54,8 +62,7 @@ const UIComponent = (props: ControlProps) => {
         },
         disabled: !props.enabled,
         error,
-        helperText:
-          errors && examples ? `Use e.g.: "${examples.join('", "')}"` : errors,
+        helperText,
         FormHelperTextProps: error
           ? { sx: { color: 'error.main' } }
           : undefined,

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -242,10 +242,10 @@
           "properties": {
             "bloodPressure": {
               "description": "75367002\tBlood pressure [mmHg]",
+              "examples": ["90/60", "120/80"],
               "pattern": "^\\d{3}\\/\\d{2}$",
               "title": "BP in mmHg",
-              "type": "string",
-              "messages": { "pattern": "Format is 000/00" }
+              "type": "string"
             },
             "bodyMassIndex": {
               "description": "60621009\tBody mass index (BMI)",
@@ -253,17 +253,17 @@
             },
             "height": {
               "description": "50373000\tBody height measure [m]",
+              "examples": ["1.55", "0.92", "1.75"],
               "pattern": "^\\d\\.\\d{2}$",
               "title": "Height in m",
-              "type": "string",
-              "messages": { "pattern": "Format is 0.00" }
+              "type": "string"
             },
             "midUpperArmCircumference": {
               "description": "284473002\tMid upper arm circumference (MUAC) [cm]",
-              "pattern": "^\\d+\\.\\d{2}$",
+              "examples": ["23.0", "21.4"],
+              "pattern": "^\\d+\\.\\d+$",
               "title": "MUAC in cm",
-              "type": "string",
-              "messages": { "pattern": "Format is 0.00" }
+              "type": "string"
             },
             "nutritionalStatus": {
               "description": "366364004  nutritional status",
@@ -366,10 +366,10 @@
             },
             "weight": {
               "description": "735395000\tCurrent body weight [kg]",
-              "pattern": "^\\d+\\.\\d{2}$",
+              "examples": ["75.1", "60.0"],
+              "pattern": "^\\d+\\.\\d+$",
               "title": "Weight in kg",
-              "type": "string",
-              "messages": { "pattern": "Format is 0.00" }
+              "type": "string"
             },
             "whoStaging": {
               "description": "420721002 Acquired immunodeficiency syndrome-associated disorder (disorder)",

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -297,7 +297,8 @@
           "$ref": "#/definitions/Allergies"
         },
         "birthOrder": {
-          "description": "For example: 02 or 01",
+          "description": "Birth order, e.g. \"02\" for second child",
+          "examples": ["01", "02", "03"],
           "pattern": "^[0-9]{2}$",
           "type": "string"
         },


### PR DESCRIPTION
Part of #655 

Don't show regex to the user but show some examples (when available)

![image](https://user-images.githubusercontent.com/88299195/200451047-bb2adebf-b958-45f4-bc49-1e384737c880.png)

![image](https://user-images.githubusercontent.com/88299195/200450987-a868251b-7743-4766-902a-b5ee4a4dd3c6.png)
