### PR TITLE
#835 Implement "Date only" option for "DateTime" widget

### DIFF
--- a/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
@@ -88,7 +88,7 @@ const UIComponent = (props: ControlProps) => {
             }}
             inputFormat="dd/MM/yyyy hh:mm"
             error={error || props.errors}
-            // readOnly={!!props.uischema.options?.['readonly']}
+            readOnly={!!props.uischema.options?.['readonly']}
           />
         ) : (
           <BaseDatePickerInput
@@ -104,6 +104,7 @@ const UIComponent = (props: ControlProps) => {
                 );
             }}
             inputFormat="dd/MM/yyyy"
+            readOnly={!!props.uischema.options?.['readonly']}
           />
         )}
       </Box>

--- a/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
@@ -50,10 +50,8 @@ export const datetimeTester = rankWith(5, isDateTimeControl);
 const UIComponent = (props: ControlProps) => {
   const [error, setError] = React.useState('');
   const { data, handleChange, label, path, uischema } = props;
-  if (!props.visible) {
-    return null;
-  }
   const dateFormatter = useFormatDateTime().customDate;
+
   if (!props.visible) {
     return null;
   }

--- a/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
@@ -7,7 +7,11 @@ import {
   TextFieldProps,
   StandardTextFieldProps,
 } from '@mui/material';
-import { BasicTextInput } from '@openmsupply-client/common';
+import {
+  BasicTextInput,
+  BaseDatePickerInput,
+  useFormatDateTime,
+} from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
@@ -45,10 +49,16 @@ export const datetimeTester = rankWith(5, isDateTimeControl);
 
 const UIComponent = (props: ControlProps) => {
   const [error, setError] = React.useState('');
-  const { data, handleChange, label, path } = props;
+  const { data, handleChange, label, path, uischema } = props;
   if (!props.visible) {
     return null;
   }
+  const dateFormatter = useFormatDateTime().customDate;
+  if (!props.visible) {
+    return null;
+  }
+
+  const dateOnly = uischema.options?.['dateOnly'] ?? false;
 
   return (
     <Box
@@ -63,22 +73,39 @@ const UIComponent = (props: ControlProps) => {
         <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
-        <BaseDateTimePickerInput
-          // undefined is displayed as "now" and null as unset
-          value={data ?? null}
-          onChange={e => {
-            try {
-              setError('');
-              if (e) handleChange(path, e.toISOString());
-            } catch (err) {
-              setError((err as Error).message);
-              console.error(err);
-            }
-          }}
-          inputFormat="dd/MM/yyyy hh:mm"
-          error={error || props.errors}
-          // readOnly={!!props.uischema.options?.['readonly']}
-        />
+        {!dateOnly ? (
+          <BaseDateTimePickerInput
+            // undefined is displayed as "now" and null as unset
+            value={data ?? null}
+            onChange={e => {
+              try {
+                setError('');
+                if (e) handleChange(path, e.toISOString());
+              } catch (err) {
+                setError((err as Error).message);
+                console.error(err);
+              }
+            }}
+            inputFormat="dd/MM/yyyy hh:mm"
+            error={error || props.errors}
+            // readOnly={!!props.uischema.options?.['readonly']}
+          />
+        ) : (
+          <BaseDatePickerInput
+            // undefined is displayed as "now" and null as unset
+            value={data ?? null}
+            onChange={e => {
+              if (e)
+                handleChange(
+                  path,
+                  // By default, will set current date-time. However, if a date
+                  // is selected, the time will be considered "midnight"
+                  dateFormatter(e, 'yyyy-MM-dd') + ' 00:00:00'
+                );
+            }}
+            inputFormat="dd/MM/yyyy"
+          />
+        )}
       </Box>
     </Box>
   );

--- a/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
+++ b/client/packages/common/src/ui/forms/JsonForms/components/DateTime.tsx
@@ -58,6 +58,32 @@ const UIComponent = (props: ControlProps) => {
 
   const dateOnly = uischema.options?.['dateOnly'] ?? false;
 
+  const inputFormat = !dateOnly ? 'dd/MM/yyyy hh:mm' : 'dd/MM/yyyy';
+
+  const onChange = (e: Date | null) => {
+    if (!e) return;
+
+    try {
+      const dateString = !dateOnly
+        ? e.toISOString()
+        : // By default, will use current date-time. However, if a
+          // different date is selected, the time will be considered "midnight"
+          dateFormatter(e, 'yyyy-MM-dd') + ' 00:00:00';
+      setError('');
+      if (e) handleChange(path, dateString);
+    } catch (err) {
+      setError((err as Error).message);
+      console.error(err);
+    }
+  };
+
+  const sharedComponentProps = {
+    value: data ?? null,
+    onChange: (e: Date | null) => onChange(e),
+    inputFormat,
+    readOnly: !!props.uischema.options?.['readonly'],
+  };
+
   return (
     <Box
       display="flex"
@@ -74,36 +100,11 @@ const UIComponent = (props: ControlProps) => {
         {!dateOnly ? (
           <BaseDateTimePickerInput
             // undefined is displayed as "now" and null as unset
-            value={data ?? null}
-            onChange={e => {
-              try {
-                setError('');
-                if (e) handleChange(path, e.toISOString());
-              } catch (err) {
-                setError((err as Error).message);
-                console.error(err);
-              }
-            }}
-            inputFormat="dd/MM/yyyy hh:mm"
+            {...sharedComponentProps}
             error={error || props.errors}
-            readOnly={!!props.uischema.options?.['readonly']}
           />
         ) : (
-          <BaseDatePickerInput
-            // undefined is displayed as "now" and null as unset
-            value={data ?? null}
-            onChange={e => {
-              if (e)
-                handleChange(
-                  path,
-                  // By default, will set current date-time. However, if a date
-                  // is selected, the time will be considered "midnight"
-                  dateFormatter(e, 'yyyy-MM-dd') + ' 00:00:00'
-                );
-            }}
-            inputFormat="dd/MM/yyyy"
-            readOnly={!!props.uischema.options?.['readonly']}
-          />
+          <BaseDatePickerInput {...sharedComponentProps} />
         )}
       </Box>
     </Box>

--- a/server/service/src/sync/program_schemas/hiv_care_program.json
+++ b/server/service/src/sync/program_schemas/hiv_care_program.json
@@ -83,15 +83,7 @@
       "type": "object"
     },
     "Gender": {
-      "enum": [
-        "FEMALE",
-        "MALE",
-        "TRANSGENDER",
-        "TRANSGENDER_MALE",
-        "TRANSGENDER_FEMALE",
-        "UNKNOWN",
-        "NON_BINARY"
-      ],
+      "enum": ["FEMALE", "MALE", "TRANSGENDER", "TRANSGENDER_MALE", "TRANSGENDER_FEMALE", "UNKNOWN", "NON_BINARY"],
       "type": "string"
     },
     "HIVCareProgramEnrolment": {
@@ -119,13 +111,7 @@
           "$ref": "#/definitions/HIVStatus"
         },
         "priorART": {
-          "enum": [
-            "TRANSFER_IN_WITH_RECORDS",
-            "TRANSFER_IN_WITHOUT_RECORDS",
-            "PPTCT_PROPHYLAXIS",
-            "PEP",
-            "PrEP"
-          ],
+          "enum": ["TRANSFER_IN_WITH_RECORDS", "TRANSFER_IN_WITHOUT_RECORDS", "PPTCT_PROPHYLAXIS", "PEP", "PrEP"],
           "type": "string"
         },
         "riskGroup": {

--- a/server/service/src/sync/program_schemas/hiv_care_program_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_care_program_ui_schema.json
@@ -10,7 +10,8 @@
       "type": "Control",
       "scope": "#/properties/enrolmentDatetime",
       "options": {
-        "readonly": true
+        "readonly": true,
+        "dateOnly": true
       }
     },
     {

--- a/server/service/src/sync/program_schemas/hiv_testing_program_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_testing_program_ui_schema.json
@@ -9,8 +9,10 @@
     {
       "type": "Control",
       "scope": "#/properties/enrolmentDatetime",
+      "label": "Enrolment Date",
       "options": {
-        "readonly": true
+        "readonly": true,
+        "dateOnly": true
       }
     },
     {
@@ -58,10 +60,7 @@
           ["TRANSFER_IN", "Transfer in"],
           ["STI", "STI"],
           ["ANC", "ANC"],
-          [
-            "EXPOSED_INFANT_WELL_BABY_CLINIC",
-            "Exposed infant well baby clinic"
-          ],
+          ["EXPOSED_INFANT_WELL_BABY_CLINIC", "Exposed infant well baby clinic"],
           ["IN_PATIENT", "In patient"]
         ]
       }


### PR DESCRIPTION
Fix #835 

Just allows the "DateTime" widget to be used but only show the "Date" part to the user. By default, the saved date will be the current date/time, but if a date is selected it will store the time component as "midnight" on the selected date (because any further precision would be misleading).

Ideally, we'd just use the "Date" widget most of the time, but this is for cases where we want to capture the full date time but without burdening the user with a "time" selector (such as the "Enrolment Date" option in Program enrolment form)

Note -- there is some Prettier auto-formatting changes in the JSON here which we probably don't want. We should probably co-ordinate our configurations to avoid this.