### PR TITLE
Fix cli report printing

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -224,6 +224,8 @@ pub async fn start_server(
             .wrap(logger_middleware())
             .wrap(cors_policy(&closure_settings))
             .wrap(compress_middleware())
+            // needed for static files service
+            .app_data(Data::new(closure_settings.clone()))
             .configure(attach_graphql_schema(graphql_schema.clone()))
             .configure(config_static_files)
             .configure(config_server_frontend)

--- a/server/service/src/report/html_printing.rs
+++ b/server/service/src/report/html_printing.rs
@@ -33,6 +33,12 @@ pub fn html_to_pdf(
         None => std::env::current_dir()?,
     }
     .join("report_printing_tmp");
+    // headless chrome needs an absolute path
+    let temp_dir = if !temp_dir.is_absolute() {
+        std::env::current_dir()?.join(temp_dir)
+    } else {
+        temp_dir
+    };
     fs::create_dir_all(&temp_dir)?;
 
     let document_name = format!("{}.html", document_id);

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -28,8 +28,9 @@ impl StaticFileService {
     pub fn new(base_dir: &Option<String>) -> anyhow::Result<Self> {
         let file_dir = match base_dir {
             Some(file_dir) => PathBuf::from_str(file_dir)?.join(STATIC_FILE_DIR),
-            None => std::env::current_dir()?.join(STATIC_FILE_DIR),
+            None => PathBuf::from_str(STATIC_FILE_DIR)?,
         };
+
         Ok(StaticFileService {
             dir: file_dir,
             max_lifetime_millis: 60 * 60 * 1000, // 1 hours


### PR DESCRIPTION
Two issues:
- headless chrome requires an absolute path (at least here)
- the server Data settings are needed by the static file service