### PR TITLE
655 Number widget string representation

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -29,9 +29,7 @@ type NumberOptions = {
   /*
   Options only required if the saved data should be converted to a string
   representation of the number
-  */
-  output?: 'string';
-  /*
+
   The output string will be padded with leading 0's up to the number of significant figures specified
   */
   sigFigs?: number;
@@ -52,7 +50,7 @@ const UIComponent = (props: ControlProps) => {
   // The selected number can be saved as a string (with optional leading zeroes)
   // using the "output: string" and "sigFig" options
   const formatValue = (value: number): number | string => {
-    if (options?.['output'] !== 'string') return value;
+    if (schema?.type !== 'string') return value;
     return String(value).padStart(options?.['sigFigs'] ?? 0, '0');
   };
 

--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -39,15 +39,15 @@ type NumberOptions = {
 
 const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path, errors, schema, uischema } = props;
-
-  const options: NumberOptions = uischema?.options ?? {};
-
   const [localData, setLocalData] = useState<number | undefined>(Number(data));
+
   const onChange = useDebounceCallback(
     (value: number | string) => handleChange(path, value),
     [path]
   );
   const error = !!errors;
+
+  const options: NumberOptions = uischema?.options ?? {};
 
   // The selected number can be saved as a string (with optional leading zeroes)
   // using the "output: string" and "sigFig" options

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -129,15 +129,7 @@
       "type": "object"
     },
     "Gender": {
-      "enum": [
-        "FEMALE",
-        "MALE",
-        "TRANSGENDER",
-        "TRANSGENDER_MALE",
-        "TRANSGENDER_FEMALE",
-        "UNKNOWN",
-        "NON_BINARY"
-      ],
+      "enum": ["FEMALE", "MALE", "TRANSGENDER", "TRANSGENDER_MALE", "TRANSGENDER_FEMALE", "UNKNOWN", "NON_BINARY"],
       "type": "string"
     },
     "Handedness": {
@@ -158,14 +150,7 @@
       "type": "object"
     },
     "MaritalStatus": {
-      "enum": [
-        "SINGLE",
-        "MARRIED",
-        "DIVORCED",
-        "WIDOWED",
-        "SEPARATED",
-        "REGISTERED_PARTNERSHIP"
-      ],
+      "enum": ["SINGLE", "MARRIED", "DIVORCED", "WIDOWED", "SEPARATED", "REGISTERED_PARTNERSHIP"],
       "type": "string"
     },
     "Note": {
@@ -376,8 +361,6 @@
         },
         "birthOrder": {
           "description": "Birth order, e.g. \"02\" for second child",
-          "examples": ["01", "02", "03"],
-          "pattern": "^[0-9]{2}$",
           "type": "string"
         },
         "birthPlace": {

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -255,8 +255,9 @@
                   }
                 },
                 {
-                  "type": "Control",
-                  "scope": "#/properties/birthOrder"
+                  "type": "Number",
+                  "scope": "#/properties/birthOrder",
+                  "options": { "output": "string", "sigFig": 2 }
                 },
                 {
                   "type": "Control",


### PR DESCRIPTION
Closes #655 

Last item on the list. Solution as per [this comment](https://github.com/openmsupply/open-msupply/issues/655#issuecomment-1333088425)

Can save "numbers" as strings with the appropriate option specified, which means we can use the "Number" selector for the Birth Order field and still get a useful 2-digit string for the ID Generator, rather than the user having to type a very specific, unintuitive number format into a free test field.

The "Number" widget will continue to use a number as its internal "localData", but is optionally converted to a string when saving (onChange), and converted back when loading.

See inline comments for more.