### PR TITLE
#910 Timestamp fixes

### DIFF
--- a/server/graphql/general/src/queries/tests/activity_log.rs
+++ b/server/graphql/general/src/queries/tests/activity_log.rs
@@ -34,21 +34,21 @@ mod graphql {
             "activityLogs": {
                 "nodes": [
                     {
-                        "datetime": "2020-01-01T00:00:00",
+                        "datetime": "2020-01-01T00:00:00+00:00",
                         "id": "log_a",
                         "type": "USER_LOGGED_IN",
                         "recordId": null,
                         "storeId": null,
                     },
                     {
-                        "datetime": "2020-01-01T00:00:00",
+                        "datetime": "2020-01-01T00:00:00+00:00",
                         "id": "log_b",
                         "type": "INVOICE_CREATED",
                         "recordId": "outbound_shipment_a",
                         "storeId": "store_b",
                     },
                     {
-                        "datetime": "2020-01-01T00:00:00",
+                        "datetime": "2020-01-01T00:00:00+00:00",
                         "id": "log_c",
                         "type": "INVOICE_STATUS_ALLOCATED",
                         "recordId": "inbound_shipment_a",
@@ -106,7 +106,7 @@ mod graphql {
                         "id": "log_b",
                         "type": "INVOICE_CREATED",
                         "recordId": "outbound_shipment_a",
-                        "datetime": "2020-01-01T00:00:00",
+                        "datetime": "2020-01-01T00:00:00+00:00",
                         "store": {
                             "id": "store_b"
                         },

--- a/server/graphql/types/src/types/activity_log.rs
+++ b/server/graphql/types/src/types/activity_log.rs
@@ -1,5 +1,6 @@
 use async_graphql::{dataloader::DataLoader, *};
-use chrono::NaiveDateTime;
+use chrono::DateTime;
+use chrono::Utc;
 use graphql_core::{
     loader::{StoreByIdLoader, UserLoader},
     ContextExt,
@@ -64,8 +65,8 @@ impl ActivityLogNode {
         &self.row().record_id
     }
 
-    pub async fn datetime(&self) -> &NaiveDateTime {
-        &self.row().datetime
+    pub async fn datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(self.row().datetime.clone(), Utc)
     }
 
     pub async fn event(&self) -> &Option<String> {


### PR DESCRIPTION
Closes #910 

Seems like this is mostly related to the Activity log -- the back-end type was a NaiveDateTime rather than a UTC timestamp. 

I've made the small change to the back-end and it's showing correctly in the "Outbound shipment" UI as per the original screenshot.

@DhanyaHerath is there any other places specifically this could still be wrong that I should check?