### PR TITLE
834 Remove code from Program Selector UI

### DIFF
--- a/client/packages/system/src/Patient/Components/EncounterSearchInput/EncounterSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/EncounterSearchInput/EncounterSearchInput.tsx
@@ -23,18 +23,6 @@ export const getEncounterOptionRenderer =
     return (
       <DefaultAutocompleteItemOption {...props} key={props.id}>
         <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Box display="flex" flexDirection="row" gap={1} width={110}>
-            <Typography
-              overflow="hidden"
-              fontWeight="bold"
-              textOverflow="ellipsis"
-              sx={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {name?.substring(0, 3)}
-            </Typography>
-          </Box>
           <Typography>{name}</Typography>
         </Box>
       </DefaultAutocompleteItemOption>

--- a/client/packages/system/src/Program/Components/ProgramOptionRenderer.tsx
+++ b/client/packages/system/src/Program/Components/ProgramOptionRenderer.tsx
@@ -21,20 +21,16 @@ export const getProgramOptionRenderer =
     return (
       <DefaultAutocompleteItemOption {...props} key={props.id}>
         <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Box display="flex" flexDirection="row" gap={1} width={110}>
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="center"
+            gap={1}
+            width={50}
+          >
             <Box flex={0} style={{ height: 24, minWidth: 20 }}>
               {props['aria-disabled'] && <CheckIcon fontSize="small" />}
             </Box>
-            <Typography
-              overflow="hidden"
-              fontWeight="bold"
-              textOverflow="ellipsis"
-              sx={{
-                whiteSpace: 'no-wrap',
-              }}
-            >
-              {name?.substring(0, 3)}
-            </Typography>
           </Box>
           <Typography>{name}</Typography>
         </Box>


### PR DESCRIPTION
Fix #834 

Very quick fix -- just remove the UI element and make the remaining "Checked" column centered, as discussed in [this comment](https://github.com/openmsupply/open-msupply/issues/834#issuecomment-1326958182).

Is that the only place where this appears?