### PR TITLE
655 conditional text input

### DIFF
--- a/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
@@ -33,6 +33,8 @@ import {
   firstItemArrayTester,
   CategorizationTabLayout,
   categorizationTabLayoutTester,
+  Autocomplete,
+  autocompleteTester,
 } from './components';
 import {
   AccordionGroup,
@@ -156,6 +158,7 @@ const renderers = [
   { tester: arrayTester, renderer: Array },
   { tester: firstItemArrayTester, renderer: FirstItemArray },
   { tester: categorizationTabLayoutTester, renderer: CategorizationTabLayout },
+  { tester: autocompleteTester, renderer: Autocomplete },
   // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
   ...materialRenderers,
 ];

--- a/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/JsonForm.tsx
@@ -35,6 +35,8 @@ import {
   categorizationTabLayoutTester,
   Autocomplete,
   autocompleteTester,
+  conditionalSelectTester,
+  ConditionalSelect,
 } from './components';
 import {
   AccordionGroup,
@@ -159,6 +161,7 @@ const renderers = [
   { tester: firstItemArrayTester, renderer: FirstItemArray },
   { tester: categorizationTabLayoutTester, renderer: CategorizationTabLayout },
   { tester: autocompleteTester, renderer: Autocomplete },
+  { tester: conditionalSelectTester, renderer: ConditionalSelect },
   // We should be able to remove materialRenderers once we are sure we have custom components to cover all cases.
   ...materialRenderers,
 ];

--- a/client/packages/common/src/ui/forms/JsonForms/components/Autocomplete.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Autocomplete.tsx
@@ -72,6 +72,7 @@ const UIComponent = (props: ControlProps) => {
       !(schemaOptions?.values ?? []).includes(s)
     ) {
       setLocalData(undefined);
+      handleChange(path, undefined);
     } else {
       setLocalData(s);
       handleChange(path, s === '' ? undefined : s);

--- a/client/packages/common/src/ui/forms/JsonForms/components/Autocomplete.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Autocomplete.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { ControlProps, rankWith, uiTypeIs } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import {
+  Autocomplete as MuiAutocomplete,
+  Box,
+  FORM_INPUT_COLUMN_WIDTH,
+  FORM_LABEL_COLUMN_WIDTH,
+} from '@openmsupply-client/common';
+import { z } from 'zod';
+import { useZodOptionsValidation } from '../useZodOptionsValidation';
+import { FormLabel } from '@mui/material';
+
+type Options = {
+  freeText?: boolean;
+  values?: string[];
+};
+const Options: z.ZodType<Options | undefined> = z
+  .object({
+    freeText: z.boolean().optional(),
+    values: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
+export const autocompleteTester = rankWith(10, uiTypeIs('Autocomplete'));
+
+type DisplayOption = { label: string };
+
+const UIComponent = (props: ControlProps) => {
+  const { data, handleChange, label, path, errors } = props;
+  const { errors: zErrors, options: schemaOptions } = useZodOptionsValidation(
+    Options,
+    props.uischema.options
+  );
+
+  const [localData, setLocalData] = useState<string | undefined>(data);
+
+  if (!props.visible) {
+    return null;
+  }
+
+  // In free text mode we don't get an onChange update when changing focus; do an update manually
+  const onClose = () => {
+    if (!schemaOptions?.freeText) {
+      return;
+    }
+    handleChange(path, localData);
+  };
+
+  const onInputChange = (_event: React.SyntheticEvent, value: string) => {
+    if (schemaOptions?.freeText) {
+      // set the local data so that we have it in onClose; don't set it otherwise because it would
+      // affect the normal behaviour, i.e. the input wouldn't clear if the value is not valid
+      setLocalData(value);
+    }
+  };
+
+  const onChange = (
+    _event: React.SyntheticEvent,
+    value: DisplayOption | null | string
+  ) => {
+    let s = '';
+    if (typeof value === 'string') {
+      // from freeText mode
+      s = value;
+    } else {
+      s = value?.label ?? '';
+    }
+    if (
+      !schemaOptions?.freeText &&
+      !(schemaOptions?.values ?? []).includes(s)
+    ) {
+      setLocalData(undefined);
+    } else {
+      setLocalData(s);
+      handleChange(path, s === '' ? undefined : s);
+    }
+  };
+
+  const options: DisplayOption[] = (schemaOptions?.values ?? []).map(
+    (option: string) => ({
+      label: option,
+    })
+  );
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={2}
+      justifyContent="space-around"
+      style={{ minWidth: 300 }}
+      marginTop={1}
+    >
+      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
+        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+      </Box>
+      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+        <MuiAutocomplete
+          sx={{ '.MuiFormControl-root': { minWidth: '135px' } }}
+          options={options}
+          value={{ label: localData ?? '' }}
+          // some type problem here, freeSolo seems to have type `undefined`
+          freeSolo={schemaOptions?.freeText as undefined}
+          onClose={onClose}
+          onChange={onChange}
+          onInputChange={onInputChange}
+          clearable={!props.config?.required}
+          inputProps={{
+            error: !!zErrors || !!errors,
+            helperText: zErrors ?? errors,
+          }}
+          isOptionEqualToValue={(option, value) => {
+            if (typeof value === 'string') {
+              return option.label === value;
+            }
+            return option.label === value.label;
+          }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const Autocomplete = withJsonFormsControlProps(UIComponent);

--- a/client/packages/common/src/ui/forms/JsonForms/components/ConditionalSelect.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/ConditionalSelect.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
+import { FormLabel, Box } from '@mui/material';
+import { Autocomplete } from '@openmsupply-client/common';
+import {
+  FORM_LABEL_COLUMN_WIDTH,
+  FORM_INPUT_COLUMN_WIDTH,
+} from '../styleConstants';
+import { z } from 'zod';
+import { useZodOptionsValidation } from '../useZodOptionsValidation';
+import { get as extractProperty } from 'lodash';
+
+export const conditionalSelectTester = rankWith(
+  10,
+  uiTypeIs('ConditionalSelect')
+);
+
+type Options = {
+  conditionField: string;
+  conditionalValues: Record<string, string[]>;
+};
+const Options: z.ZodType<Options> = z
+  .object({
+    conditionField: z.string(),
+    conditionalValues: z.record(z.array(z.string())),
+  })
+  .strict();
+
+type DisplayOption = { label: string };
+
+const UIComponent = (props: ControlProps) => {
+  const { core } = useJsonForms();
+  const { data, handleChange, label, path } = props;
+  const { errors: zErrors, options: schemaOptions } = useZodOptionsValidation(
+    Options,
+    props.uischema.options
+  );
+  const [options, setOptions] = useState<DisplayOption[]>([]);
+  const conditionField = extractProperty(
+    core?.data ?? {},
+    schemaOptions?.conditionField ?? ''
+  );
+  useEffect(() => {
+    const currentOptions =
+      schemaOptions?.conditionalValues[conditionField]?.map(it => ({
+        label: it,
+      })) ?? [];
+    setOptions(currentOptions);
+  }, [schemaOptions, conditionField]);
+
+  if (!props.visible) {
+    return null;
+  }
+  const onChange = (
+    _event: React.SyntheticEvent,
+    value: DisplayOption | null
+  ) => handleChange(path, value?.label);
+  const value = (data ? options.find(o => o.label === data) : undefined) ?? {
+    label: '',
+  };
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={2}
+      justifyContent="space-around"
+      style={{ minWidth: 300 }}
+      marginTop={1}
+    >
+      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
+        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+      </Box>
+      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+        <Autocomplete
+          sx={{ '.MuiFormControl-root': { minWidth: '135px' } }}
+          options={options}
+          value={value}
+          onChange={onChange}
+          clearable={!props.config?.required}
+          inputProps={{
+            error: !!zErrors || !!props.errors,
+            helperText: zErrors ?? props.errors,
+          }}
+          isOptionEqualToValue={option => option.label === data}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const ConditionalSelect = withJsonFormsControlProps(UIComponent);

--- a/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/Text.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ControlProps, rankWith, schemaTypeIs } from '@jsonforms/core';
-import { withJsonFormsControlProps } from '@jsonforms/react';
+import { Actions, ControlProps, rankWith, schemaTypeIs } from '@jsonforms/core';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
   DetailInputWithLabelRow,
   useDebounceCallback,
@@ -108,6 +108,28 @@ const UIComponent = (props: ControlProps) => {
           examples: examples.join('", "'),
         })
       : zErrors ?? errors ?? customErrors;
+
+  const { core, dispatch } = useJsonForms();
+  useEffect(() => {
+    if (!core || !dispatch) {
+      return;
+    }
+    const currentErrors = core?.errors ?? [];
+    if (customErrors) {
+      dispatch(
+        Actions.updateErrors([
+          ...currentErrors,
+          {
+            instancePath: path,
+            message: customErrors,
+            schemaPath: path,
+            keyword: '',
+            params: {},
+          },
+        ])
+      );
+    }
+  }, [core, dispatch, customErrors]);
 
   useEffect(() => {
     // Using debounce, the actual data is set after 500ms after the last key stroke (localDataTime).

--- a/client/packages/common/src/ui/forms/JsonForms/components/index.ts
+++ b/client/packages/common/src/ui/forms/JsonForms/components/index.ts
@@ -8,3 +8,4 @@ export * from './Array';
 export * from './FirstItemArray';
 export * from './Boolean';
 export * from './CategorizationTabLayout';
+export * from './Autocomplete';

--- a/client/packages/common/src/ui/forms/JsonForms/components/index.ts
+++ b/client/packages/common/src/ui/forms/JsonForms/components/index.ts
@@ -9,3 +9,4 @@ export * from './FirstItemArray';
 export * from './Boolean';
 export * from './CategorizationTabLayout';
 export * from './Autocomplete';
+export * from './ConditionalSelect';

--- a/client/packages/system/src/Patient/JsonForms/useJsonForms.tsx
+++ b/client/packages/system/src/Patient/JsonForms/useJsonForms.tsx
@@ -85,12 +85,16 @@ export const useJsonForms = (
   createDoc?: CreateDocument
 ) => {
   const {
-    data: initialData,
+    data: loadedData,
     isLoading,
     documentId,
     documentRegistry,
     error,
   } = useDocumentLoader(docName, createDoc);
+  const [initialData, setInitialData] = useState(loadedData);
+  useEffect(() => {
+    setInitialData(loadedData);
+  }, [loadedData]);
   // current modified data
   const [data, setData] = useState<JsonData | undefined>();
   const [isSaving, setSaving] = useState(false);
@@ -118,6 +122,8 @@ export const useJsonForms = (
 
       const successSnack = success(t('success.data-saved'));
       successSnack();
+
+      setInitialData(data);
       return result?.name;
     } catch (err) {
       const errorSnack = errorNotification(t('error.problem-saving'));

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -78,11 +78,8 @@ const PatientDetailView: FC = () => {
   }, [patient]);
 
   const handleSave = useUpsertPatient();
-  const { JsonForm, saveData, revert, isSaving, isDirty } = useJsonForms(
-    patient ? undefined : documentName,
-    { handleSave },
-    createDoc
-  );
+  const { JsonForm, saveData, revert, isSaving, isDirty, validationError } =
+    useJsonForms(patient ? undefined : documentName, { handleSave }, createDoc);
   useEffect(() => {
     return () => setNewPatient(undefined);
   }, []);
@@ -140,7 +137,7 @@ const PatientDetailView: FC = () => {
             />
             <LoadingButton
               color="secondary"
-              disabled={!isDirty}
+              disabled={!isDirty || !!validationError}
               isLoading={isSaving}
               onClick={() => showSaveConfirmation()}
             >

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -124,14 +124,168 @@
                   "scope": "#/properties/dateOfBirthIsEstimated"
                 },
                 {
-                  "type": "Control",
-                  "label": "Birth District",
-                  "scope": "#/properties/birthPlace/properties/district"
+                  "type": "Autocomplete",
+                  "label": "Birth Province",
+                  "scope": "#/properties/birthPlace/properties/region",
+                  "options": {
+                    "freeText": false,
+                    "values": [
+                      "Western",
+                      "Gulf",
+                      "Central",
+                      "National Capital District",
+                      "Milne Bay",
+                      "Oro",
+                      "Southern Highlands",
+                      "Enga",
+                      "Western Highlands",
+                      "Simbu",
+                      "Eastern Highlands",
+                      "Morobe",
+                      "Madang",
+                      "East Sepik",
+                      "Saundaun",
+                      "Manus",
+                      "New Ireland",
+                      "East New Britain",
+                      "West New Britain",
+                      "North Solomon",
+                      "Expatriate",
+                      "Hela",
+                      "Jiwaka"
+                    ]
+                  }
                 },
                 {
-                  "type": "Control",
-                  "label": "Birth Province",
-                  "scope": "#/properties/birthPlace/properties/region"
+                  "type": "ConditionalSelect",
+                  "label": "Birth District",
+                  "scope": "#/properties/birthPlace/properties/district",
+                  "options": {
+                    "conditionField": "birthPlace.region",
+                    "conditionalValues": {
+                      "Western": [
+                        "Middle Fly",
+                        "North Fly District",
+                        "South Fly"
+                      ],
+                      "Gulf": ["Kerema District", "Kikori District"],
+                      "Central": [
+                        "Abau District",
+                        "Goilala District",
+                        "Kairuku-Hiri District",
+                        "Rigo District"
+                      ],
+                      "National Capital District": [
+                        "Moresby North-East",
+                        "Moresby North_West",
+                        "Moresby South"
+                      ],
+                      "Milne Bay": [
+                        "Alotau District",
+                        "Esa'ala District",
+                        "Kiriwini-Goodenough District",
+                        "Samarai-Murua District"
+                      ],
+                      "Oro": ["Ijivitari District", "Sohe District"],
+                      "Southern Highlands": [
+                        "Ialibu-Pangia District",
+                        "Imbonggu District",
+                        "Kagua-Erave District",
+                        "Komo-Magarima District",
+                        "Koroba-Kopiago District",
+                        "Mendi-Munihu District",
+                        "Nipa-Kutubu District",
+                        "Tari-Pori District"
+                      ],
+                      "Enga": [
+                        "Kandep District",
+                        "Kompiam District",
+                        "Lagaip-Porgera District",
+                        "Wabag District",
+                        "Kandep"
+                      ],
+                      "Western Highlands": [
+                        "Anglimp-South Waghi District",
+                        "Dei District",
+                        "Jimi District",
+                        "Mount Hagen District",
+                        "Mul-Baiyer District",
+                        "North Waghi District",
+                        "Tambul-Nebilyer District"
+                      ],
+                      "Simbu": [
+                        "Chauve District",
+                        "Gumine District",
+                        "Karimui-Nomane District",
+                        "Kerowagi District",
+                        "Kundiawa-Gembogl District",
+                        "Sina Sina-Yonggomugl District"
+                      ],
+                      "Eastern Highlands": [
+                        "Daulo District",
+                        "Goroka District",
+                        "Henganofi District",
+                        "Kainantu District",
+                        "Lufa District",
+                        "Obura-Wonenara District",
+                        "Okapa District District",
+                        "Unggai-Benna District"
+                      ],
+                      "Morobe": [
+                        "Bulolo District",
+                        "Finschhafen District",
+                        "Huon District",
+                        "Kabwum District",
+                        "Lae District",
+                        "Markham District",
+                        "Menyamya District",
+                        "Nawae District",
+                        "Tewae-Siassi District"
+                      ],
+                      "Madang": [
+                        "Bogia District",
+                        "Madang District",
+                        "Middle Ramu District",
+                        "Rai Coast District",
+                        "Sumkar District",
+                        "Usino Bundi District"
+                      ],
+                      "East Sepik": [
+                        "Ambunti-Dreikikir District",
+                        "Angoram District",
+                        "Maprik District",
+                        "Wewak District",
+                        "Wosera-Gawi District",
+                        "Yangoru-Saussia District"
+                      ],
+                      "Saundaun": [
+                        "Aitape-Lumi District",
+                        "Nuku District",
+                        "Telefomin District",
+                        "Vanimo-Green River District"
+                      ],
+                      "Manus": ["Manus District"],
+                      "New Ireland": ["Kavieng District", "Namatanai District"],
+                      "East New Britain": [
+                        "Gazelle District",
+                        "Kokopo District",
+                        "Pomio District",
+                        "Rabaul District"
+                      ],
+                      "West New Britain": [
+                        "Kandrian-Gloucester District",
+                        "Talasea District"
+                      ],
+                      "North Solomon": [
+                        "Central Bougainville District",
+                        "North Bougainville District",
+                        "South Bougainville District"
+                      ],
+                      "Expatriate": ["Other"],
+                      "Hela": [],
+                      "Jiwaka": []
+                    }
+                  }
                 },
                 {
                   "type": "Control",


### PR DESCRIPTION
Part of #655

- Adds an Autocomplete control
- Adds a ConditionalSelect control
- Use these controls to select province and district

The Autocomplete component supports a "freeStyle" mode which allows users to select from a dropdown as well as entering some text. This made this component a bit more complicated than expected. The build in freeSolo option worked but the onChange callback wasn't called when changing focus, i.e. the form data wasn't updated after entering the text. Furthermore, you have to handle a `string|DisplayOption` type when the input changed since the freeSolo option is always a string...

I tried to quickly write a test for it but had some problem to drill down to the right components to do the actions. Any experience with it? otherwise I will try again later.