### PR TITLE
743 Add printing to both apis

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -30,6 +30,8 @@ export interface NativeAPI {
   // Will return currently connected client (to display in UI)
   connectedServer: () => Promise<FrontEndHost | null>;
   goBackToDiscovery: () => void;
+  // Boolean to indicate that native client handles print
+  print: (html: string) => Promise<boolean>;
 }
 
 declare global {
@@ -45,6 +47,8 @@ interface AndroidNativeApi {
   connectToServer: (server: string) => void;
   connectedServer: () => string;
   goBackToDiscovery: () => void;
+  // Boolean to indicate that native client handles print
+  print: (html: string) => boolean;
 }
 
 declare const androidNativeAPI: AndroidNativeApi;
@@ -72,6 +76,7 @@ const fromAndroidNative = (api: AndroidNativeApi): NativeAPI => ({
     return JSON.parse(server) as FrontEndHost;
   },
   goBackToDiscovery: () => api.goBackToDiscovery(),
+  print: async html => api.print(html),
 });
 
 type NativeClientState = {

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -1,3 +1,4 @@
+import { FrontEndHost } from '@common/hooks';
 import { SupportedLocales } from '@common/intl';
 import { ThemeOptions } from '@mui/material';
 import { UserStoreNodeFragment } from '../authentication/api/operations.generated';
@@ -23,6 +24,7 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/theme/logohash': string;
   '/mru/credentials': AuthenticationCredentials;
+  '/mru/previous-server': FrontEndHost;
   '/auth/error': AuthError | undefined;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;

--- a/client/packages/electron/src/electron.ts
+++ b/client/packages/electron/src/electron.ts
@@ -7,6 +7,8 @@ import {
   frontEndHostUrl,
   isProtocol,
 } from '@openmsupply-client/common/src/hooks/useNativeClient';
+import { nativePrint } from './nativePrint';
+
 const SERVICE_TYPE = 'omsupply';
 const PROTOCOL_KEY = 'protocol';
 const CLIENT_VERSION_KEY = 'client_version';
@@ -69,6 +71,11 @@ const start = (): void => {
   );
 
   ipcMain.handle(IPC_MESSAGES.CONNECTED_SERVER, async () => connectedServer);
+
+  ipcMain.handle(IPC_MESSAGES.PRINT, async (_, html: string) => {
+    nativePrint(html);
+    return true;
+  });
 
   ipcMain.handle(IPC_MESSAGES.DISCOVERED_SERVERS, async () => {
     const servers = discoveredServers;

--- a/client/packages/electron/src/nativePrint.ts
+++ b/client/packages/electron/src/nativePrint.ts
@@ -1,0 +1,33 @@
+import { BrowserWindow } from 'electron';
+
+export const nativePrint = async (html: string) => {
+  const data = await convertToPdf(html);
+
+  let urlData = `data:application/pdf;base64,${Buffer.from(data).toString(
+    'base64'
+  )}`;
+
+  const previewWindow = new BrowserWindow({
+    title: 'Print Preview',
+    show: true,
+  });
+  previewWindow.on('page-title-updated', function (e) {
+    e.preventDefault();
+  });
+  await previewWindow.loadURL(urlData);
+};
+
+const convertToPdf = async (html: string) => {
+  const convertToPdfWindow = new BrowserWindow({
+    title: 'convertToPdfWindow',
+    show: false,
+  });
+
+  var urlData = `data:text/html;charset=UTF-8,'<!DOCTYPE html>${encodeURIComponent(
+    html
+  )}`;
+  await convertToPdfWindow.loadURL(urlData);
+
+  const printOptions = {};
+  return await convertToPdfWindow.webContents.printToPDF(printOptions);
+};

--- a/client/packages/electron/src/preload.ts
+++ b/client/packages/electron/src/preload.ts
@@ -10,6 +10,7 @@ const electronNativeAPI: NativeAPI = {
     ipcRenderer.send(IPC_MESSAGES.CONNECT_TO_SERVER, server),
   discoveredServers: () => ipcRenderer.invoke(IPC_MESSAGES.DISCOVERED_SERVERS),
   goBackToDiscovery: () => ipcRenderer.send(IPC_MESSAGES.GO_BACK_TO_DISCOVERY),
+  print: (html: string) => ipcRenderer.invoke(IPC_MESSAGES.PRINT, html),
 };
 
 contextBridge.exposeInMainWorld('electronNativeAPI', electronNativeAPI);

--- a/client/packages/electron/src/shared.ts
+++ b/client/packages/electron/src/shared.ts
@@ -4,4 +4,5 @@ export const IPC_MESSAGES = {
   CONNECT_TO_SERVER: 'connect-to-server',
   CONNECTED_SERVER: 'connected-server',
   GO_BACK_TO_DISCOVERY: 'go-back-to-discovery',
+  PRINT: 'print',
 };

--- a/client/packages/mobile/app/src/main/java/org/openmsupply/mobile/MainActivity.java
+++ b/client/packages/mobile/app/src/main/java/org/openmsupply/mobile/MainActivity.java
@@ -185,6 +185,17 @@ public class MainActivity extends AppCompatActivity implements NsdManager.Discov
 
     }
 
+    @JavascriptInterface
+    public boolean print(String html) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                startPrint(html);
+            }
+        });
+        return true;
+    }
+
     // Available in JS as androidNativeAPI.connectedServer
     @JavascriptInterface
     public String connectedServer() {
@@ -263,6 +274,27 @@ public class MainActivity extends AppCompatActivity implements NsdManager.Discov
             e.printStackTrace();
             return null;
         }
