### PR TITLE
Create item counts dashboard query

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -28,14 +28,6 @@ export type Scalars = {
    * * `2000-02-24`
    */
   NaiveDate: string;
-  /**
-   * ISO 8601 combined date and time without timezone.
-   *
-   * # Examples
-   *
-   * * `2015-07-01T08:59:60.123`,
-   */
-  NaiveDateTime: string;
 };
 
 export type ActivityLogConnector = {
@@ -54,7 +46,7 @@ export type ActivityLogFilterInput = {
 
 export type ActivityLogNode = {
   __typename: 'ActivityLogNode';
-  datetime: Scalars['NaiveDateTime'];
+  datetime: Scalars['DateTime'];
   event?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   recordId?: Maybe<Scalars['String']>;
@@ -1321,6 +1313,13 @@ export type ItemConnector = {
   totalCount: Scalars['Int'];
 };
 
+export type ItemCounts = {
+  __typename: 'ItemCounts';
+  lowStock: Scalars['Int'];
+  noStock: Scalars['Int'];
+  total: Scalars['Int'];
+};
+
 export type ItemFilterInput = {
   code?: InputMaybe<SimpleStringFilterInput>;
   codeOrName?: InputMaybe<SimpleStringFilterInput>;
@@ -2142,6 +2141,7 @@ export type Queries = {
   invoiceByNumber: InvoiceResponse;
   invoiceCounts: InvoiceCounts;
   invoices: InvoicesResponse;
+  itemCounts: ItemCounts;
   /** Query omSupply "item" entries */
   items: ItemsResponse;
   latestSyncStatus?: Maybe<FullSyncStatusNode>;
@@ -2228,6 +2228,12 @@ export type QueriesInvoicesArgs = {
   filter?: InputMaybe<InvoiceFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<InvoiceSortInput>>;
+  storeId: Scalars['String'];
+};
+
+
+export type QueriesItemCountsArgs = {
+  lowStockThreshold?: InputMaybe<Scalars['Int']>;
   storeId: Scalars['String'];
 };
 

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1315,6 +1315,11 @@ export type ItemConnector = {
 
 export type ItemCounts = {
   __typename: 'ItemCounts';
+  itemCounts: ItemCountsResponse;
+};
+
+export type ItemCountsResponse = {
+  __typename: 'ItemCountsResponse';
   lowStock: Scalars['Int'];
   noStock: Scalars['Int'];
   total: Scalars['Int'];

--- a/client/packages/dashboard/src/api/api.ts
+++ b/client/packages/dashboard/src/api/api.ts
@@ -22,7 +22,7 @@ export const getDashboardQueries = (
     },
     itemCounts: async (lowStockThreshold: number) => {
       const result = await queries.itemCounts({ storeId, lowStockThreshold });
-      return result?.itemCounts ?? {};
+      return result?.itemCounts?.itemCounts ?? {};
     },
   },
 });

--- a/client/packages/dashboard/src/api/api.ts
+++ b/client/packages/dashboard/src/api/api.ts
@@ -20,9 +20,9 @@ export const getDashboardQueries = (
         expiringSoon: result?.stockCounts.expiringSoon ?? 0,
       };
     },
-    itemStats: async () => {
-      const result = await queries.itemStats({ storeId });
-      return result?.items.nodes;
+    itemCounts: async (lowStockThreshold: number) => {
+      const result = await queries.itemCounts({ storeId, lowStockThreshold });
+      return result?.itemCounts ?? {};
     },
   },
 });

--- a/client/packages/dashboard/src/api/hooks/index.ts
+++ b/client/packages/dashboard/src/api/hooks/index.ts
@@ -7,7 +7,7 @@ export const useDashboard = {
   },
 
   statistics: {
-    item: Statistics.useItemStats,
+    item: Statistics.useItemCounts,
     stock: Statistics.useStockCounts,
   },
 };

--- a/client/packages/dashboard/src/api/hooks/statistics/index.ts
+++ b/client/packages/dashboard/src/api/hooks/statistics/index.ts
@@ -1,7 +1,7 @@
-import { useItemStats } from './useItemStats';
+import { useItemCounts } from './useItemCounts';
 import { useStockCounts } from './useStockCounts';
 
 export const Statistics = {
-  useItemStats,
+  useItemCounts,
   useStockCounts,
 };

