### PR TITLE
Update navigation style

### DIFF
--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -132,7 +132,7 @@ export const themeOptions = {
       },
     },
     drawer: {
-      selectedBackgroundColor: 'transparent',
+      selectedBackgroundColor: '#fff',
     },
     saveButtonRow: { height: 40 },
     footer: { height: 32 },

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -45,7 +45,7 @@ const StyledListItem = styled<
     ? {
         ...getListItemCommonStyles(),
         backgroundColor: theme.mixins.drawer.selectedBackgroundColor,
-        boxShadow: theme.shadows[5],
+        boxShadow: theme.shadows[3],
         fontWeight: 'bold',
         marginTop: 5,
       }
@@ -119,7 +119,20 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   );
 
   return visible ? (
-    <StyledListItem isSelected={selected} to={to}>
+    <StyledListItem
+      isSelected={selected}
+      to={to}
+      sx={
+        inactive
+          ? { width: '220px' }
+          : {
+              maxWidth: 165,
+              '& .MuiTypography-root': {
+                maxWidth: 130,
+              },
+            }
+      }
+    >
       <ListItemButton
         sx={{
           ...getListItemCommonStyles(),
@@ -137,8 +150,21 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         component={CustomLink}
       >
         <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
+        {inactive && drawer.isOpen && (
+          <ChevronDownIcon
+            className="menu_section_icon"
+            sx={{
+              color: 'gray.main',
+              fontSize: '1rem',
+              marginLeft: 0.5,
+              stroke: theme => theme.palette.gray.main,
+              strokeWidth: 1.5,
+              transform: 'rotate(-90deg)',
+            }}
+          />
+        )}
         <Box className="navLinkText">
-          <Box width={10} />
+          {!end && <Box width={4} />}
 
           <Badge
             {...badgeProps}

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -40,17 +40,25 @@ const StyledListItem = styled<
   FC<ListItemProps & { isSelected: boolean; to: string }>
 >(ListItem, {
   shouldForwardProp: prop => prop !== 'isSelected',
-})(({ theme, isSelected }) => ({
-  ...getListItemCommonStyles(),
-  backgroundColor: isSelected
-    ? theme.mixins.drawer.selectedBackgroundColor
-    : 'transparent',
-  boxShadow: isSelected ? theme.shadows[3] : 'none',
-  marginTop: 5,
-  '&:hover': {
-    boxShadow: theme.shadows[8],
-  },
-}));
+})(({ theme, isSelected }) =>
+  isSelected
+    ? {
+        ...getListItemCommonStyles(),
+        backgroundColor: theme.mixins.drawer.selectedBackgroundColor,
+        boxShadow: theme.shadows[5],
+        fontWeight: 'bold',
+        marginTop: 5,
+      }
+    : {
+        ...getListItemCommonStyles(),
+        backgroundColor: 'transparent',
+        marginTop: 5,
+        '&:hover': {
+          boxShadow: theme.shadows[3],
+          backgroundColor: theme.palette.background.toolbar,
+        },
+      }
+);
 
 export interface AppNavLinkProps {
   badgeProps?: BadgeProps;
@@ -149,34 +157,33 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
           >
             <ListItemText
               primary={text}
-              sx={
-                isSelectedParentItem
-                  ? {
-                      '& .MuiTypography-root': { fontWeight: 'bold' },
-                      flexGrow: 0,
-                    }
-                  : { flexGrow: 0 }
-              }
+              sx={{
+                '& .MuiTypography-root': {
+                  fontWeight:
+                    selected || isSelectedParentItem ? 'bold' : 'normal',
+                  color: isSelectedParentItem ? 'primary.main' : undefined,
+                },
+                flexGrow: 0,
+              }}
             />
           </Badge>
-          {end && (
-            <ListItemIcon
+
+          <ListItemIcon
+            sx={{
+              minWidth: 20,
+              display: selected && drawer.isOpen ? 'flex' : 'none',
+              alignItems: 'center',
+            }}
+            className="chevron"
+          >
+            <ChevronDownIcon
               sx={{
-                minWidth: 20,
-                display: selected ? 'flex' : 'none',
-                alignItems: 'center',
+                transform: 'rotate(-90deg)',
+                fontSize: '1rem',
+                color: 'primary.main',
               }}
-              className="chevron"
-            >
-              <ChevronDownIcon
-                sx={{
-                  transform: 'rotate(-90deg)',
-                  fontSize: '1rem',
-                  color: 'primary.main',
-                }}
-              />
-            </ListItemIcon>
-          )}
+            />
+          </ListItemIcon>
         </Box>
       </ListItemButton>
     </StyledListItem>

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -86,6 +86,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
 
   const selected = useSelectedNavMenuItem(to, !!end, drawer.isOpen);
   const isSelectedParentItem = inactive && !!useMatch({ path: `${to}/*` });
+  const showMenuSectionIcon = inactive && drawer.isOpen;
   const handleClick = () => {
     // reset the clicked nav path when navigating
     // otherwise the child menu remains open
@@ -119,20 +120,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   );
 
   return visible ? (
-    <StyledListItem
-      isSelected={selected}
-      to={to}
-      sx={
-        inactive
-          ? { width: '220px' }
-          : {
-              maxWidth: 165,
-              '& .MuiTypography-root': {
-                maxWidth: 130,
-              },
-            }
-      }
-    >
+    <StyledListItem isSelected={selected} to={to}>
       <ListItemButton
         sx={{
           ...getListItemCommonStyles(),
@@ -150,7 +138,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         component={CustomLink}
       >
         <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
-        {inactive && drawer.isOpen && (
+        {showMenuSectionIcon && (
           <ChevronDownIcon
             className="menu_section_icon"
             sx={{
@@ -165,7 +153,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         )}
         <Box className="navLinkText">
           {!end && <Box width={4} />}
-
+          {!showMenuSectionIcon && <Box width={4} />}
           <Badge
             {...badgeProps}
             sx={{

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -13,12 +13,17 @@ export const AppNavSection: FC<
       sx={
         isActive
           ? {
+              '& .menu_section_icon': { transform: 'unset' },
               '& .MuiCollapse-root': {
+                marginLeft: '48px',
                 marginTop: -1.5,
+                borderLeft: '1px solid',
+                borderColor: 'gray.light',
+                paddingLeft: 1,
               },
               '& .MuiCollapse-wrapperInner > ul > li.MuiListItem-root': {
                 height: 30,
-                marginLeft: 1,
+                '& .MuiListItemIcon-root': { minWidth: 0 },
               },
             }
           : {}

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -20,12 +20,6 @@ export const AppNavSection: FC<
                 height: 30,
                 marginLeft: 1,
               },
-              '& .navLinkText': {
-                flex: 1,
-              },
-              '& .MuiListItem-root:hover .chevron': {
-                display: 'flex',
-              },
             }
           : {}
       }

--- a/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavSection.tsx
@@ -23,7 +23,15 @@ export const AppNavSection: FC<
               },
               '& .MuiCollapse-wrapperInner > ul > li.MuiListItem-root': {
                 height: 30,
+                paddingLeft: 1,
+                paddingRight: 2,
                 '& .MuiListItemIcon-root': { minWidth: 0 },
+              },
+              '& div > ul > li.MuiListItem-root': {
+                width: 165,
+                '& .MuiTypography-root': {
+                  maxWidth: 135,
+                },
               },
             }
           : {}

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -115,6 +115,7 @@ const StyledDrawer = styled(Box, {
     '& .MuiDrawer-paper': openedMixin(theme),
     '& .navLinkText': {
       display: 'inline-flex',
+      flex: 1,
     },
     '& div > ul > li': {
       width: 220,

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -47,6 +47,9 @@ const commonListContainerStyles = {
 
 const LowerListContainer = styled(Box)({
   ...commonListContainerStyles,
+  '& .MuiListItem-root': {
+    width: 220,
+  },
 });
 
 const UpperListContainer = styled(Box)({
@@ -116,9 +119,6 @@ const StyledDrawer = styled(Box, {
     '& .navLinkText': {
       display: 'inline-flex',
       flex: 1,
-    },
-    '& div > ul > li': {
-      width: 220,
     },
   }),
   ...(!isOpen && {

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -47,9 +47,6 @@ const commonListContainerStyles = {
 
 const LowerListContainer = styled(Box)({
   ...commonListContainerStyles,
-  '& .MuiListItem-root': {
-    width: 220,
-  },
 });
 
 const UpperListContainer = styled(Box)({
@@ -119,6 +116,9 @@ const StyledDrawer = styled(Box, {
     '& .navLinkText': {
       display: 'inline-flex',
       flex: 1,
+    },
+    '& div > ul > li': {
+      width: 220,
     },
   }),
   ...(!isOpen && {

--- a/client/packages/host/src/components/Navigation/CatalogueNav.tsx
+++ b/client/packages/host/src/components/Navigation/CatalogueNav.tsx
@@ -22,7 +22,7 @@ export const CatalogueNav: FC = () => {
       <AppNavLink
         end={false}
         to={AppRoute.Catalogue}
-        icon={<ListIcon color="primary" />}
+        icon={<ListIcon color="primary" style={{ width: 20 }} />}
         text={t('catalogue')}
         inactive
       />


### PR DESCRIPTION
Closes #1018 

Changes as requested. Not sold on the use of the primary colour on the selected parent, but see what you think 😃.
The highlights are back to the white, which was in, and changed in the previous PR following feedback. Once again, see what you think.

Samples:

Dashboard selected:

<img width="261" alt="Screenshot 2023-01-13 at 10 17 48 AM" src="https://user-images.githubusercontent.com/9192912/212184290-b8db737d-846f-41f8-8cec-21cfc98f21e4.png">

Dashboard selected: Customers hovered:

<img width="261" alt="Screenshot 2023-01-13 at 10 18 00 AM" src="https://user-images.githubusercontent.com/9192912/212184437-2a02726c-d877-46b6-b013-7bc8e108bcd6.png">

Outbound selected, Requisitions hovered:

<img width="325" alt="Screenshot 2023-01-13 at 10 17 39 AM" src="https://user-images.githubusercontent.com/9192912/212184278-31f1612d-ba5a-4803-94b5-fdeaec88a0e1.png">
