### PR TITLE
Add options to language menu

### DIFF
--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -95,6 +95,24 @@ const currencyOptions = {
     negativePattern: '-!#',
     format,
   },
+  es: {
+    symbol: '$',
+    separator: ',',
+    decimal: '.',
+    precision: 2,
+    pattern: '!#',
+    negativePattern: '-!#',
+    format,
+  },
+  tet: {
+    symbol: '$',
+    separator: ',',
+    decimal: '.',
+    precision: 2,
+    pattern: '!#',
+    negativePattern: '-!#',
+    format,
+  },
 };
 
 export const useCurrency = (dp?: number) => {
@@ -104,8 +122,8 @@ export const useCurrency = (dp?: number) => {
   return {
     c: (value: currency.Any) => currency(value, { ...options, precision }),
     options,
-    language
-  }
+    language,
+  };
 };
 
 export const useFormatCurrency = (dp?: number) => {

--- a/client/packages/common/src/intl/locales/es/app.json
+++ b/client/packages/common/src/intl/locales/es/app.json
@@ -1,0 +1,3 @@
+{
+  "dashboard": "Tablero"
+}

--- a/client/packages/common/src/intl/locales/es/common.json
+++ b/client/packages/common/src/intl/locales/es/common.json
@@ -1,0 +1,1 @@
+{ "button.language": "Idioma" }

--- a/client/packages/common/src/intl/locales/tet/app.json
+++ b/client/packages/common/src/intl/locales/tet/app.json
@@ -1,0 +1,3 @@
+{
+  "dashboard": "Dashboard"
+}

--- a/client/packages/common/src/intl/locales/tet/common.json
+++ b/client/packages/common/src/intl/locales/tet/common.json
@@ -1,0 +1,1 @@
+{ "button.language": "Lingua" }

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -1,4 +1,4 @@
-import { IntlUtils } from '@common/intl';
+import { IntlUtils, SupportedLocales } from '@common/intl';
 import {
   isValid,
   differenceInMonths,
@@ -15,10 +15,10 @@ import {
   formatRelative,
   formatDistanceToNow,
 } from 'date-fns';
-import { enGB, enUS, fr, ar } from 'date-fns/locale';
+import { enGB, enUS, fr, ar, es } from 'date-fns/locale';
 
 // Map locale string (from i18n) to locale object (from date-fns)
-const getLocaleObj = { fr, ar };
+const getLocaleObj = { fr, ar, es };
 
 export const MINIMUM_EXPIRY_MONTHS = 3;
 
@@ -61,14 +61,20 @@ export const DateUtils = {
   isEqual,
 };
 
+const getLocale = (language: SupportedLocales) => {
+  switch (language) {
+    case 'en':
+      return navigator.language === 'en-US' ? enUS : enGB;
+    case 'tet':
+      return enGB;
+    default:
+      return getLocaleObj[language];
+  }
+};
+
 export const useFormatDateTime = () => {
   const language = IntlUtils.useCurrentLanguage();
-  const locale =
-    language === 'en'
-      ? navigator.language === 'en-US'
-        ? enUS
-        : enGB
-      : getLocaleObj[language];
+  const locale = getLocale(language);
 
   const localisedDate = (date: Date | string | number): string =>
     formatIfValid(dateInputHandler(date), 'P', { locale });

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -5,7 +5,13 @@ import { LanguageType } from '../../types/schema';
 
 export { useTranslationNext };
 
-const locales = ['en' as const, 'ar' as const, 'fr' as const] as const;
+const locales = [
+  'ar' as const,
+  'en' as const,
+  'es' as const,
+  'fr' as const,
+  'tet' as const,
+] as const;
 
 export type SupportedLocales = typeof locales[number];
 
@@ -38,8 +44,9 @@ export const IntlUtils = {
   useCurrentLanguage: (): SupportedLocales => {
     const { i18n } = useTranslationNext();
     const { language } = i18n;
-    if (language === 'en' || language === 'fr' || language === 'ar') {
-      return language;
+    const supportedLanguage = language as SupportedLocales;
+    if (locales.includes(supportedLanguage)) {
+      return supportedLanguage;
     }
     if (!EnvUtils.isProduction()) {
       throw new Error(`Language '${language}' not supported`);

--- a/client/packages/common/src/utils/testing/testing.tsx
+++ b/client/packages/common/src/utils/testing/testing.tsx
@@ -91,9 +91,7 @@ export const TestingRouterContext: FC<PropsWithChildrenOnly> = ({
 );
 
 export const TestingProvider: FC<
-  PropsWithChildren<{
-    locale?: 'en' | 'fr' | 'ar' | 'es' | 'tet';
-  }>
+  PropsWithChildren<{ locale?: SupportedLocales }>
 > = ({ children, locale = 'en' }) => (
   <React.Suspense fallback={<span>[suspended]</span>}>
     <QueryClientProvider client={queryClient}>
@@ -159,7 +157,7 @@ export const setScreenSize_ONLY_FOR_TESTING = (screenSize: number): void => {
 export const renderHookWithProvider = <Props, Result>(
   hook: (props: Props) => Result,
   options?: {
-    providerProps?: { locale: 'en' | 'fr' | 'ar' | 'es' | 'tet' };
+    providerProps?: { locale: SupportedLocales };
   }
 ) =>
   renderHook(hook, {

--- a/client/packages/common/src/utils/testing/testing.tsx
+++ b/client/packages/common/src/utils/testing/testing.tsx
@@ -92,7 +92,7 @@ export const TestingRouterContext: FC<PropsWithChildrenOnly> = ({
 
 export const TestingProvider: FC<
   PropsWithChildren<{
-    locale?: 'en' | 'fr' | 'ar';
+    locale?: 'en' | 'fr' | 'ar' | 'es' | 'tet';
   }>
 > = ({ children, locale = 'en' }) => (
   <React.Suspense fallback={<span>[suspended]</span>}>
@@ -159,7 +159,7 @@ export const setScreenSize_ONLY_FOR_TESTING = (screenSize: number): void => {
 export const renderHookWithProvider = <Props, Result>(
   hook: (props: Props) => Result,
   options?: {
-    providerProps?: { locale: 'en' | 'fr' | 'ar' };
+    providerProps?: { locale: 'en' | 'fr' | 'ar' | 'es' | 'tet' };
   }
 ) =>
   renderHook(hook, {

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { IntlUtils, useNavigate, Select } from '@openmsupply-client/common';
+import {
+  IntlUtils,
+  useNavigate,
+  Select,
+  MenuItem,
+  Option,
+} from '@openmsupply-client/common';
 
 export const LanguageMenu: React.FC = () => {
   const navigate = useNavigate();
@@ -11,12 +17,29 @@ export const LanguageMenu: React.FC = () => {
   };
 
   const options = [
-    { label: 'Arabic', value: 'ar' },
-    { label: 'French', value: 'fr' },
+    { label: 'عربي', value: 'ar' },
+    { label: 'Français', value: 'fr' },
     { label: 'English', value: 'en' },
+    { label: 'Española', value: 'es' },
+    { label: 'Tetum', value: 'tet' },
   ];
 
+  const renderOption = (option: Option) => (
+    <MenuItem
+      key={option.value}
+      value={option.value}
+      sx={option.value === 'ar' ? { justifyContent: 'flex-end' } : {}}
+    >
+      {option.label}
+    </MenuItem>
+  );
+
   return (
-    <Select onChange={handleChange} options={options} value={i18n.language} />
+    <Select
+      onChange={handleChange}
+      options={options}
+      value={i18n.language}
+      renderOption={renderOption}
+    />
   );
 };


### PR DESCRIPTION
Fixes #877 

Adds Tetum and Spanish options to the menu. 
Have added a couple of example translations to test that it is working.