--- a/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
@@ -1,8 +1,10 @@
 import { useAuthContext, useQuery } from '@openmsupply-client/common';
 import { useDashboardApi } from './../utils/useDashboardApi';
 
-export const useItemStats = () => {
+export const useItemCounts = (lowStockThreshold: number) => {
   const api = useDashboardApi();
   const { storeId } = useAuthContext();
-  return useQuery(['dashboard', 'item-stats', storeId], api.get.itemStats);
+  return useQuery(['dashboard', 'item-counts', storeId], () =>
+    api.get.itemCounts(lowStockThreshold)
+  );
 };

--- a/client/packages/dashboard/src/api/operations.generated.ts
+++ b/client/packages/dashboard/src/api/operations.generated.ts
@@ -19,7 +19,7 @@ export type ItemCountsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ItemCountsQuery = { __typename: 'Queries', itemCounts: { __typename: 'ItemCounts', total: number, noStock: number, lowStock: number } };
+export type ItemCountsQuery = { __typename: 'Queries', itemCounts: { __typename: 'ItemCounts', itemCounts: { __typename: 'ItemCountsResponse', lowStock: number, noStock: number, total: number } } };
 
 
 export const StockCountsDocument = gql`
@@ -36,10 +36,12 @@ export const StockCountsDocument = gql`
     `;
 export const ItemCountsDocument = gql`
     query itemCounts($storeId: String!, $lowStockThreshold: Int!) {
-  itemCounts(storeId: $storeId, lowStockThreshold: $lowStockThreshold) {
-    total
-    noStock
-    lowStock
+  itemCounts(lowStockThreshold: $lowStockThreshold, storeId: $storeId) {
+    itemCounts {
+      lowStock
+      noStock
+      total
+    }
   }
 }
     `;

--- a/client/packages/dashboard/src/api/operations.graphql
+++ b/client/packages/dashboard/src/api/operations.graphql
@@ -1,11 +1,3 @@
-fragment ItemStats on ItemNode {
-  stats(storeId: $storeId) {
-    averageMonthlyConsumption
-    availableStockOnHand
-    availableMonthsOfStockOnHand
-  }
-}
-
 query stockCounts(
   $storeId: String!
   $daysTillExpired: Int
@@ -21,13 +13,10 @@ query stockCounts(
   }
 }
 
-query itemStats($storeId: String!) {
-  items(storeId: $storeId, filter: { isVisible: true }) {
-    ... on ItemConnector {
-      nodes {
-        ...ItemStats
-      }
-      totalCount
-    }
+query itemCounts($storeId: String!, $lowStockThreshold: Int!) {
+  itemCounts(storeId: $storeId, lowStockThreshold: $lowStockThreshold) {
+    total
+    noStock
+    lowStock
   }
 }

--- a/client/packages/dashboard/src/api/operations.graphql
+++ b/client/packages/dashboard/src/api/operations.graphql
@@ -14,9 +14,11 @@ query stockCounts(
 }
 
 query itemCounts($storeId: String!, $lowStockThreshold: Int!) {
-  itemCounts(storeId: $storeId, lowStockThreshold: $lowStockThreshold) {
-    total
-    noStock
-    lowStock
+  itemCounts(lowStockThreshold: $lowStockThreshold, storeId: $storeId) {
+    itemCounts {
+      lowStock
+      noStock
+      total
+    }
   }
 }

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -24,21 +24,10 @@ export const StockWidget: React.FC = () => {
   const formatNumber = useFormatNumber();
   const { data: expiryData, isLoading: isExpiryLoading } =
     useDashboard.statistics.stock();
-  const { data: itemStatsData, isLoading: isItemStatsLoading } =
-    useDashboard.statistics.item();
+  const { data: itemCountsData, isLoading: isItemStatsLoading } =
+    useDashboard.statistics.item(LOW_MOS_THRESHOLD);
   const [hasExpiryError, setHasExpiryError] = React.useState(false);
   const [hasItemStatsError, setHasItemStatsError] = React.useState(false);
-
-  const lowStockItemsCount =
-    itemStatsData?.filter(
-      item =>
-        item.stats.availableStockOnHand > 0 &&
-        (item.stats.availableMonthsOfStockOnHand ?? 0) < LOW_MOS_THRESHOLD
-    ).length || 0;
-
-  const noStockItemsCount =
-    itemStatsData?.filter(item => item.stats.availableStockOnHand === 0)
-      .length || 0;
 
   React.useEffect(() => {
     if (!isExpiryLoading && expiryData === undefined) setHasExpiryError(true);
@@ -46,10 +35,10 @@ export const StockWidget: React.FC = () => {
   }, [expiryData, isExpiryLoading]);
 
   React.useEffect(() => {
-    if (!isItemStatsLoading && itemStatsData === undefined)
+    if (!isItemStatsLoading && itemCountsData === undefined)
       setHasItemStatsError(true);
     return () => setHasItemStatsError(false);
-  }, [itemStatsData, isItemStatsLoading]);
+  }, [itemCountsData, isItemStatsLoading]);
 
   const { mutateAsync: onCreate } = useRequest.document.insert();
   const onError = (e: unknown) => {
@@ -107,15 +96,15 @@ export const StockWidget: React.FC = () => {
                 stats={[
                   {
                     label: t('label.total-items', { ns: 'dashboard' }),
-                    value: formatNumber.round(itemStatsData?.length),
+                    value: formatNumber.round(itemCountsData?.total || 0),
                   },
                   {
                     label: t('label.items-no-stock'),
-                    value: formatNumber.round(noStockItemsCount),
+                    value: formatNumber.round(itemCountsData?.noStock || 0),
                   },
                   {
                     label: t('label.low-stock-items'),
-                    value: formatNumber.round(lowStockItemsCount),
+                    value: formatNumber.round(itemCountsData?.lowStock || 0),
                   },
                 ]}
               />

--- a/client/packages/system/src/Log/api/operations.generated.ts
+++ b/client/packages/system/src/Log/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: any, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
+export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
 
 export type ActivityLogsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -14,7 +14,7 @@ export type ActivityLogsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: any, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
+export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
 
 export const ActivityLogRowFragmentDoc = gql`
     fragment ActivityLogRow on ActivityLogNode {

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -198,6 +198,15 @@ impl GeneralQueries {
     ) -> Result<RequisitionStatsResponse> {
         response_requisition_stats(ctx, &store_id, &requisition_line_id)
     }
+
+    pub async fn item_counts(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        #[graphql(desc = "Low stock threshold in months")] low_stock_threshold: Option<i32>,
+    ) -> Result<ItemCounts> {
+        item_counts(ctx, store_id, low_stock_threshold)
+    }
 }
 
 #[derive(Default, Clone)]

--- a/server/graphql/general/src/queries/item_counts.rs
+++ b/server/graphql/general/src/queries/item_counts.rs
@@ -1,0 +1,53 @@
+use async_graphql::*;
+use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
+
+use service::auth::{Resource, ResourceAccessRequest};
+
+pub struct ItemCounts {
+    low_stock_threshold: Option<i32>,
+    store_id: String,
+}
+
+#[Object]
+impl ItemCounts {
+    async fn total(&self, ctx: &Context<'_>) -> Result<i64> {
+        let service_provider = ctx.service_provider();
+        let service_ctx = service_provider.basic_context()?;
+        let service = &service_provider.item_count_service;
+        Ok(service.count_total(&service_ctx)?)
+    }
+
+    async fn no_stock(&self, ctx: &Context<'_>) -> Result<i64> {
+        let service_provider = ctx.service_provider();
+        let service_ctx = service_provider.basic_context()?;
+        let service = &service_provider.item_count_service;
+        Ok(service.count_no_stock(&service_ctx, &self.store_id)?)
+    }
+
+    async fn low_stock(&self, ctx: &Context<'_>) -> Result<i64> {
+        let service_provider = ctx.service_provider();
+        let service_ctx = service_provider.basic_context()?;
+        let service = &service_provider.item_count_service;
+        let low_stock_threshold_in_months = self.low_stock_threshold.unwrap_or(3);
+        Ok(service.count_low_stock(&service_ctx, &self.store_id, low_stock_threshold_in_months)?)
+    }
+}
+
+pub fn item_counts(
+    ctx: &Context<'_>,
+    store_id: String,
+    low_stock_threshold: Option<i32>,
+) -> Result<ItemCounts> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::StockCount,
+            store_id: Some(store_id.clone()),
+        },
+    )?;
+
+    Ok(ItemCounts {
+        low_stock_threshold,
+        store_id,
+    })
+}

