### PR TITLE
#861 Highlight current Text box

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -22,6 +22,12 @@ const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
   border: 'none',
   '&:focus': {
     outline: 'none',
+    borderBottom: '2px solid #FF0000',
+    borderRadius: '8px 8px 0px 0px',
+  },
+  '&:hover': {
+    borderBottom: '2px solid #4F4F4F',
+    borderRadius: '8px 8px 0px 0px',
   },
 }));
 

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -20,9 +20,9 @@ const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
   padding: '4px 8px',
   textAlign: 'right',
   border: 'none',
-  '&:focus': {
+  '&:focus:not(hover)': {
     outline: 'none',
-    borderBottom: '2px solid #FF0000',
+    borderBottom: '2px solid #3e7bfa',
     borderRadius: '8px 8px 0px 0px',
   },
   '&:hover': {

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -22,11 +22,11 @@ const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
   border: 'none',
   '&:focus:not(hover)': {
     outline: 'none',
-    borderBottom: '2px solid #3e7bfa',
+    borderBottom: `2px solid ${theme.palette.secondary.main}`,
     borderRadius: '8px 8px 0px 0px',
   },
   '&:hover': {
-    borderBottom: '2px solid #4F4F4F',
+    borderBottom: `2px solid ${theme.palette.gray.main}`,
     borderRadius: '8px 8px 0px 0px',
   },
 }));

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -29,7 +29,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
       variant="standard"
       size="small"
       InputProps={{
-        disableUnderline: true,
         ...InputProps,
         sx: {
           backgroundColor: theme =>

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -30,6 +30,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       size="small"
       InputProps={{
         ...InputProps,
+        color: 'secondary',
         sx: {
           backgroundColor: theme =>
             props.disabled

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -12,6 +12,7 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
   ({ sx, InputProps, error, ...props }, ref) => (
     <TextField
       ref={ref}
+      color='secondary'
       sx={{
         '& .MuiInput-underline:before': { borderBottomWidth: 0 },
         '& .MuiInput-input': { color: 'gray.dark' },
@@ -20,6 +21,7 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
       variant="standard"
       size="small"
       InputProps={{
+        disableUnderline: error ? true : false,
         ...InputProps,
         sx: {
           border: theme =>

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -20,7 +20,6 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
       variant="standard"
       size="small"
       InputProps={{
-        disableUnderline: true,
         ...InputProps,
         sx: {
           border: theme =>


### PR DESCRIPTION
Closes #861 

Will need to update programs with develop again after this is merged.

- Added blue underline when text + select components are in focus
- Also changed the currency input to have blue underline on focus or grey underline on hover
- Disabled underline if there's an error, so that the focus underline doesn't overlap with error border