### PR TITLE
655 id generator can handle numeric values

### DIFF
--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -151,7 +151,7 @@ const validateFields = (
     const field = extractProperty(data, part.field);
     const fieldName =
       typeof part.field === 'string' ? part.field : part.field.join('.');
-    if (field === undefined || typeof field !== 'string' || field === '') {
+    if (field === undefined || field === '') {
       return `Missing required field: ${fieldName}`;
     }
   }
@@ -186,10 +186,10 @@ const valueFromPart = async (
   switch (part.type) {
     case 'Field': {
       const field = extractProperty(data, part.field);
-      if (field === undefined || typeof field !== 'string') {
+      if (field === undefined) {
         return undefined;
       }
-      return field;
+      return String(field);
     }
     case 'StoreCode': {
       return config.store?.code;

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -360,7 +360,7 @@
           "$ref": "#/definitions/Allergies"
         },
         "birthOrder": {
-          "description": "Birth order, e.g. \"02\" for second child",
+          "description": "Birth order, e.g. second child = 2",
           "type": "number"
         },
         "birthPlace": {

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -361,7 +361,9 @@
         },
         "birthOrder": {
           "description": "Birth order, e.g. second child = 2",
-          "type": "number"
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99
         },
         "birthPlace": {
           "$ref": "#/definitions/Address",

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -129,15 +129,7 @@
       "type": "object"
     },
     "Gender": {
-      "enum": [
-        "FEMALE",
-        "MALE",
-        "TRANSGENDER",
-        "TRANSGENDER_MALE",
-        "TRANSGENDER_FEMALE",
-        "UNKNOWN",
-        "NON_BINARY"
-      ],
+      "enum": ["FEMALE", "MALE", "TRANSGENDER", "TRANSGENDER_MALE", "TRANSGENDER_FEMALE", "UNKNOWN", "NON_BINARY"],
       "type": "string"
     },
     "Handedness": {
@@ -158,14 +150,7 @@
       "type": "object"
     },
     "MaritalStatus": {
-      "enum": [
-        "SINGLE",
-        "MARRIED",
-        "DIVORCED",
-        "WIDOWED",
-        "SEPARATED",
-        "REGISTERED_PARTNERSHIP"
-      ],
+      "enum": ["SINGLE", "MARRIED", "DIVORCED", "WIDOWED", "SEPARATED", "REGISTERED_PARTNERSHIP"],
       "type": "string"
     },
     "Note": {
@@ -376,9 +361,7 @@
         },
         "birthOrder": {
           "description": "Birth order, e.g. \"02\" for second child",
-          "examples": ["01", "02", "03"],
-          "pattern": "^[0-9]{2}$",
-          "type": "string"
+          "type": "number"
         },
         "birthPlace": {
           "$ref": "#/definitions/Address",

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -62,7 +62,7 @@
                       {
                         "type": "Field",
                         "field": "birthOrder",
-                        "mutations": [{ "firstNChars": 2 }, { "toUpperCase": true }, { "padString": "00" }]
+                        "mutations": [{ "firstNChars": 2 }, { "padString": "00" }]
                       },
                       {
                         "type": "Field",

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -62,7 +62,7 @@
                       {
                         "type": "Field",
                         "field": "birthOrder",
-                        "mutations": [{ "firstNChars": 2 }, { "toUpperCase": true }]
+                        "mutations": [{ "firstNChars": 2 }, { "toUpperCase": true }, { "padString": "00" }]
                       },
                       {
                         "type": "Field",


### PR DESCRIPTION
Replaces PR #955

Closes #655 

After [rethinking that one](https://github.com/openmsupply/open-msupply/pull/944#discussion_r1050164902), it seems to make more sense to have the ID generator handle a numeric input part rather than changing the Number control to output strings.

Which is actually a much simpler change and keeps each control more focused on what it should be doing.