### PR TITLE
818 sync translation handle empty datetime strings

### DIFF
--- a/server/service/src/sync/sync_serde.rs
+++ b/server/service/src/sync/sync_serde.rs
@@ -11,7 +11,7 @@ pub fn empty_str_as_option_string<'de, D: Deserializer<'de>>(
     Ok(s.filter(|s| !s.is_empty()))
 }
 
-pub fn empty_str_as_option_generic<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+pub fn empty_str_as_option<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
     d: D,
 ) -> Result<Option<T>, D::Error> {
     let s: Option<String> = empty_str_as_option_string(d)?;

--- a/server/service/src/sync/sync_serde.rs
+++ b/server/service/src/sync/sync_serde.rs
@@ -4,20 +4,22 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-pub fn empty_str_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<String>, D::Error> {
+pub fn empty_str_as_option_string<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<String>, D::Error> {
     let s: Option<String> = Option::deserialize(d)?;
     Ok(s.filter(|s| !s.is_empty()))
 }
 
-pub fn empty_str_as_option_datetime<'de, D: Deserializer<'de>>(
+pub fn empty_str_as_option_generic<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
     d: D,
-) -> Result<Option<NaiveDateTime>, D::Error> {
-    let s: Option<String> = empty_str_as_option(d)?;
+) -> Result<Option<T>, D::Error> {
+    let s: Option<String> = empty_str_as_option_string(d)?;
 
     let Some(s) = s else { return Ok(None)};
 
     let str_d: StrDeserializer<D::Error> = s.as_str().into_deserializer();
-    Ok(Some(NaiveDateTime::deserialize(str_d)?))
+    Ok(Some(T::deserialize(str_d)?))
 }
 
 pub fn zero_date_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<NaiveDate>, D::Error> {

--- a/server/service/src/sync/sync_serde.rs
+++ b/server/service/src/sync/sync_serde.rs
@@ -1,9 +1,23 @@
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{value::StrDeserializer, IntoDeserializer},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 pub fn empty_str_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<String>, D::Error> {
     let s: Option<String> = Option::deserialize(d)?;
     Ok(s.filter(|s| !s.is_empty()))
+}
+
+pub fn empty_str_as_option_datetime<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<Option<NaiveDateTime>, D::Error> {
+    let s: Option<String> = empty_str_as_option(d)?;
+
+    let Some(s) = s else { return Ok(None)};
+
+    let str_d: StrDeserializer<D::Error> = s.as_str().into_deserializer();
+    Ok(Some(NaiveDateTime::deserialize(str_d)?))
 }
 
 pub fn zero_date_as_option<'de, D: Deserializer<'de>>(d: D) -> Result<Option<NaiveDate>, D::Error> {

--- a/server/service/src/sync/test/test_data/invoice.rs
+++ b/server/service/src/sync/test/test_data/invoice.rs
@@ -84,7 +84,14 @@ const TRANSACT_1: (&'static str, &'static str) = (
       "user4": "",
       "user_ID": "",
       "wardID": "",
-      "waybill_number": ""
+      "waybill_number": "",
+      "om_allocated_datetime": "",
+      "om_picked_datetime": null,
+      "om_shipped_datetime": "",
+      "om_delivered_datetime": "",
+      "om_verified_datetime": "",
+      "om_created_datetime": "",
+      "om_transport_reference": ""
   }"#,
 );
 fn transact_1_pull_record() -> TestSyncPullRecord {

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -43,7 +43,7 @@ const REQUISITION_REQUEST: (&'static str, &'static str) = (
       "om_created_datetime": "",
       "om_sent_datetime": "",
       "om_finalised_datetime": "",
-      "om_expected_delivery_date": null,
+      "om_expected_delivery_date": "0000-00-00", 
       "om_max_months_of_stock": 0,
       "om_status": "",
       "om_colour": "" 

--- a/server/service/src/sync/test/test_data/requisition.rs
+++ b/server/service/src/sync/test/test_data/requisition.rs
@@ -39,7 +39,14 @@ const REQUISITION_REQUEST: (&'static str, &'static str) = (
       "programID": "F36DBBC6DBCA4528BDA2403CE07CB44F",
       "lastModifiedAt": 1594273006,
       "is_emergency": false,
-      "isRemoteOrder": false
+      "isRemoteOrder": false,
+      "om_created_datetime": "",
+      "om_sent_datetime": "",
+      "om_finalised_datetime": "",
+      "om_expected_delivery_date": null,
+      "om_max_months_of_stock": 0,
+      "om_status": "",
+      "om_colour": "" 
     }"#,
 );
 fn requisition_request_pull_record() -> TestSyncPullRecord {

--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -41,7 +41,8 @@ const REQUISITION_LINE_1: (&'static str, &'static str) = (
         "DOSforAMCadjustment": 0,
         "requestedPackSize": 0,
         "approved_quantity": 0,
-        "authoriser_comment": ""
+        "authoriser_comment": "",
+        "om_snapshot_datetime": ""
     }"#,
 );
 fn requisition_line_request_pull_record() -> TestSyncPullRecord {

--- a/server/service/src/sync/test/test_data/stocktake.rs
+++ b/server/service/src/sync/test/test_data/stocktake.rs
@@ -29,7 +29,8 @@ const STOCKTAKE_1: (&'static str, &'static str) = (
       "stock_take_date": "2021-07-30",
       "stock_take_time": 47061,
       "store_ID": "store_a",
-      "type": ""
+      "type": "",
+      "om_created_datetime": ""
     }"#,
 );
 fn stocktake_pull_record() -> TestSyncPullRecord {

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -5,7 +5,7 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option};
+use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string};
 
 use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
 
@@ -32,7 +32,7 @@ pub struct LegacyActivityLogRow {
     #[serde(rename = "record_ID")]
     pub record_id: String,
     pub datetime: NaiveDateTime,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub event: Option<String>,
 }
 

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1,8 +1,8 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
-        date_from_date_time, date_option_to_isostring, date_to_isostring,
-        empty_str_as_option_generic, empty_str_as_option_string, naive_time, zero_date_as_option,
+        date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
+        empty_str_as_option_string, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -126,38 +126,38 @@ pub struct LegacyTransactRow {
 
     #[serde(default)]
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_allocated_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub allocated_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_picked_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub picked_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_shipped_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub shipped_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_delivered_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub delivered_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_verified_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub verified_datetime: Option<NaiveDateTime>,
 
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(default)]
     pub om_status: Option<InvoiceRowStatus>,
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(default)]
     pub om_type: Option<InvoiceRowType>,
 

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -1,8 +1,8 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
-        date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
-        empty_str_as_option_datetime, naive_time, zero_date_as_option,
+        date_from_date_time, date_option_to_isostring, date_to_isostring,
+        empty_str_as_option_generic, empty_str_as_option_string, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -83,22 +83,22 @@ pub struct LegacyTransactRow {
     #[serde(rename = "type")]
     pub _type: LegacyTransactType,
     pub status: LegacyTransactStatus,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "user_ID")]
     pub user_id: Option<String>,
     pub hold: bool,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub their_ref: Option<String>,
 
     #[serde(default)]
     #[serde(rename = "om_transport_reference")]
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub transport_reference: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub requisition_ID: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub linked_transaction_id: Option<String>,
 
     /// creation time
@@ -126,39 +126,43 @@ pub struct LegacyTransactRow {
 
     #[serde(default)]
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_allocated_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub allocated_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_picked_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub picked_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_shipped_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub shipped_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_delivered_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub delivered_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_verified_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub verified_datetime: Option<NaiveDateTime>,
 
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(default)]
     pub om_status: Option<InvoiceRowStatus>,
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(default)]
     pub om_type: Option<InvoiceRowType>,
 
     /// We ignore the legacy colour field
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(default)]
     pub om_colour: Option<String>,
 }

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
         date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
