### PR TITLE
Disable bundleAnalyzerPlugin

### DIFF
--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -21,7 +21,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.TOKEN_REPO}}
 
       - name: Build
-        run: cd ./client && yarn build-dev
+        run: cd ./client && yarn build-stats
 
       - name: Upload base stats.json
         uses: actions/upload-artifact@v2
@@ -43,7 +43,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.TOKEN_REPO}}
 
       - name: Build
-        run: cd ./client && yarn build-dev
+        run: cd ./client && yarn build-stats
 
       - name: Upload base stats.json
         uses: actions/upload-artifact@v2

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "start-remote": "lerna run --scope @openmsupply-client/* --parallel start-remote",
     "start": "yarn start-remote",
     "build": "lerna run --scope @openmsupply-client/* build",
-    "build-dev": "lerna run --scope @openmsupply-client/* build-dev",
+    "build-stats": "lerna run --scope @openmsupply-client/* build-stats",
     "serve": "lerna run --scope @openmsupply-client/* --parallel serve",
     "clean": "lerna run --scope @openmsupply-client/* --parallel clean",
     "compile": "lerna run --scope @openmsupply-client/* --parallel tsc --since HEAD",

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -23,7 +23,7 @@
     "start-remote": "webpack-cli serve --env API_HOST='https://demo-open.msupply.org'",
     "start-local": "webpack-cli serve --env API_HOST='http://localhost:8000'",
     "build": "webpack --env production",
-    "build-stats": "webpack --env stats",
+    "build-stats": "webpack --env stats --env production",
     "serve": "serve dist -p 3003",
     "tsc": "tsc --build"
   },

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -23,7 +23,7 @@
     "start-remote": "webpack-cli serve --env API_HOST='https://demo-open.msupply.org'",
     "start-local": "webpack-cli serve --env API_HOST='http://localhost:8000'",
     "build": "webpack --env production",
-    "build-dev": "webpack",
+    "build-stats": "webpack --env stats",
     "serve": "serve dist -p 3003",
     "tsc": "tsc --build"
   },


### PR DESCRIPTION
Fixes #836 

HMR builds with webpack in develop mode, which was running the bundle analyzer due to our `!!isProduction` config.
Have shifted to an explicit build script 