### PR TITLE
#777 Tab indicator correctly moves when Details panel is opened

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -1,8 +1,9 @@
 import React, { FC, ReactNode, useState, useEffect } from 'react';
 import { TabContext } from '@mui/lab';
 import { Box } from '@mui/material';
-import { useDetailPanelStore } from '@common/hooks';
+import { useDetailPanelStore, useDrawer } from '@common/hooks';
 import { LocaleKey, useTranslation } from '@common/intl';
+import { debounce } from 'lodash';
 import { AppBarTabsPortal } from '../../portals';
 import { DetailTab } from './DetailTab';
 import { ShortTabList, Tab } from './Tabs';
@@ -18,14 +19,18 @@ export const DetailTabs: FC<DetailTabsProps> = ({ tabs }) => {
   const [currentTab, setCurrentTab] = useState<string>(tabs[0]?.value ?? '');
   const t = useTranslation('common');
 
-  const { isOpen } = useDetailPanelStore();
-
-  // Ugly hack to force the "Underline" indicator for the currently active tab
-  // to re-render when the "More" details panel is expanded. See issue #777 for
-  // more detail.
+  // Inelegant hack to force the "Underline" indicator for the currently active
+  // tab to re-render in the correct position when one of the side "drawers" is
+  // expanded. See issue #777 for more detail.
+  const { isOpen: detailPanelOpen } = useDetailPanelStore();
+  const { isOpen: drawerOpen } = useDrawer();
+  const handleResize = debounce(
+    () => window.dispatchEvent(new Event('resize')),
+    100
+  );
   useEffect(() => {
-    window.dispatchEvent(new Event('resize'));
-  }, [isOpen]);
+    handleResize();
+  }, [detailPanelOpen, drawerOpen]);
 
   return (
     <TabContext value={currentTab}>

--- a/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/DetailTabs.tsx
@@ -1,6 +1,7 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode, useState, useEffect } from 'react';
 import { TabContext } from '@mui/lab';
 import { Box } from '@mui/material';
+import { useDetailPanelStore } from '@common/hooks';
 import { LocaleKey, useTranslation } from '@common/intl';
 import { AppBarTabsPortal } from '../../portals';
 import { DetailTab } from './DetailTab';
@@ -16,6 +17,15 @@ interface DetailTabsProps {
 export const DetailTabs: FC<DetailTabsProps> = ({ tabs }) => {
   const [currentTab, setCurrentTab] = useState<string>(tabs[0]?.value ?? '');
   const t = useTranslation('common');
+
+  const { isOpen } = useDetailPanelStore();
+
+  // Ugly hack to force the "Underline" indicator for the currently active tab
+  // to re-render when the "More" details panel is expanded. See issue #777 for
+  // more detail.
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, [isOpen]);
 
   return (
     <TabContext value={currentTab}>


### PR DESCRIPTION
Closes #777

![777-banner](https://user-images.githubusercontent.com/5456533/208340129-3cb4be01-8399-428b-bab4-53c545d9749f.jpg)

Uses solution suggested by @mark-prins to trigger the underline indicator to recalculate its position.