-        naive_time, zero_date_as_option,
+        empty_str_as_option_datetime, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -92,7 +92,9 @@ pub struct LegacyTransactRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub their_ref: Option<String>,
 
+    #[serde(default)]
     #[serde(rename = "om_transport_reference")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub transport_reference: Option<String>,
     #[serde(deserialize_with = "empty_str_as_option")]
     pub requisition_ID: Option<String>,
@@ -122,22 +124,34 @@ pub struct LegacyTransactRow {
 
     pub mode: TransactMode,
 
+    #[serde(default)]
     #[serde(rename = "om_created_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub created_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_allocated_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub allocated_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_picked_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub picked_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_shipped_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub shipped_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_delivered_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub delivered_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_verified_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub verified_datetime: Option<NaiveDateTime>,
 
     pub om_status: Option<InvoiceRowStatus>,

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
-    sync_serde::{date_option_to_isostring, empty_str_as_option, zero_date_as_option},
+    sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
 };
 use chrono::NaiveDate;
 use repository::{
@@ -50,12 +50,12 @@ pub struct LegacyTransLineRow {
     pub item_id: String,
     pub item_name: String,
     #[serde(rename = "item_line_ID")]
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub stock_line_id: Option<String>,
     #[serde(rename = "location_ID")]
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub location_id: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
@@ -69,7 +69,7 @@ pub struct LegacyTransLineRow {
     pub r#type: LegacyTransLineType,
     #[serde(rename = "quantity")]
     pub number_of_packs: f64,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub note: Option<String>,
 
     #[serde(rename = "om_item_code")]

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -1,4 +1,6 @@
-use crate::sync::sync_serde::{date_option_to_isostring, empty_str_as_option, zero_date_as_option};
+use crate::sync::sync_serde::{
+    date_option_to_isostring, empty_str_as_option_string, zero_date_as_option,
+};
 use chrono::NaiveDate;
 use repository::{Gender, NameRow, NameType, StorageConnection, SyncBufferRow};
 
@@ -63,13 +65,13 @@ pub struct LegacyNameRow {
     pub customer: bool,
     pub supplier: bool,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub supplying_store_id: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "first")]
     pub first_name: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "last")]
     pub last_name: Option<String>,
 
