### PR TITLE
Filter current store from customer & supplier lists

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -28,14 +28,6 @@ export type Scalars = {
    * * `2000-02-24`
    */
   NaiveDate: string;
-  /**
-   * ISO 8601 combined date and time without timezone.
-   *
-   * # Examples
-   *
-   * * `2015-07-01T08:59:60.123`,
-   */
-  NaiveDateTime: string;
 };
 
 export type ActivityLogConnector = {
@@ -54,7 +46,7 @@ export type ActivityLogFilterInput = {
 
 export type ActivityLogNode = {
   __typename: 'ActivityLogNode';
-  datetime: Scalars['NaiveDateTime'];
+  datetime: Scalars['DateTime'];
   event?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   recordId?: Maybe<Scalars['String']>;

--- a/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
+++ b/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
@@ -5,7 +5,7 @@ export const useStockItemsWithStats = () => {
   const queryParams = {
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
     offset: 0,
-    first: 1000, // TODO: remove arbitrary limit
+    first: 5000, // TODO: remove arbitrary limit
   };
   const api = useItemApi();
   return useQuery(api.keys.paramList(queryParams), () =>

--- a/client/packages/system/src/Log/api/operations.generated.ts
+++ b/client/packages/system/src/Log/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: any, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
+export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
 
 export type ActivityLogsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -14,7 +14,7 @@ export type ActivityLogsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: any, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
+export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
 
 export const ActivityLogRowFragmentDoc = gql`
     fragment ActivityLogRow on ActivityLogNode {

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -91,39 +91,6 @@ pub fn get_names(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.clone(), user.user_id)?;
 
-    // exclude the current store from the list of names
-    // if requesting for customers or suppliers
-    let filter = {
-        if let Some(name_filter) = filter {
-            let is_customer = name_filter.is_customer.unwrap_or(false);
-            let is_supplier = name_filter.is_supplier.unwrap_or(false);
-            let has_id_filter = name_filter.id.is_some();
-
-            let filter = if (is_customer || is_supplier) && !has_id_filter {
-                let store_row = repository::StoreRowRepository::new(&service_context.connection)
-                    .find_one_by_id(&store_id)?;
-                let store_name_id = match store_row {
-                    Some(store) => Some(store.name_id),
-                    None => None,
-                };
-
-                Some(NameFilterInput {
-                    id: Some(EqualFilterStringInput {
-                        equal_to: None,
-                        equal_any: None,
-                        not_equal_to: store_name_id,
-                    }),
-                    ..name_filter
-                })
-            } else {
-                Some(name_filter)
-            };
-            filter
-        } else {
-            None
-        }
-    };
-
     let names = service_provider
         .general_service
         .get_names(

--- a/server/repository/src/migrations/v1_01_01/mod.rs
+++ b/server/repository/src/migrations/v1_01_01/mod.rs
@@ -100,8 +100,7 @@ impl Migration for V1_01_01 {
             connection,
             r#"DELETE
                 FROM name_store_join 
-                WHERE name_store_join.name_id IN (SELECT name_id FROM store WHERE store.id = name_store_join.store_id)
-                    AND (name_store_join.name_is_customer = true OR name_store_join.name_is_supplier = true);"#
+                WHERE name_store_join.name_id IN (SELECT name_id FROM store WHERE store.id = name_store_join.store_id);"#
         )?;
 
         Ok(())

--- a/server/repository/src/migrations/v1_01_01/mod.rs
+++ b/server/repository/src/migrations/v1_01_01/mod.rs
@@ -95,6 +95,15 @@ impl Migration for V1_01_01 {
             "#
         )?;
 
+        // Remove self-referencing name_store_joins
+        sql!(
+            connection,
+            r#"DELETE
+                FROM name_store_join nsj 
+                WHERE nsj.name_id IN (SELECT s.name_id FROM store s WHERE s.id = nsj.store_id)
+                    AND (nsj.name_is_customer = true OR nsj.name_is_supplier = true);"#
+        )?;
+
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v1_01_01/mod.rs
+++ b/server/repository/src/migrations/v1_01_01/mod.rs
@@ -99,9 +99,9 @@ impl Migration for V1_01_01 {
         sql!(
             connection,
             r#"DELETE
-                FROM name_store_join nsj 
-                WHERE nsj.name_id IN (SELECT s.name_id FROM store s WHERE s.id = nsj.store_id)
-                    AND (nsj.name_is_customer = true OR nsj.name_is_supplier = true);"#
+                FROM name_store_join 
+                WHERE name_store_join.name_id IN (SELECT name_id FROM store WHERE store.id = name_store_join.store_id)
+                    AND (name_store_join.name_is_customer = true OR name_store_join.name_is_supplier = true);"#
         )?;
 
         Ok(())

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -9,7 +9,7 @@ const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
     r#"{
       "ID": "66607B6E7F2A47E782B8AC6743F71A8A",
       "inactive": false,
-      "name_ID": "name_store_a",
+      "name_ID": "name_store_c",
       "spare_Category_ID": 0,
       "spare_Category_optional2_id": 0,
       "spare_Category_optional_id": 0,
@@ -24,7 +24,7 @@ fn name_store_join_1_pull_record() -> TestSyncPullRecord {
         PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
             id: NAME_STORE_JOIN_1.0.to_string(),
             store_id: "store_a".to_string(),
-            name_id: "name_store_a".to_string(),
+            name_id: "name_store_c".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
         }),
@@ -36,7 +36,7 @@ const NAME_STORE_JOIN_2: (&'static str, &'static str) = (
     r#"{
       "ID": "BE65A4A05E4D47E88303D6105A7872CC",
       "inactive": false,
-      "name_ID": "name_store_b",
+      "name_ID": "name_store_a",
       "spare_Category_ID": 0,
       "spare_Category_optional2_id": 0,
       "spare_Category_optional_id": 0,
@@ -50,9 +50,9 @@ fn name_store_join_2_pull_record() -> TestSyncPullRecord {
         PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
             id: NAME_STORE_JOIN_2.0.to_string(),
             store_id: "store_b".to_string(),
-            name_id: "name_store_b".to_string(),
+            name_id: "name_store_a".to_string(),
             name_is_customer: false,
-            name_is_supplier: false,
+            name_is_supplier: true,
         }),
     )
 }
@@ -63,7 +63,7 @@ const NAME_STORE_JOIN_3: (&'static str, &'static str) = (
     r#"{
       "ID": "BE65A4A05E4D47E88303D6105A7872C2",
       "inactive": false,
-      "name_ID": "name_store_b",
+      "name_ID": "name_store_c",
       "spare_Category_ID": 0,
       "spare_Category_optional2_id": 0,
       "spare_Category_optional_id": 0,
@@ -79,7 +79,7 @@ fn name_store_join_3_pull_record() -> TestSyncPullRecord {
         PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
             id: NAME_STORE_JOIN_3.0.to_string(),
             store_id: "store_b".to_string(),
-            name_id: "name_store_b".to_string(),
+            name_id: "name_store_c".to_string(),
             name_is_customer: true,
             name_is_supplier: true,
         }),

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -46,16 +46,13 @@ impl SyncTranslation for NameStoreJoinTranslation {
             }
         };
 
-        let name_is_customer = data.name_is_customer.unwrap_or(name.is_customer);
-        let name_is_supplier = data.name_is_supplier.unwrap_or(name.is_supplier);
-
         if let Some(store) = StoreRowRepository::new(connection)
             .find_one_by_id(&data.store_ID)
             .unwrap_or(None)
         {
             // if the name_store_join is referencing itself, then exclude it
             // this is an invalid configuration which shouldn't be possible.. but is
-            if store.name_id == data.name_ID && (name_is_customer || name_is_supplier) {
+            if store.name_id == data.name_ID {
                 return Ok(None);
             }
         }
@@ -64,8 +61,8 @@ impl SyncTranslation for NameStoreJoinTranslation {
             id: data.ID,
             name_id: data.name_ID,
             store_id: data.store_ID,
-            name_is_customer,
-            name_is_supplier,
+            name_is_customer: data.name_is_customer.unwrap_or(name.is_customer),
+            name_is_supplier: data.name_is_supplier.unwrap_or(name.is_supplier),
         };
 
         Ok(Some(IntegrationRecords::from_upsert(


### PR DESCRIPTION
Fixes #986 

Have added a filter to the name list query, when `is_supplier` or `is_customer` is set in the filter. If however, someone queries for a specific id, then no filter is applied - I don't want to mess with filter functionality.

The situation requires a specific set up: in my test db ( same as demo site ) the store Kopu is a supplier and customer of itself, and that shows as an entry in `name_store_join` which has the store linked to itself. This is the same in mSupply - so wouldn't be a translation / sync error.