### PR TITLE
Clear linked invoice id when changing name

### DIFF
--- a/server/service/src/invoice/outbound_shipment/update_name/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update_name/generate.rs
@@ -30,6 +30,7 @@ pub fn generate(
     let mut new_invoice = InvoiceRow {
         id: uuid(),
         name_id: input_other_party_id.unwrap_or(existing_invoice.name_id.clone()),
+        linked_invoice_id: None,
         ..old_invoice.clone()
     };
 


### PR DESCRIPTION
Closes #806

Linked invoice id wasn't being cleared so invoices were being duped when processors are fired