@@ -78,29 +80,29 @@ pub struct LegacyNameRow {
     #[serde(serialize_with = "date_option_to_isostring")]
     pub date_of_birth: Option<NaiveDate>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub phone: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "charge code")]
     pub charge_code: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub country: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "bill_address1")]
     pub address1: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "bill_address2")]
     pub address2: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub email: Option<String>,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "url")]
     pub website: Option<String>,
 

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -1,4 +1,4 @@
-use crate::sync::sync_serde::empty_str_as_option;
+use crate::sync::sync_serde::empty_str_as_option_string;
 use repository::{ReportContext, ReportRow, ReportType, StorageConnection, SyncBufferRow};
 
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ pub struct LegacyReportRow {
     pub context: LegacyReportContext,
     pub template: String,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "Comment")]
     pub comment: Option<String>,
 }

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -12,8 +12,7 @@ use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
         date_and_time_to_datatime, date_from_date_time, date_option_to_isostring,
-        date_to_isostring, empty_str_as_option_generic, empty_str_as_option_string,
-        zero_date_as_option,
+        date_to_isostring, empty_str_as_option, empty_str_as_option_string, zero_date_as_option,
     },
 };
 
@@ -107,17 +106,17 @@ pub struct LegacyRequisitionRow {
 
     #[serde(default)]
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_sent_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub sent_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_finalised_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub finalised_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
@@ -129,7 +128,7 @@ pub struct LegacyRequisitionRow {
     #[serde(rename = "om_max_months_of_stock")]
     pub max_months_of_stock: Option<f64>,
 
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(default)]
     pub om_status: Option<RequisitionRowStatus>,
     /// We ignore the legacy colour field

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -11,8 +11,8 @@ use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
 use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
-        date_and_time_to_datatime, date_from_date_time, date_to_isostring, empty_str_as_option,
-        empty_str_as_option_datetime,
+        date_and_time_to_datatime, date_from_date_time, date_option_to_isostring,
+        date_to_isostring, empty_str_as_option, empty_str_as_option_datetime, zero_date_as_option,
     },
 };
 
@@ -121,6 +121,8 @@ pub struct LegacyRequisitionRow {
 
     #[serde(default)]
     #[serde(rename = "om_expected_delivery_date")]
+    #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub expected_delivery_date: Option<NaiveDate>,
 
     #[serde(rename = "om_max_months_of_stock")]

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -12,6 +12,7 @@ use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
         date_and_time_to_datatime, date_from_date_time, date_to_isostring, empty_str_as_option,
+        empty_str_as_option_datetime,
     },
 };
 