--- a/server/graphql/general/src/queries/item_counts.rs
+++ b/server/graphql/general/src/queries/item_counts.rs
@@ -3,6 +3,7 @@ use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 
 use service::auth::{Resource, ResourceAccessRequest};
 
+const DEFAULT_LOW_STOCK_THRESHOLD: i32 = 3;
 pub struct ItemCounts {
     low_stock_threshold: Option<i32>,
     store_id: String,
@@ -28,7 +29,9 @@ impl ItemCounts {
         let service_provider = ctx.service_provider();
         let service_ctx = service_provider.basic_context()?;
         let service = &service_provider.item_count_service;
-        let low_stock_threshold_in_months = self.low_stock_threshold.unwrap_or(3);
+        let low_stock_threshold_in_months = self
+            .low_stock_threshold
+            .unwrap_or(DEFAULT_LOW_STOCK_THRESHOLD);
         Ok(service.count_low_stock(&service_ctx, &self.store_id, low_stock_threshold_in_months)?)
     }
 }

--- a/server/graphql/general/src/queries/item_counts.rs
+++ b/server/graphql/general/src/queries/item_counts.rs
@@ -9,30 +9,31 @@ pub struct ItemCounts {
     store_id: String,
 }
 
+#[derive(SimpleObject)]
+pub struct ItemCountsResponse {
+    total: i64,
+    no_stock: i64,
+    low_stock: i64,
+}
+
 #[Object]
 impl ItemCounts {
-    async fn total(&self, ctx: &Context<'_>) -> Result<i64> {
-        let service_provider = ctx.service_provider();
-        let service_ctx = service_provider.basic_context()?;
-        let service = &service_provider.item_count_service;
-        Ok(service.count_total(&service_ctx)?)
-    }
-
-    async fn no_stock(&self, ctx: &Context<'_>) -> Result<i64> {
-        let service_provider = ctx.service_provider();
-        let service_ctx = service_provider.basic_context()?;
-        let service = &service_provider.item_count_service;
-        Ok(service.count_no_stock(&service_ctx, &self.store_id)?)
-    }
-
-    async fn low_stock(&self, ctx: &Context<'_>) -> Result<i64> {
+    async fn item_counts(&self, ctx: &Context<'_>) -> Result<ItemCountsResponse> {
         let service_provider = ctx.service_provider();
         let service_ctx = service_provider.basic_context()?;
         let service = &service_provider.item_count_service;
         let low_stock_threshold_in_months = self
             .low_stock_threshold
             .unwrap_or(DEFAULT_LOW_STOCK_THRESHOLD);
-        Ok(service.count_low_stock(&service_ctx, &self.store_id, low_stock_threshold_in_months)?)
+
+        match service.get_item_counts(&service_ctx, &self.store_id, low_stock_threshold_in_months) {
+            Ok(item_counts) => Ok(ItemCountsResponse {
+                total: item_counts.total,
+                no_stock: item_counts.no_stock,
+                low_stock: item_counts.low_stock,
+            }),
+            Err(err) => Err(err.into()),
+        }
     }
 }
 

--- a/server/graphql/general/src/queries/mod.rs
+++ b/server/graphql/general/src/queries/mod.rs
@@ -29,6 +29,8 @@ pub mod display_settings;
 pub mod initialisation_status;
 pub mod response_requisition_line_stats;
 pub use self::response_requisition_line_stats::*;
+pub mod item_counts;
+pub use self::item_counts::*;
 
 #[cfg(test)]
 mod tests;

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -2,7 +2,6 @@ use super::{
     item_row::{
         item, item::dsl as item_dsl, item_is_visible, item_is_visible::dsl as item_is_visible_dsl,
     },
-    stock_line_row::{stock_line, stock_line::dsl as stock_line_dsl},
     unit_row::{unit, unit::dsl as unit_dsl},
     DBType, ItemIsVisibleRow, ItemRow, ItemRowType, StorageConnection, UnitRow,
 };
@@ -101,34 +100,6 @@ impl<'a> ItemRepository<'a> {
         let query = create_filtered_query(filter);
 
         Ok(query.count().get_result(&self.connection.connection)?)
-    }
-
-    pub fn count_no_stock(
-        &self,
-        filter: Option<ItemFilter>,
-        store_id: &str,
-    ) -> Result<i64, RepositoryError> {
-        let stock_lines = stock_line_dsl::stock_line
-            .select(stock_line::item_id)
-            .filter(stock_line::store_id.eq(store_id));
-        let query = create_filtered_query(filter.clone()).filter(item::id.ne_all(stock_lines));
-        let no_stock_lines_count: i64 = match query.count().get_result(&self.connection.connection)
-        {
-            Ok(count) => count,
-            Err(error) => return Err(RepositoryError::from(error)),
-        };
-
-        let stock_lines = stock_line_dsl::stock_line
-            .select(stock_line::item_id)
-            .filter(stock_line::store_id.eq(store_id))
-            .filter(stock_line::available_number_of_packs.eq(0.0));
-        let query = create_filtered_query(filter).filter(item::id.eq_any(stock_lines));
-        let no_stock_count: i64 = match query.count().get_result(&self.connection.connection) {
-            Ok(count) => count,
-            Err(error) => return Err(RepositoryError::from(error)),
-        };
-
-        Ok(no_stock_count + no_stock_lines_count)
     }
 
     pub fn query_one(&self, filter: ItemFilter) -> Result<Option<Item>, RepositoryError> {

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -69,7 +69,6 @@ impl<'a> NameRepository<'a> {
         store_id: &str,
         filter: Option<NameFilter>,
     ) -> Result<i64, RepositoryError> {
-        // TODO (beyond M1), check that store_id matches current store
         let query = create_filtered_query(store_id.to_string(), filter);
 
         Ok(query.count().get_result(&self.connection.connection)?)
@@ -98,7 +97,6 @@ impl<'a> NameRepository<'a> {
         filter: Option<NameFilter>,
         sort: Option<NameSort>,
     ) -> Result<Vec<Name>, RepositoryError> {
-        // TODO (beyond M1), check that store_id matches current store
         let mut query = create_filtered_query(store_id.to_string(), filter);
 
         if let Some(sort) = sort {

--- a/server/repository/src/test_db/mod.rs
+++ b/server/repository/src/test_db/mod.rs
@@ -17,9 +17,9 @@ use crate::{
     StorageConnection, StorageConnectionManager,
 };
 
-/// Generic setup method to help setup test enviroment
+/// Generic setup method to help setup test environment
 /// - sets up database (create one and initialises schema), drops existing database
-/// - creates connectuion
+/// - creates connection
 /// - inserts mock data
 pub async fn setup_all(
     db_name: &str,

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -51,7 +51,7 @@ impl ItemCountServiceTrait for ItemServiceCount {
             .filter(|item| {
                 item.average_monthly_consumption != 0.0
                     && item.available_stock_on_hand as f64 / item.average_monthly_consumption
-                        <= low_stock_threshold as f64
+                        < low_stock_threshold as f64
             });
 
         item_stats.count().try_into()

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -71,3 +71,208 @@ impl ItemCountServiceTrait for ItemServiceCount {
         })
     }
 }
+
+#[cfg(test)]
+mod item_count_service_test {
+    use chrono::{Duration, Utc};
+    use repository::{
+        mock::{mock_master_list_item_query_test1, mock_store_b, MockDataInserts},
+        test_db, InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineRowType, InvoiceRow,
+        InvoiceRowRepository, InvoiceRowType, ItemRow, ItemRowRepository, ItemRowType,
+        MasterListLineRow, MasterListLineRowRepository, StockLineRow, StockLineRowRepository,
+    };
+    use util::inline_init;
+
+    use crate::{
+        dashboard::item_count::{ItemCountServiceTrait, ItemServiceCount},
+        service_provider::ServiceContext,
+    };
+
+    fn data(
+        store_id: &str,
+        master_list_id: &str,
+    ) -> (Vec<ItemRow>, Vec<StockLineRow>, Vec<MasterListLineRow>) {
+        let mut items = Vec::new();
+        let mut stock_lines = Vec::new();
+        let mut master_list_lines = Vec::new();
+        for index in 0..50 {
+            items.push(inline_init(|r: &mut ItemRow| {
+                r.id = format!("item_id_{:05}", index);
+                r.name = format!("name{}", index);
+                r.code = format!("code{}", index);
+                r.r#type = ItemRowType::Stock;
+            }));
+            stock_lines.push(inline_init(|r: &mut StockLineRow| {
+                r.id = format!("stock_line_id_{:05}", index);
+                r.item_id = format!("item_id_{:05}", index);
+                r.store_id = store_id.to_string();
+                r.available_number_of_packs = 5.0;
+                r.pack_size = 1;
+                // match index < 25 {
+                //     true => index.into(),
+                //     false => 0.0,
+                // };
+            }));
+            master_list_lines.push(MasterListLineRow {
+                id: format!("master_list_line_id_{:05}", index),
+                item_id: format!("item_id_{:05}", index),
+                master_list_id: master_list_id.to_string(),
+            });
+        }
+        for index in 50..100 {
+            items.push(inline_init(|r: &mut ItemRow| {
+                r.id = format!("item_id_{:05}", index);
+                r.name = format!("name{}", index);
+                r.code = format!("code{}", index);
+                r.r#type = ItemRowType::Stock;
+            }));
+        }
+
+        (items, stock_lines, master_list_lines)
+    }
+
+    fn insert_data(service_context: &ServiceContext) {
+        let master_list = mock_master_list_item_query_test1().master_list;
+        let item_row_repository = ItemRowRepository::new(&service_context.connection);
+        let master_list_line_repository =
+            MasterListLineRowRepository::new(&service_context.connection);
+        let stock_line_repository = StockLineRowRepository::new(&service_context.connection);
+
+        let store_1 = mock_store_b();
+        let (items, stock_lines, master_list_lines) = data(&store_1.id, &master_list.id);
+
+        for row in items.iter() {
+            item_row_repository.upsert_one(row).unwrap();
+        }
+
+        for master_list_line in master_list_lines.iter() {
+            master_list_line_repository
+                .upsert_one(&master_list_line)
+                .unwrap();
+        }
+
+        for stock_line in stock_lines.iter() {
+            stock_line_repository.upsert_one(&stock_line).unwrap();
+        }
+    }
+    #[actix_rt::test]
+    async fn test_total_items_count() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "omsupply-database-total-items-count",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .name_store_joins()
+                .units()
+                .items()
+                .full_master_list(),
+        )
+        .await;
+        let service_context = ServiceContext::new_without_triggers(connection);
+        insert_data(&service_context);
+
+        let service = ItemServiceCount {};
+        let counts = service
+            .get_item_counts(&service_context, "store_b", 0)
+            .unwrap();
+
+        // count of total items which are visible to store b
+        // with visibility determined by master list & master list name join
+        assert_eq!(51, counts.total);
+    }
+
+    #[actix_rt::test]
+    async fn test_no_stock_items_count() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "omsupply-database-total-items-count",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .name_store_joins()
+                .units()
+                .items()
+                .full_master_list(),
+        )
+        .await;
+        let service_context = ServiceContext::new_without_triggers(connection);
+        insert_data(&service_context);
+
+        let service = ItemServiceCount {};
+        let counts = service
+            .get_item_counts(&service_context, "store_b", 0)
+            .unwrap();
+
+        // count of items with no stock
+        // total items: 200+
+        // items visible to store b: 51
+        // items with no stock: 26
+        // where no stock = available_number_of_packs == 0 or no stock line exists
+        assert_eq!(26, counts.no_stock);
+
+        // delete a stock line and check that the count is updated
+        let stock_line_repository = StockLineRowRepository::new(&service_context.connection);
+        stock_line_repository.delete("stock_line_id_00000").unwrap();
+
+        let counts = service
+            .get_item_counts(&service_context, "store_b", 0)
+            .unwrap();
+
+        // a stock line with available_number_of_packs > 0 has been removed
+        assert_eq!(27, counts.no_stock);
+    }
+
+    #[actix_rt::test]
+    async fn test_low_stock_items_count() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "omsupply-database-total-items-count",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .name_store_joins()
+                .units()
+                .items()
+                .full_master_list(),
+        )
+        .await;
+        let service_context = ServiceContext::new_without_triggers(connection);
+        insert_data(&service_context);
+
+        let service = ItemServiceCount {};
+        let counts = service
+            .get_item_counts(&service_context, "store_b", 3)
+            .unwrap();
+
+        assert_eq!(0, counts.low_stock);
+
+        // insert an invoice so that we have consumption history for an item
+        let invoice_repository = InvoiceRowRepository::new(&service_context.connection);
+        let invoice_line_repository = InvoiceLineRowRepository::new(&service_context.connection);
+        invoice_repository
+            .upsert_one(&inline_init(|r: &mut InvoiceRow| {
+                r.id = "invoice_00000".to_string();
+                r.name_id = "name_store_a".to_string();
+                r.name_store_id = Some("store_a".to_string());
+                r.store_id = "store_b".to_string();
+                r.picked_datetime = Some(Utc::now().naive_utc() - Duration::days(10));
+                r.r#type = InvoiceRowType::OutboundShipment;
+            }))
+            .unwrap();
+
+        invoice_line_repository
+            .upsert_one(&inline_init(|r: &mut InvoiceLineRow| {
+                r.id = "invoice_line_row_id_00000".to_string();
+                r.invoice_id = "invoice_00000".to_string();
+                r.item_id = "item_id_00000".to_string();
+                r.number_of_packs = 20.0;
+                r.pack_size = 1;
+                r.r#type = InvoiceLineRowType::StockOut;
+            }))
+            .unwrap();
+
+        let counts = service
+            .get_item_counts(&service_context, "store_b", 3)
+            .unwrap();
+
+        assert_eq!(1, counts.low_stock);
+    }
+}

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -1,0 +1,59 @@
+use std::{convert::TryInto, num::TryFromIntError};
+
+use repository::{ItemFilter, ItemRepository, RepositoryError};
+
+use crate::{item_stats::get_item_stats, service_provider::ServiceContext};
+
+pub trait ItemCountServiceTrait: Send + Sync {
+    fn count_total(&self, ctx: &ServiceContext) -> Result<i64, RepositoryError> {
+        ItemServiceCount {}.count_total(ctx)
+    }
+
+    fn count_no_stock(&self, ctx: &ServiceContext, store_id: &str) -> Result<i64, RepositoryError> {
+        ItemServiceCount {}.count_no_stock(ctx, store_id)
+    }
+
+    /// # Arguments
+    ///
+    /// * i32 threshold number of months below which is considered low stock
+    fn count_low_stock(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        low_stock_threshold: i32,
+    ) -> Result<i64, TryFromIntError> {
+        ItemServiceCount {}.count_low_stock(ctx, store_id, low_stock_threshold)
+    }
+}
+
+pub struct ItemServiceCount {}
+
+impl ItemCountServiceTrait for ItemServiceCount {
+    fn count_total(&self, ctx: &ServiceContext) -> Result<i64, RepositoryError> {
+        let repo = ItemRepository::new(&ctx.connection);
+        repo.count(Some(ItemFilter::new().match_is_visible(true)))
+    }
+
+    fn count_no_stock(&self, ctx: &ServiceContext, store_id: &str) -> Result<i64, RepositoryError> {
+        let repo = ItemRepository::new(&ctx.connection);
+        repo.count_no_stock(Some(ItemFilter::new().match_is_visible(true)), store_id)
+    }
+
+    fn count_low_stock(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        low_stock_threshold: i32,
+    ) -> Result<i64, TryFromIntError> {
+        let item_stats = get_item_stats(ctx, store_id, None, None)
+            .unwrap()
+            .into_iter()
+            .filter(|item| {
+                item.average_monthly_consumption != 0.0
+                    && item.available_stock_on_hand as f64 / item.average_monthly_consumption
+                        <= low_stock_threshold as f64
+            });
+
+        item_stats.count().try_into()
+    }
+}

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -453,6 +453,5 @@ mod item_count_service_test {
             .unwrap();
 
         assert_eq!(1, counts.low_stock);
-        // test_db::
     }
 }

