### PR TITLE
#838(1) Multi-line text input support

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -10,25 +10,28 @@ import { FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../useZodOptionsValidation';
 
-type Options = {
-  /**
-   * Additional pattern to be matched that can be defined in ui schema
-   */
-  pattern?: string;
-  /**
-   * Examples for the correct pattern
-   */
-  examples?: string[];
-  width?: string;
-};
-const Options: z.ZodType<Options | undefined> = z
+const Options = z
   .object({
+    /**
+     * Additional pattern to be matched that can be defined in ui schema
+     */
     pattern: z.string().optional(),
+    /**
+     * Examples for the correct pattern
+     */
     examples: z.array(z.string()).optional(),
     width: z.string().optional(),
+    // If true, text input will expand to multiple lines if required
+    multiline: z.boolean().optional(),
+    /*
+    How many rows should the textbox display initially (default: 1)
+    */
+    rows: z.number().optional(),
   })
   .strict()
   .optional();
+
+type Options = z.infer<typeof Options>;
 
 // Validates the option and parses the pattern into RegEx
 const useOptions = (
@@ -147,6 +150,8 @@ const UIComponent = (props: ControlProps) => {
   }
 
   const width = schemaOptions?.width ?? '100%';
+  const multiline = schemaOptions?.multiline !== false;
+  const rows = schemaOptions?.rows;
 
   return (
     <DetailInputWithLabelRow
@@ -166,6 +171,8 @@ const UIComponent = (props: ControlProps) => {
           ? { sx: { color: 'error.main' } }
           : undefined,
         required: props.required,
+        multiline,
+        rows,
       }}
       labelWidthPercentage={FORM_LABEL_WIDTH}
       inputAlignment={'start'}

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -21,11 +21,15 @@ const Options = z
      */
     examples: z.array(z.string()).optional(),
     width: z.string().optional(),
-    // If true, text input will expand to multiple lines if required
+    /**
+     * If true, text input will expand to multiple lines if required (default:
+     * true)
+     */
     multiline: z.boolean().optional(),
-    /*
-    How many rows should the textbox display initially (default: 1)
-    */
+    /**
+     * How many rows should the textbox display initially (default: 1, ignored
+     * if `multiline === false`)
+     */
     rows: z.number().optional(),
   })
   .strict()

--- a/server/service/src/sync/program_schemas/patient.json
+++ b/server/service/src/sync/program_schemas/patient.json
@@ -156,30 +156,12 @@
     "Note": {
       "properties": {
         "authorId": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "properties": {
-            "length": {
-              "type": "number"
-            }
-          },
-          "required": ["length"],
-          "type": "object"
+          "type": "string"
         },
         "created": {
-          "additionalProperties": {
-            "type": "string"
-          },
           "description": "Datetime when the note has been created",
           "format": "date-time",
-          "properties": {
-            "length": {
-              "type": "number"
-            }
-          },
-          "required": ["length"],
-          "type": "object"
+          "type": "string"
         },
         "text": {
           "type": "string"

--- a/server/service/src/sync/program_schemas/patient_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_ui_schema.json
@@ -282,11 +282,13 @@
                           "elements": [
                             {
                               "type": "Control",
-                              "scope": "/properties/address1"
+                              "scope": "/properties/address1",
+                              "options": { "rows": 3 }
                             },
                             {
                               "type": "Control",
-                              "scope": "/properties/address2"
+                              "scope": "/properties/address2",
+                              "options": { "rows": 3 }
                             },
                             {
                               "type": "Control",


### PR DESCRIPTION
First part of #838.

This just adds functionality for multi-line text input fields. I'll add the more substantial "Notes" component next, which will be a wrapper for existing components including this one.

Turns out we don't need to make a new component for multi-line -- it's easy just to pass the "multiline" and "rows" properties to the existing `DetailInputWithLabelRow` component.