@@ -104,12 +105,15 @@ pub struct LegacyRequisitionRow {
     pub comment: Option<String>,
 
     #[serde(rename = "om_created_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_sent_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub sent_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_finalised_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub finalised_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_expected_delivery_date")]

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -104,18 +104,22 @@ pub struct LegacyRequisitionRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub comment: Option<String>,
 
+    #[serde(default)]
     #[serde(rename = "om_created_datetime")]
     #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub created_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_sent_datetime")]
     #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub sent_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_finalised_datetime")]
     #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub finalised_datetime: Option<NaiveDateTime>,
 
+    #[serde(default)]
     #[serde(rename = "om_expected_delivery_date")]
     pub expected_delivery_date: Option<NaiveDate>,
 

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -12,7 +12,8 @@ use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
         date_and_time_to_datatime, date_from_date_time, date_option_to_isostring,
-        date_to_isostring, empty_str_as_option, empty_str_as_option_datetime, zero_date_as_option,
+        date_to_isostring, empty_str_as_option_generic, empty_str_as_option_string,
+        zero_date_as_option,
     },
 };
 
@@ -83,7 +84,7 @@ pub struct LegacyRequisitionRow {
     pub store_ID: String,
     pub r#type: LegacyRequisitionType,
     pub status: LegacyRequisitionStatus,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(rename = "user_ID")]
     pub user_id: Option<String>,
     // created_datetime
@@ -92,31 +93,31 @@ pub struct LegacyRequisitionRow {
 
     #[serde(rename = "lastModifiedAt")]
     pub last_modified_at: i64,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub requester_reference: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub linked_requisition_id: Option<String>,
     /// min_months_of_stock
     pub thresholdMOS: f64,
     /// relates to max_months_of_stock
     pub daysToSupply: i64,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
 
     #[serde(default)]
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_sent_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub sent_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
     #[serde(rename = "om_finalised_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub finalised_datetime: Option<NaiveDateTime>,
 
     #[serde(default)]
@@ -127,9 +128,12 @@ pub struct LegacyRequisitionRow {
 
     #[serde(rename = "om_max_months_of_stock")]
     pub max_months_of_stock: Option<f64>,
+
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(default)]
     pub om_status: Option<RequisitionRowStatus>,
     /// We ignore the legacy colour field
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     #[serde(default)]
     pub om_colour: Option<String>,
 }

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -1,4 +1,7 @@
-use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option};
+use crate::sync::{
+    api::RemoteSyncRecordV5,
+    sync_serde::{empty_str_as_option, empty_str_as_option_datetime},
+};
 use chrono::NaiveDateTime;
 use repository::{
     ChangelogRow, ChangelogTableName, RequisitionLineRow, RequisitionLineRowRepository,
@@ -41,6 +44,7 @@ pub struct LegacyRequisitionLineRow {
     pub comment: Option<String>,
 
     #[serde(rename = "om_snapshot_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
     pub snapshot_datetime: Option<NaiveDateTime>,
 }
 

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
-    sync_serde::{empty_str_as_option, empty_str_as_option_datetime},
+    sync_serde::{empty_str_as_option_generic, empty_str_as_option_string},
 };
 use chrono::NaiveDateTime;
 use repository::{
@@ -40,11 +40,11 @@ pub struct LegacyRequisitionLineRow {
     // average_monthly_consumption: daily_usage * NUMBER_OF_DAYS_IN_A_MONTH
     pub daily_usage: f64,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
 
     #[serde(rename = "om_snapshot_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     pub snapshot_datetime: Option<NaiveDateTime>,
 }
 

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
-    sync_serde::{empty_str_as_option_generic, empty_str_as_option_string},
+    sync_serde::{empty_str_as_option, empty_str_as_option_string},
 };
 use chrono::NaiveDateTime;
 use repository::{
@@ -44,7 +44,7 @@ pub struct LegacyRequisitionLineRow {
     pub comment: Option<String>,
 
     #[serde(rename = "om_snapshot_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     pub snapshot_datetime: Option<NaiveDateTime>,
 }
 

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
-    sync_serde::{date_option_to_isostring, empty_str_as_option, zero_date_as_option},
+    sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
 };
 use chrono::NaiveDate;
 use repository::{
@@ -26,20 +26,20 @@ pub struct LegacyStockLineRow {
     pub ID: String,
     pub store_ID: String,
     pub item_ID: String,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]
     pub expiry_date: Option<NaiveDate>,
     pub hold: bool,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub location_ID: Option<String>,
     pub pack_size: i32,
     pub available: f64,
     pub quantity: f64,
     pub cost_price: f64,
     pub sell_price: f64,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub note: Option<String>,
 }
 

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -1,8 +1,8 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
-        date_from_date_time, date_option_to_isostring, date_to_isostring,
-        empty_str_as_option_generic, empty_str_as_option_string, naive_time, zero_date_as_option,
+        date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
+        empty_str_as_option_string, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -70,12 +70,12 @@ pub struct LegacyStocktakeRow {
     pub store_ID: String,
 
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(default)]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_finalised_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_generic")]
+    #[serde(deserialize_with = "empty_str_as_option")]
     #[serde(default)]
     pub finalised_datetime: Option<NaiveDateTime>,
 }

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -2,7 +2,7 @@ use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
         date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
