### PR TITLE
#893 Select text on input focus

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -54,6 +54,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
       }}
       defaultValue={defaultValue}
       onValueChange={newValue => onChangeNumber(c(newValue || '').value)}
+      onFocus={e => e.target.select()}
       allowNegativeValue={allowNegativeValue}
       prefix={prefix}
       suffix={suffix}

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -12,7 +12,7 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
   ({ sx, InputProps, error, ...props }, ref) => (
     <TextField
       ref={ref}
-      color='secondary'
+      color="secondary"
       sx={{
         '& .MuiInput-underline:before': { borderBottomWidth: 0 },
         '& .MuiInput-input': { color: 'gray.dark' },
@@ -20,6 +20,7 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
       }}
       variant="standard"
       size="small"
+      onFocus={e => e.target.select()}
       InputProps={{
         disableUnderline: error ? true : false,
         ...InputProps,

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -20,7 +20,6 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
       }}
       variant="standard"
       size="small"
-      onFocus={e => e.target.select()}
       InputProps={{
         disableUnderline: error ? true : false,
         ...InputProps,

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
@@ -20,6 +20,7 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
         const parsed = Number(e.target.value);
         if (!Number.isNaN(parsed) && !!onChange) onChange(parsed);
       }}
+      onFocus={e => e.target.select()}
       type="number"
       {...props}
     />


### PR DESCRIPTION
Fix #893.

Initially tried adding this to just the "NumericTextInput" component, but then thought that it probably makes sense to auto-select text for all input fields. Does this seem reasonable to everyone else? @mark-prins @Chris-Petty 