--- a/server/service/src/dashboard/item_count.rs
+++ b/server/service/src/dashboard/item_count.rs
@@ -106,12 +106,11 @@ mod item_count_service_test {
                 r.id = format!("stock_line_id_{:05}", index);
                 r.item_id = format!("item_id_{:05}", index);
                 r.store_id = store_id.to_string();
-                r.available_number_of_packs = 5.0;
+                r.available_number_of_packs = match index < 25 {
+                    true => 5.0, // index.into(),
+                    false => 0.0,
+                };
                 r.pack_size = 1;
-                // match index < 25 {
-                //     true => index.into(),
-                //     false => 0.0,
-                // };
             }));
             master_list_lines.push(MasterListLineRow {
                 id: format!("master_list_line_id_{:05}", index),
@@ -184,7 +183,7 @@ mod item_count_service_test {
     #[actix_rt::test]
     async fn test_no_stock_items_count() {
         let (_, connection, _, _) = test_db::setup_all(
-            "omsupply-database-total-items-count",
+            "omsupply-database-no-stock-items-count",
             MockDataInserts::none()
                 .names()
                 .stores()
@@ -224,7 +223,7 @@ mod item_count_service_test {
     #[actix_rt::test]
     async fn test_low_stock_items_count() {
         let (_, connection, _, _) = test_db::setup_all(
-            "omsupply-database-total-items-count",
+            "omsupply-database-low-stock-items-count",
             MockDataInserts::none()
                 .names()
                 .stores()
@@ -274,5 +273,6 @@ mod item_count_service_test {
             .unwrap();
 
         assert_eq!(1, counts.low_stock);
+        // test_db::
     }
 }

--- a/server/service/src/dashboard/mod.rs
+++ b/server/service/src/dashboard/mod.rs
@@ -1,2 +1,3 @@
 pub mod invoice_count;
+pub mod item_count;
 pub mod stock_expiry_count;

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -3,6 +3,7 @@ use crate::{
     auth::{AuthService, AuthServiceTrait},
     dashboard::{
         invoice_count::{InvoiceCountService, InvoiceCountServiceTrait},
+        item_count::{ItemCountServiceTrait, ItemServiceCount},
         stock_expiry_count::{StockExpiryCountServiceTrait, StockExpiryServiceCount},
     },
     display_settings_service::{DisplaySettingsService, DisplaySettingsServiceTrait},
@@ -50,6 +51,7 @@ pub struct ServiceProvider {
     // Dashboard:
     pub invoice_count_service: Box<dyn InvoiceCountServiceTrait>,
     pub stock_expiry_count_service: Box<dyn StockExpiryCountServiceTrait>,
+    pub item_count_service: Box<dyn ItemCountServiceTrait>,
     // Stock stats
     pub item_stats_service: Box<dyn ItemStatsServiceTrait>,
     // Stock
@@ -123,6 +125,7 @@ impl ServiceProvider {
             site_is_initialised_trigger,
             display_settings_service: Box::new(DisplaySettingsService {}),
             stock_line_service: Box::new(StockLineService {}),
+            item_count_service: Box::new(ItemServiceCount {}),
         }
     }
 


### PR DESCRIPTION
Closes #927 

Adds a query for the three item count values and updates f/e to use the query instead of iterating over all items manually.
There's one change to functionality - in the current version we are including in the low stock total items which have `0` AMC but have stock on hand. This was useful when data was still in a test state, but now I would expect consumption to be accurate and AMC populated. Correct me if wrong here.