-        naive_time, zero_date_as_option,
+        empty_str_as_option_datetime, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -70,9 +70,13 @@ pub struct LegacyStocktakeRow {
     pub store_ID: String,
 
     #[serde(rename = "om_created_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(default)]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_finalised_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(default)]
     pub finalised_datetime: Option<NaiveDateTime>,
 }
 

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -1,8 +1,8 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
     sync_serde::{
-        date_from_date_time, date_option_to_isostring, date_to_isostring, empty_str_as_option,
-        empty_str_as_option_datetime, naive_time, zero_date_as_option,
+        date_from_date_time, date_option_to_isostring, date_to_isostring,
+        empty_str_as_option_generic, empty_str_as_option_string, naive_time, zero_date_as_option,
     },
 };
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -43,18 +43,18 @@ pub struct LegacyStocktakeRow {
     #[serde(rename = "created_by_ID")]
     pub user_id: String,
     pub status: LegacyStocktakeStatus,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub Description: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
     #[serde(rename = "Locked")]
     pub is_locked: bool,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub invad_additions_ID: Option<String>,
 
     // Ignore invad_reductions_ID for V1
-    // #[serde(deserialize_with = "empty_str_as_option")]
+    // #[serde(deserialize_with = "empty_str_as_option_string")]
     // invad_reductions_ID: Option<String>,
     pub serial_number: i64,
     #[serde(serialize_with = "date_to_isostring")]
@@ -70,12 +70,12 @@ pub struct LegacyStocktakeRow {
     pub store_ID: String,
 
     #[serde(rename = "om_created_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     #[serde(default)]
     pub created_datetime: Option<NaiveDateTime>,
 
     #[serde(rename = "om_finalised_datetime")]
-    #[serde(deserialize_with = "empty_str_as_option_datetime")]
+    #[serde(deserialize_with = "empty_str_as_option_generic")]
     #[serde(default)]
     pub finalised_datetime: Option<NaiveDateTime>,
 }

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     api::RemoteSyncRecordV5,
-    sync_serde::{date_option_to_isostring, empty_str_as_option, zero_date_as_option},
+    sync_serde::{date_option_to_isostring, empty_str_as_option_string, zero_date_as_option},
 };
 use chrono::NaiveDate;
 use repository::{
@@ -26,18 +26,18 @@ pub struct LegacyStocktakeLineRow {
     pub ID: String,
     pub stock_take_ID: String,
 
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub location_id: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub comment: Option<String>,
     pub snapshot_qty: f64,
     pub snapshot_packsize: i32,
     pub stock_take_qty: f64,
     pub is_edited: bool,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub item_line_ID: Option<String>,
     pub item_ID: String,
-    #[serde(deserialize_with = "empty_str_as_option")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub Batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
     #[serde(serialize_with = "date_option_to_isostring")]


### PR DESCRIPTION
Fixes #818

- `empty_str_as_option_generic` new deserializer. Handles empty string values for generic type. `Option<T>` I think you could say.
- Fixes all all the `om_*` fields of type `Option<NaiveDateTime>` when the JSON value is `""`
- Fixes all all the `om_*` fields of type `Option<SomeEnum>` when the JSON value is `""`. E.g `om_status` and `om_type`.