### PR TITLE
841 remove graphql request logging

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -95,6 +95,7 @@ Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Co
 
 ### Ubuntu
 
+- Install libavahi-compat-libdnssd-dev (dnssd dependency): `sudo apt install libavahi-compat-libdnssd-dev`
 - Install Postgres dev libs: `sudo apt install postgresql-server-dev-13`
 
 ### Optional

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -1,14 +1,10 @@
 #[cfg(test)]
 mod tests;
 
-use std::sync::Arc;
-
 use actix_web::web::{self, Data};
 use actix_web::HttpResponse;
 use actix_web::{guard, HttpRequest};
-use async_graphql::extensions::{
-    Extension, ExtensionContext, ExtensionFactory, Logger, NextExecute,
-};
+
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::{EmptySubscription, Schema};
 use async_graphql::{MergedObject, Response};
@@ -29,7 +25,6 @@ use graphql_stock_line::{StockLineMutations, StockLineQueries};
 use graphql_stocktake::{StocktakeMutations, StocktakeQueries};
 use graphql_stocktake_line::StocktakeLineMutations;
 
-use log::info;
 use repository::StorageConnectionManager;
 use service::auth_data::AuthData;
 use service::service_provider::ServiceProvider;
@@ -149,9 +144,7 @@ impl GraphqlSchema {
                 .data(auth.clone())
                 .data(settings.clone())
                 // Add self requester to operational
-                .data(Data::new(SelfRequestImpl::new_boxed(self_requester_schema)))
-                .extension(Logger)
-                .extension(ResponseLogger);
+                .data(Data::new(SelfRequestImpl::new_boxed(self_requester_schema)));
 
         // Initialisation schema should ony need service_provider
         let initialisiation_builder = InitialisationSchema::build(
@@ -159,9 +152,7 @@ impl GraphqlSchema {
             InitialisationMutations,
             EmptySubscription,
         )
-        .data(service_provider.clone())
-        .extension(Logger)
-        .extension(ResponseLogger);
+        .data(service_provider.clone());
 
         GraphqlSchema {
             operational: operational_builder.finish(),
@@ -217,30 +208,6 @@ async fn graphql_playground() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(playground_source(GraphQLPlaygroundConfig::new("/graphql")))
-}
-
-pub struct ResponseLogger;
-impl ExtensionFactory for ResponseLogger {
-    fn create(&self) -> Arc<dyn Extension> {
-        Arc::new(ResponseLoggerExtension)
-    }
-}
-struct ResponseLoggerExtension;
-#[async_trait::async_trait]
-impl Extension for ResponseLoggerExtension {
-    async fn execute(
-        &self,
-        ctx: &ExtensionContext<'_>,
-        operation_name: Option<&str>,
-        next: NextExecute<'_>,
-    ) -> async_graphql::Response {
-        let resp = next.run(ctx, operation_name).await;
-        info!(
-            target: "async-graphql",
-            "[Execute Response] {:?}\nresponse_length: {}", operation_name, format!("{:?}", resp).len()
-        );
-        resp
-    }
 }
 
 // TODO remove this and just do reqwest query to self


### PR DESCRIPTION
The main culprit was the async_graphql::extensionsLogger, I removed it and the custom ResponseLogger. I first just wanted to comment it out but it would be a little bit messy because the comment would needed at multiple places. @andreievg do you think it is worth it to put some more afford in to make it easy to get it back when needed?

Closes #841 