### PR TITLE
655 conditional district

### DIFF
--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -19,11 +19,13 @@ type Options = {
    * Examples for the correct pattern
    */
   examples?: string[];
+  width?: string;
 };
 const Options: z.ZodType<Options | undefined> = z
   .object({
     pattern: z.string().optional(),
-    examples: z.array(z.string()),
+    examples: z.array(z.string()).optional(),
+    width: z.string().optional(),
   })
   .strict()
   .optional();
@@ -122,7 +124,7 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
 
-  const width = props.uischema?.options?.['width'] ?? '100%';
+  const width = schemaOptions?.width ?? '100%';
 
   return (
     <DetailInputWithLabelRow

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -125,13 +125,58 @@
                 },
                 {
                   "type": "Control",
-                  "label": "Birth District",
-                  "scope": "#/properties/birthPlace/properties/district"
+                  "label": "Birth Province",
+                  "scope": "#/properties/birthPlace/properties/region",
+                  "options": {
+                    "allowedValues": ["Western", "Gulf"]
+                  }
                 },
                 {
                   "type": "Control",
-                  "label": "Birth Province",
-                  "scope": "#/properties/birthPlace/properties/region"
+                  "label": "Birth District",
+                  "scope": "#/properties/birthPlace/properties/district",
+                  "enabled": false,
+                  "rule": {
+                    "effect": "SHOW",
+                    "condition": {
+                      "scope": "#/properties/birthPlace/properties/region",
+                      "schema": { "const": null }
+                    }
+                  }
+                },
+                {
+                  "type": "Control",
+                  "label": "Birth District",
+                  "scope": "#/properties/birthPlace/properties/district",
+                  "rule": {
+                    "effect": "SHOW",
+                    "condition": {
+                      "scope": "#/properties/birthPlace/properties/region",
+                      "schema": { "const": "Western" }
+                    }
+                  },
+                  "options": {
+                    "allowedValues": [
+                      "Middle Fly",
+                      "North Fly District",
+                      "South Fly"
+                    ]
+                  }
+                },
+                {
+                  "type": "Control",
+                  "label": "Birth District",
+                  "scope": "#/properties/birthPlace/properties/district",
+                  "rule": {
+                    "effect": "SHOW",
+                    "condition": {
+                      "scope": "#/properties/birthPlace/properties/region",
+                      "schema": { "const": "Gulf" }
+                    }
+                  },
+                  "options": {
+                    "allowedValues": ["Kerema District", "Kikori District"]
+                  }
                 },
                 {
                   "type": "Control",


### PR DESCRIPTION
Part of #655 to make district conditional on the province.

I added an allowedValues option to the Text control, effectively converting it into an Autocomplete.
I then use rules to hide/show district controls with the correct allowedValues

There are two things I don't like and I would like to have feedback:
1) Ok to morph the Text like this or better to have a dedicated control for it? (There is also a requirement coming up that adds suggestions to a text input, e.g. allergies, while still allowing custom user input)
2) The rules are quite verbose.

Alternative, have a special control for the district that has an option like `conditions: { "Province1": ["destrictA", "DestrictB"], ... }` and peeks at the province control. 