### PR TITLE
UI review Items part I

### DIFF
--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -132,7 +132,7 @@ export const themeOptions = {
       },
     },
     drawer: {
-      selectedBackgroundColor: '#fff',
+      selectedBackgroundColor: 'transparent',
     },
     saveButtonRow: { height: 40 },
     footer: { height: 32 },

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Grid, Paper, Tooltip, Typography } from '@mui/material';
-import { BarChartIcon, InlineSpinner, StockIcon } from '../../../';
+import { InlineSpinner, StockIcon } from '../../../';
 import { useTranslation } from '@common/intl';
 
 export type Stat = {
@@ -48,6 +48,7 @@ export const StatsPanel: FC<StatsPanelProps> = ({
         item
         sx={{
           color: 'gray.main',
+          flex: 1,
           fontSize: '12px',
           fontWeight: 500,
           marginInlineStart: '8px',
@@ -66,7 +67,6 @@ export const StatsPanel: FC<StatsPanelProps> = ({
         marginBottom: '21px',
         boxShadow: theme => theme.shadows[1],
         padding: '14px 24px',
-        minWidth: '300px',
         width: width ? `${width}px` : undefined,
       }}
     >
@@ -101,12 +101,6 @@ export const StatsPanel: FC<StatsPanelProps> = ({
               ))}
             </Grid>
           )}
-          <Grid item>
-            <BarChartIcon
-              sx={{ height: '50px', width: '125px' }}
-              color="secondary"
-            />
-          </Grid>
         </Grid>
       </Grid>
     </Paper>

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -13,11 +13,16 @@ import { styled } from '@mui/material/styles';
 import { useMatch, Link } from 'react-router-dom';
 import { useDrawer } from '@common/hooks';
 
-const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
+const useSelectedNavMenuItem = (
+  to: string,
+  end: boolean,
+  isOpen: boolean
+): boolean => {
   // This nav menu item should be selected when lower level elements
   // are selected. For example, the route /outbound-shipment/{id} should
   // highlight the nav menu item for outbound-shipments.
-  const highlightLowerLevels = !end || to.endsWith('*');
+  // If the drawer is closed, highlight the higher level elements.
+  const highlightLowerLevels = !isOpen ? false : !end || to.endsWith('*');
   // If we need to highlight the higher levels append a wildcard to the match path.
   const path = highlightLowerLevels ? to : `${to}/*`;
   const selected = useMatch({ path });
@@ -71,7 +76,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   } = props;
   const drawer = useDrawer();
 
-  const selected = useSelectedNavMenuItem(to, !!end);
+  const selected = useSelectedNavMenuItem(to, !!end, drawer.isOpen);
   const handleClick = () => {
     if (onClick) onClick();
     drawer.onClick();

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -12,6 +12,7 @@ import {
 import { styled } from '@mui/material/styles';
 import { useMatch, Link } from 'react-router-dom';
 import { useDrawer } from '@common/hooks';
+import { ChevronDownIcon } from '@common/icons';
 
 const useSelectedNavMenuItem = (
   to: string,
@@ -139,6 +140,24 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
                   : {}
               }
             />
+            {end && (
+              <ListItemIcon
+                sx={{
+                  minWidth: 20,
+                  display: selected ? 'flex' : 'none',
+                  alignItems: 'center',
+                }}
+                className="chevron"
+              >
+                <ChevronDownIcon
+                  sx={{
+                    transform: 'rotate(-90deg)',
+                    fontSize: '1rem',
+                    color: 'primary.main',
+                  }}
+                />
+              </ListItemIcon>
+            )}
           </Box>
         </Badge>
       </ListItemButton>

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -22,7 +22,7 @@ const useSelectedNavMenuItem = (
   // are selected. For example, the route /outbound-shipment/{id} should
   // highlight the nav menu item for outbound-shipments.
   // If the drawer is closed, highlight the higher level elements.
-  const highlightLowerLevels = !isOpen ? false : !end || to.endsWith('*');
+  const highlightLowerLevels = isOpen ? !end || to.endsWith('*') : false;
   // If we need to highlight the higher levels append a wildcard to the match path.
   const path = highlightLowerLevels ? to : `${to}/*`;
   const selected = useMatch({ path });
@@ -77,6 +77,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const drawer = useDrawer();
 
   const selected = useSelectedNavMenuItem(to, !!end, drawer.isOpen);
+  const isSelectedParentItem = inactive && !!useMatch({ path: `${to}/*` });
   const handleClick = () => {
     if (onClick) onClick();
     drawer.onClick();
@@ -127,7 +128,14 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
           <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
           <Box className="navLinkText">
             <Box width={10} />
-            <ListItemText primary={text} />
+            <ListItemText
+              primary={text}
+              sx={
+                isSelectedParentItem
+                  ? { '& .MuiTypography-root': { fontWeight: 'bold' } }
+                  : {}
+              }
+            />
           </Box>
         </Badge>
       </ListItemButton>

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -79,6 +79,9 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const selected = useSelectedNavMenuItem(to, !!end, drawer.isOpen);
   const isSelectedParentItem = inactive && !!useMatch({ path: `${to}/*` });
   const handleClick = () => {
+    // reset the clicked nav path when navigating
+    // otherwise the child menu remains open
+    drawer.setClickedNavPath(undefined);
     if (onClick) onClick();
     drawer.onClick();
   };

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -33,7 +33,6 @@ const useSelectedNavMenuItem = (
 const getListItemCommonStyles = () => ({
   height: 40,
   borderRadius: 20,
-  justifyContent: 'center',
   alignItems: 'center',
 });
 
@@ -116,6 +115,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
       <ListItemButton
         sx={{
           ...getListItemCommonStyles(),
+          justifyContent: drawer.isOpen ? 'flex-start' : 'center',
           '&.MuiListItemButton-root:hover': {
             backgroundColor: 'transparent',
           },
@@ -128,38 +128,56 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         disableGutters
         component={CustomLink}
       >
-        <Badge {...badgeProps} sx={{ alignItems: 'center', flexGrow: 1 }}>
-          <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
-          <Box className="navLinkText">
-            <Box width={10} />
+        <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
+        <Box className="navLinkText">
+          <Box width={10} />
+
+          <Badge
+            {...badgeProps}
+            sx={{
+              alignItems: 'center',
+              flexGrow: 1,
+              '& .MuiBadge-badge': drawer.isOpen
+                ? {
+                    transform: 'scale(0.75) translate(75%, -25%)',
+                  }
+                : {
+                    top: 'unset',
+                    transform: 'scale(0.75) translate(50%, -50%)',
+                  },
+            }}
+          >
             <ListItemText
               primary={text}
               sx={
                 isSelectedParentItem
-                  ? { '& .MuiTypography-root': { fontWeight: 'bold' } }
-                  : {}
+                  ? {
+                      '& .MuiTypography-root': { fontWeight: 'bold' },
+                      flexGrow: 0,
+                    }
+                  : { flexGrow: 0 }
               }
             />
-            {end && (
-              <ListItemIcon
+          </Badge>
+          {end && (
+            <ListItemIcon
+              sx={{
+                minWidth: 20,
+                display: selected ? 'flex' : 'none',
+                alignItems: 'center',
+              }}
+              className="chevron"
+            >
+              <ChevronDownIcon
                 sx={{
-                  minWidth: 20,
-                  display: selected ? 'flex' : 'none',
-                  alignItems: 'center',
+                  transform: 'rotate(-90deg)',
+                  fontSize: '1rem',
+                  color: 'primary.main',
                 }}
-                className="chevron"
-              >
-                <ChevronDownIcon
-                  sx={{
-                    transform: 'rotate(-90deg)',
-                    fontSize: '1rem',
-                    color: 'primary.main',
-                  }}
-                />
-              </ListItemIcon>
-            )}
-          </Box>
-        </Badge>
+              />
+            </ListItemIcon>
+          )}
+        </Box>
       </ListItemButton>
     </StyledListItem>
   ) : null;

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -1,0 +1,18 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { Box, Theme } from '@mui/material';
+import { useMatch } from 'react-router-dom';
+import { useDrawer } from '@common/hooks';
+
+export const AppNavSection: FC<
+  PropsWithChildren<{ isActive: boolean; to: string }>
+> = ({ children, isActive, to }) => {
+  const { isOpen } = useDrawer();
+  const backgroundColor = (theme: Theme) =>
+    useMatch({ path: `${to}/*` })
+      ? theme.palette.background.toolbar
+      : 'transparent';
+  const sx = isActive ? { borderRadius: 2, boxShadow: 3, backgroundColor } : {};
+
+  // the div is picking up styles from parent objects and ends up wider than it should be
+  return isOpen ? <Box sx={sx}>{children}</Box> : <>{children}</>;
+};

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -19,7 +19,9 @@ export const AppNavSection: FC<
               '& .MuiCollapse-wrapperInner > ul > li.MuiListItem-root': {
                 height: 30,
                 marginLeft: 1,
-                // boxShadow: 'none',
+              },
+              '& .navLinkText': {
+                flex: 1,
               },
               '& .MuiListItem-root:hover .chevron': {
                 display: 'flex',

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -1,18 +1,37 @@
 import React, { FC, PropsWithChildren } from 'react';
-import { Box, Theme } from '@mui/material';
-import { useMatch } from 'react-router-dom';
+import { Box } from '@mui/material';
 import { useDrawer } from '@common/hooks';
 
 export const AppNavSection: FC<
   PropsWithChildren<{ isActive: boolean; to: string }>
-> = ({ children, isActive, to }) => {
+> = ({ children, isActive }) => {
   const { isOpen } = useDrawer();
-  const backgroundColor = (theme: Theme) =>
-    useMatch({ path: `${to}/*` })
-      ? theme.palette.background.toolbar
-      : 'transparent';
-  const sx = isActive ? { borderRadius: 2, boxShadow: 3, backgroundColor } : {};
 
   // the div is picking up styles from parent objects and ends up wider than it should be
-  return isOpen ? <Box sx={sx}>{children}</Box> : <>{children}</>;
+  return isOpen ? (
+    <Box
+      sx={
+        isActive
+          ? {
+              '& .MuiCollapse-root': {
+                marginTop: -1.5,
+              },
+              '& .MuiCollapse-wrapperInner > ul > li.MuiListItem-root': {
+                height: 30,
+                marginLeft: 1,
+                // boxShadow: 'none',
+              },
+              '& .MuiListItem-root:hover .chevron': {
+                display: 'flex',
+              },
+            }
+          : {}
+      }
+      className="nav-section"
+    >
+      {children}
+    </Box>
+  ) : (
+    <>{children}</>
+  );
 };

--- a/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
@@ -7,11 +7,9 @@ import {
   ListItemButton,
   Box,
   ListItemProps,
-  Badge,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { ExternalLinkIcon } from '@common/icons';
-import { useDrawer } from '@common/hooks';
 
 const getListItemCommonStyles = () => ({
   height: 40,
@@ -39,7 +37,6 @@ export interface ExternalNavLinkProps {
 }
 
 export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
-  const drawer = useDrawer();
   const { icon = <span style={{ width: 2 }} />, text, to, trustedSite } = props;
 
   const CustomLink = React.useMemo(
@@ -67,7 +64,6 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
         <ListItemButton
           sx={{
             ...getListItemCommonStyles(),
-            justifyContent: drawer.isOpen ? 'flex-start' : 'center',
             '&.MuiListItemButton-root:hover': {
               backgroundColor: 'transparent',
             },
@@ -83,31 +79,21 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
           <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
           <Box className="navLinkText">
             <Box width={10} />
-            <Badge
-              color="default"
-              badgeContent={
-                <ExternalLinkIcon
-                  sx={{
-                    stroke: theme => theme.palette.gray.main,
-                    strokeWidth: '1px',
-                  }}
-                />
+            <ListItemText
+              primary={
+                <>
+                  {text}
+                  <ExternalLinkIcon
+                    sx={{
+                      height: '14px',
+                      marginLeft: 1,
+                      strokeWidth: '1px',
+                      width: '14px',
+                    }}
+                  />
+                </>
               }
-              sx={{
-                alignItems: 'center',
-                flexGrow: 1,
-                '& .MuiBadge-badge': drawer.isOpen
-                  ? {
-                      transform: 'scale(0.6) translate(75%, -25%)',
-                    }
-                  : {
-                      top: 'unset',
-                      transform: 'scale(0.5) translate(50%, -50%)',
-                    },
-              }}
-            >
-              <ListItemText primary={text} />
-            </Badge>
+            />
           </Box>
         </ListItemButton>
       </StyledListItem>

--- a/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
@@ -84,17 +84,15 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
               primary={
                 <>
                   {text}
-                  <sup>
-                    <ExternalLinkIcon
-                      sx={{
-                        height: '16px',
-                        marginLeft: 2,
-                        stroke: theme => theme.palette.gray.main,
-                        strokeWidth: '1px',
-                        width: '16px',
-                      }}
-                    />
-                  </sup>
+                  <ExternalLinkIcon
+                    sx={{
+                      height: '16px',
+                      marginLeft: 2,
+                      stroke: theme => theme.palette.gray.main,
+                      strokeWidth: '1px',
+                      width: '16px',
+                    }}
+                  />
                 </>
               }
             />

--- a/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
@@ -9,6 +9,7 @@ import {
   ListItemProps,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { ExternalLinkIcon } from '@common/icons';
 
 const getListItemCommonStyles = () => ({
   height: 40,
@@ -79,7 +80,24 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
           <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
           <Box className="navLinkText">
             <Box width={10} />
-            <ListItemText primary={text} />
+            <ListItemText
+              primary={
+                <>
+                  {text}
+                  <sup>
+                    <ExternalLinkIcon
+                      sx={{
+                        height: '16px',
+                        marginLeft: 2,
+                        stroke: theme => theme.palette.gray.main,
+                        strokeWidth: '1px',
+                        width: '16px',
+                      }}
+                    />
+                  </sup>
+                </>
+              }
+            />
           </Box>
         </ListItemButton>
       </StyledListItem>

--- a/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/ExternalNavLink.tsx
@@ -7,14 +7,15 @@ import {
   ListItemButton,
   Box,
   ListItemProps,
+  Badge,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { ExternalLinkIcon } from '@common/icons';
+import { useDrawer } from '@common/hooks';
 
 const getListItemCommonStyles = () => ({
   height: 40,
   borderRadius: 20,
-  justifyContent: 'center',
   alignItems: 'center',
 });
 
@@ -38,6 +39,7 @@ export interface ExternalNavLinkProps {
 }
 
 export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
+  const drawer = useDrawer();
   const { icon = <span style={{ width: 2 }} />, text, to, trustedSite } = props;
 
   const CustomLink = React.useMemo(
@@ -65,6 +67,7 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
         <ListItemButton
           sx={{
             ...getListItemCommonStyles(),
+            justifyContent: drawer.isOpen ? 'flex-start' : 'center',
             '&.MuiListItemButton-root:hover': {
               backgroundColor: 'transparent',
             },
@@ -80,22 +83,31 @@ export const ExternalNavLink: FC<ExternalNavLinkProps> = props => {
           <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
           <Box className="navLinkText">
             <Box width={10} />
-            <ListItemText
-              primary={
-                <>
-                  {text}
-                  <ExternalLinkIcon
-                    sx={{
-                      height: '16px',
-                      marginLeft: 2,
-                      stroke: theme => theme.palette.gray.main,
-                      strokeWidth: '1px',
-                      width: '16px',
-                    }}
-                  />
-                </>
+            <Badge
+              color="default"
+              badgeContent={
+                <ExternalLinkIcon
+                  sx={{
+                    stroke: theme => theme.palette.gray.main,
+                    strokeWidth: '1px',
+                  }}
+                />
               }
-            />
+              sx={{
+                alignItems: 'center',
+                flexGrow: 1,
+                '& .MuiBadge-badge': drawer.isOpen
+                  ? {
+                      transform: 'scale(0.6) translate(75%, -25%)',
+                    }
+                  : {
+                      top: 'unset',
+                      transform: 'scale(0.5) translate(50%, -50%)',
+                    },
+              }}
+            >
+              <ListItemText primary={text} />
+            </Badge>
           </Box>
         </ListItemButton>
       </StyledListItem>

--- a/client/packages/common/src/ui/components/navigation/index.ts
+++ b/client/packages/common/src/ui/components/navigation/index.ts
@@ -1,4 +1,5 @@
-export * from './Breadcrumbs';
 export * from './AppNavLink';
+export * from './AppNavSection';
+export * from './Breadcrumbs';
 export * from './ExternalNavLink';
 export * from './Tabs';

--- a/client/packages/common/src/ui/icons/ExternalLink.tsx
+++ b/client/packages/common/src/ui/icons/ExternalLink.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+export const ExternalLinkIcon = (props: SvgIconProps): JSX.Element => {
+  const { sx, ...rest } = props;
+  return (
+    <SvgIcon
+      {...rest}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      viewBox="0 0 24 24"
+      sx={{ ...sx, fill: 'none' }}
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+      <polyline points="15 3 21 3 21 9"></polyline>
+      <line x1="10" y1="14" x2="21" y2="3"></line>
+    </SvgIcon>
+  );
+};

--- a/client/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/client/packages/common/src/ui/icons/Icon.stories.tsx
@@ -24,6 +24,7 @@ import { DashboardIcon } from './Dashboard';
 import { DeleteIcon } from './Delete';
 import { DownloadIcon } from './Download';
 import { EditIcon } from './Edit';
+import { ExternalLinkIcon } from './ExternalLink';
 import { EyeIcon } from './Eye';
 import { EyeOffIcon } from './EyeOff';
 import { FilterIcon } from './Filter';
@@ -103,6 +104,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <DeleteIcon {...args} />, name: 'Delete' },
     { icon: <DownloadIcon {...args} />, name: 'Download' },
     { icon: <EditIcon {...args} />, name: 'Edit' },
+    { icon: <ExternalLinkIcon {...args} />, name: 'External Link' },
     { icon: <EyeIcon {...args} />, name: 'Eye' },
     { icon: <EyeOffIcon {...args} />, name: 'EyeOff' },
     { icon: <FilterIcon {...args} />, name: 'Filter' },

--- a/client/packages/common/src/ui/icons/index.ts
+++ b/client/packages/common/src/ui/icons/index.ts
@@ -20,6 +20,7 @@ export { DashboardIcon } from './Dashboard';
 export { DeleteIcon } from './Delete';
 export { DownloadIcon } from './Download';
 export { EditIcon } from './Edit';
+export { ExternalLinkIcon } from './ExternalLink';
 export { EyeIcon } from './Eye';
 export { EyeOffIcon } from './EyeOff';
 export { FilterIcon } from './Filter';

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
+import { alpha } from '@mui/material/styles';
 import { Column } from '../../columns/types';
 import { RecordWithId } from '@common/types';
 import {
@@ -60,19 +61,27 @@ export const DataRow = <T extends RecordWithId>({
         >
           <TableRow
             sx={{
+              backgroundColor: isFocused
+                ? theme => alpha(theme.palette.secondary.main, 0.1)
+                : null,
               '&.MuiTableRow-root': {
+                '&:nth-of-type(even)': {
+                  backgroundColor: 'background.toolbar',
+                },
                 '&:hover': hasOnClick
-                  ? { backgroundColor: 'background.menu' }
+                  ? theme => ({
+                      backgroundColor: alpha(theme.palette.secondary.main, 0.1),
+                    })
                   : {},
               },
               color: isDisabled ? 'gray.main' : 'black',
-              backgroundColor: isFocused ? 'background.menu' : null,
               alignItems: 'center',
               height: '40px',
               maxHeight: '45px',
               boxShadow: dense
                 ? 'none'
-                : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
+                : theme =>
+                    `inset 0 0.5px 0 0 ${alpha(theme.palette.gray.main, 0.5)}`,
               ...rowStyle,
             }}
             onClick={onRowClick}

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -65,7 +65,7 @@ const StyledDivider = styled(Divider)({
   width: 152,
 });
 
-const drawerWidth = 240;
+const drawerWidth = 260;
 
 const getDrawerCommonStyles = (theme: Theme) => ({
   backgroundColor: theme.palette.background.drawer,
@@ -118,7 +118,7 @@ const StyledDrawer = styled(Box, {
       flex: 1,
     },
     '& div > ul > li': {
-      width: 200,
+      width: 220,
     },
   }),
   ...(!isOpen && {

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -115,7 +115,6 @@ const StyledDrawer = styled(Box, {
     '& .MuiDrawer-paper': openedMixin(theme),
     '& .navLinkText': {
       display: 'inline-flex',
-      flex: 1,
     },
     '& div > ul > li': {
       width: 220,
@@ -125,6 +124,9 @@ const StyledDrawer = styled(Box, {
     ...closedMixin(theme),
     '& .MuiDrawer-paper': closedMixin(theme),
     '& .navLinkText': {
+      width: 0,
+    },
+    '& .navLinkText .MuiListItemText-root': {
       display: 'none',
     },
     '& div > ul > li': {

--- a/client/packages/host/src/components/Navigation/CatalogueNav.tsx
+++ b/client/packages/host/src/components/Navigation/CatalogueNav.tsx
@@ -6,6 +6,7 @@ import {
   RouteBuilder,
   AppNavLink,
   ListIcon,
+  AppNavSection,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
@@ -17,7 +18,7 @@ export const CatalogueNav: FC = () => {
   const t = useTranslation('app');
 
   return (
-    <>
+    <AppNavSection isActive={isActive} to={AppRoute.Catalogue}>
       <AppNavLink
         end={false}
         to={AppRoute.Catalogue}
@@ -43,6 +44,6 @@ export const CatalogueNav: FC = () => {
           />
         </List>
       </Collapse>
-    </>
+    </AppNavSection>
   );
 };

--- a/client/packages/host/src/components/Navigation/DistributionNav.tsx
+++ b/client/packages/host/src/components/Navigation/DistributionNav.tsx
@@ -6,6 +6,7 @@ import {
   useTranslation,
   RouteBuilder,
   AppNavLink,
+  AppNavSection,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
@@ -17,7 +18,7 @@ export const DistributionNav: FC = () => {
   const t = useTranslation('app');
 
   return (
-    <>
+    <AppNavSection isActive={isActive} to={AppRoute.Distribution}>
       <AppNavLink
         end={false}
         to={AppRoute.Distribution}
@@ -50,6 +51,6 @@ export const DistributionNav: FC = () => {
           />
         </List>
       </Collapse>
-    </>
+    </AppNavSection>
   );
 };

--- a/client/packages/host/src/components/Navigation/InventoryNav.tsx
+++ b/client/packages/host/src/components/Navigation/InventoryNav.tsx
@@ -6,6 +6,7 @@ import {
   useTranslation,
   RouteBuilder,
   AppNavLink,
+  AppNavSection,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
@@ -17,7 +18,7 @@ export const InventoryNav: FC = () => {
   const t = useTranslation('app');
 
   return (
-    <>
+    <AppNavSection isActive={isActive} to={AppRoute.Inventory}>
       <AppNavLink
         end={false}
         to={AppRoute.Inventory}
@@ -50,6 +51,6 @@ export const InventoryNav: FC = () => {
           />
         </List>
       </Collapse>
-    </>
+    </AppNavSection>
   );
 };

--- a/client/packages/host/src/components/Navigation/ReplenishmentNav.tsx
+++ b/client/packages/host/src/components/Navigation/ReplenishmentNav.tsx
@@ -7,6 +7,7 @@ import {
   useTranslation,
   RouteBuilder,
   AppNavLink,
+  AppNavSection,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
@@ -18,7 +19,7 @@ export const ReplenishmentNav: FC = () => {
   const t = useTranslation('app');
 
   return (
-    <>
+    <AppNavSection isActive={isActive} to={AppRoute.Replenishment}>
       <AppNavLink
         end={false}
         to={AppRoute.Replenishment}
@@ -52,6 +53,6 @@ export const ReplenishmentNav: FC = () => {
           />
         </List>
       </Collapse>
-    </>
+    </AppNavSection>
   );
 };


### PR DESCRIPTION
Fixes #856 for general items. There's a couple to address in the features branch too.

**Menu**

- [ ] highlighting of the parent menu when you are on a submenu page. It now has the parent in **bold** with the whole menu (parent+children) in a container with a box shadow. Shown as a very light grey when active, and transparent otherwise.
- [ ] when the drawer is collapsed, highlight the parent if you are on a submenu page
- [ ] add an 'external link' indication to the docs nav link

**Dashboard**
- [ ] The chart icon has been removed
- [ ] When displayed portrait on tablet, the widgets flex badly - have removed the width constraints which were mainly to accomodate the chart

**tables**
- [ ] Added an alternate row highlight in pale grey. changed the hover colour to a knocked back version of the secondary colour ( the primary looked out of place, particularly with the placeholder blue lines ). Checked with the disabled grey text and the placeholder blue text. 

### Examples
#### Tables
<img width="1259" alt="Screenshot 2022-12-20 at 1 08 56 PM" src="https://user-images.githubusercontent.com/9192912/208789626-7e1e57c2-c561-4b1d-b4aa-b8083fa51d4b.png">
<img width="1254" alt="Screenshot 2022-12-20 at 1 09 03 PM" src="https://user-images.githubusercontent.com/9192912/208789639-49810dcb-71ac-456b-98d2-60d375fcaa10.png">
<img width="1266" alt="Screenshot 2022-12-20 at 1 09 36 PM" src="https://user-images.githubusercontent.com/9192912/208789646-13019ede-0f04-409e-a4f7-532c41ef4a39.png">

### External Link
<img width="226" alt="Screenshot 2022-12-20 at 10 08 39 PM" src="https://user-images.githubusercontent.com/9192912/208789648-a8c09490-5298-42dd-b28e-8b77639ef6a6.png">
<img width="236" alt="Screenshot 2022-12-20 at 10 09 14 PM" src="https://user-images.githubusercontent.com/9192912/208789649-bb943d16-8c29-432e-98ef-83c1bb936861.png">

### Navigation
#### Collapsed menu highlights the parent item
<img width="367" alt="Screenshot 2022-12-21 at 10 46 58 AM" src="https://user-images.githubusercontent.com/9192912/208789651-64528b97-b824-4ace-a9b4-29c3bf0805fc.png">

#### Selected menu
<img width="544" alt="Screenshot 2022-12-21 at 11 57 13 AM" src="https://user-images.githubusercontent.com/9192912/208789659-e51cc8af-9bf4-4df5-bebe-2772342507d5.png">

#### Replenishment selected, hover over Catalogue
<img width="476" alt="Screenshot 2022-12-21 at 11 57 31 AM" src="https://user-images.githubusercontent.com/9192912/208789668-b31bdca0-b58c-4d15-9d17-04779b23025a.png">
#### Replenishment selected, hover over Catalogue > View Stock
<img width="336" alt="Screenshot 2022-12-21 at 11 55 49 AM" src="https://user-images.githubusercontent.com/9192912/208789656-2f08d76c-57e4-42d4-832d-e3d2a12c8314.png">


### Unable to replicate 
**Site**
- The footer text is jammed together ( storename username )

### Already done
**Other components**
- Autocomplete - highlight the search terms when filtering, perhaps bold the search characters?
- Date picker - is the selected date colour the primary? it doesn't look right