+    }
+
+    // Simple print window
+    private void startPrint(String html) {
+        printView = new WebView(this);
+        printView.setWebViewClient(new WebViewClient() {
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                return false;
+            }
+
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                String jobName = getString(R.string.app_name) + " Document";
+                PrintDocumentAdapter printAdapter = printView.createPrintDocumentAdapter(jobName);
+                printManager.print(jobName, printAdapter,
+                        new PrintAttributes.Builder().build());
+                printView = null;
+            }
+        });
+
+        printView.loadDataWithBaseURL(null, html, "text/HTML", "UTF-8", null);
     }
 
     // NsdManager.DiscoveryListener

--- a/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
+++ b/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
@@ -1,13 +1,12 @@
 import {
   EnvUtils,
-  Platform,
+  getNativeAPI,
   PrintFormat,
   useMutation,
   useNotification,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { useReportApi } from './useReportApi';
-import { Printer } from '@awesome-cordova-plugins/printer';
 
 type PrintReportParams = {
   reportId: string;
@@ -31,10 +30,9 @@ const setPrint = (frame: HTMLIFrameElement) => () => {
 const printPage = (url: string) => {
   fetch(url).then(async response => {
     const html = await response.text();
+    const nativeAPI = getNativeAPI();
 
-    if (EnvUtils.platform === Platform.Android) {
-      Printer.print(html);
-    } else {
+    if (!nativeAPI?.print(html)) {
       const frame = document.createElement('iframe');
       frame.style.position = 'fixed';
       frame.style.right = '0';

--- a/server/server/src/cors.rs
+++ b/server/server/src/cors.rs
@@ -26,7 +26,7 @@ pub fn cors_policy(config_settings: &Settings) -> Cors {
             });
 
             match sec_fetch_site_header {
-                Some(b"cross-site") => return true,
+                Some(b"same-site") => return true,
                 Some(b"same-origin") => return true,
                 Some(b"none") => return true,
                 _ => {}


### PR DESCRIPTION
#743.3

Should be pretty self explanatory. Wanted to make native functionality can be added (this of course lack all of the work Mark did on printing, but can be easily ported and extended, and I think allow for full control of native).

Both Electron and Android will just open print preview in this case.