### PR TITLE
Faster DataTable render

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -17,7 +17,7 @@ import { DataRow } from './components/DataRow/DataRow';
 import { PaginationRow } from './columns/PaginationRow';
 import { ColumnPicker, HeaderCell, HeaderRow } from './components/Header';
 import { RecordWithId } from '@common/types';
-import { useTranslation } from '@common/intl';
+import { useFormatDateTime, useTranslation } from '@common/intl';
 import { useTableStore } from './context';
 
 const DataTableComponent = <T extends RecordWithId>({
@@ -31,6 +31,7 @@ const DataTableComponent = <T extends RecordWithId>({
   isDisabled = false,
   isError = false,
   isLoading = false,
+  isRowAnimated = false,
   noDataElement,
   noDataMessage,
   overflowX = 'unset',
@@ -45,6 +46,7 @@ const DataTableComponent = <T extends RecordWithId>({
   const columnsToDisplay = columns.filter(c =>
     displayColumns.map(({ key }) => key).includes(c.key)
   );
+  const { localisedDate } = useFormatDateTime();
 
   useRegisterActions([
     {
@@ -171,6 +173,9 @@ const DataTableComponent = <T extends RecordWithId>({
               dense={dense}
               keyboardActivated={clickFocusedRow}
               generateRowTooltip={generateRowTooltip}
+              t={t}
+              localisedDate={localisedDate}
+              isAnimated={isRowAnimated}
             />
           ))}
         </TableBody>

--- a/client/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/client/packages/common/src/ui/layout/tables/columns/types.ts
@@ -1,6 +1,6 @@
 import { JSXElementConstructor } from 'react';
 import { SortBy } from '@common/hooks';
-import { useTranslation, LocaleKey } from '@common/intl';
+import { useTranslation, LocaleKey, TypedTFunction } from '@common/intl';
 import { RecordWithId } from '@common/types';
 
 export interface CellProps<T extends RecordWithId> {
@@ -14,6 +14,8 @@ export interface CellProps<T extends RecordWithId> {
   isDisabled?: boolean;
   // Unique name for browser autocomplete (to remember previously entered values for that name)
   autocompleteName?: string;
+  t: TypedTFunction<LocaleKey>;
+  d: (date: string | number | Date) => string;
 }
 
 export interface HeaderProps<T extends RecordWithId> {

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, Story } from '@storybook/react';
 import { TableBody, Table } from '@mui/material';
 import { DataRow } from './DataRow';
 import { useColumns } from '../../hooks';
+import { useFormatDateTime, useTranslation } from '@common/intl';
 
 export default {
   title: 'Table/DataRow',
@@ -12,12 +13,16 @@ export default {
   },
 } as ComponentMeta<typeof DataRow>;
 
+interface StoryRow {
+  id: string;
+  status?: string;
+  comment?: string;
+}
+
 const Template: Story = ({ onClick, generateRowTooltip = () => '' }) => {
-  const columns = useColumns<{ id: string; status: string; comment: string }>([
-    'type',
-    'status',
-    'comment',
-  ]);
+  const t = useTranslation();
+  const { localisedDate } = useFormatDateTime();
+  const columns = useColumns<StoryRow>(['type', 'status', 'comment']);
 
   return (
     <Table>
@@ -27,13 +32,18 @@ const Template: Story = ({ onClick, generateRowTooltip = () => '' }) => {
           rowKey="rowKey"
           rowIndex={0}
           rows={[]}
-          rowData={{
-            id: '',
-            status: 'Finalised',
-            comment: 'Supplier invoice',
-          }}
+          rowData={
+            {
+              id: '',
+              status: 'Finalised',
+              comment: 'Supplier invoice',
+            } as StoryRow
+          }
           onClick={onClick}
           generateRowTooltip={generateRowTooltip}
+          t={t}
+          localisedDate={localisedDate}
+          isAnimated={false}
         />
       </TableBody>
     </Table>

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
@@ -6,8 +6,11 @@ import { TableBody, Table } from '@mui/material';
 import { DataRow } from './DataRow';
 import { useColumns } from '../../hooks';
 import { TestingProvider } from '../../../../../utils';
+import { useFormatDateTime, useTranslation } from '@common/intl';
 
 describe('DataRow', () => {
+  const t = useTranslation();
+  const { localisedDate } = useFormatDateTime();
   const Example = () => {
     const columns = useColumns([
       {
@@ -27,6 +30,9 @@ describe('DataRow', () => {
             rowIndex={0}
             rowData={{ id: 'josh' }}
             generateRowTooltip={() => ''}
+            isAnimated={false}
+            t={t}
+            localisedDate={localisedDate}
           />
         </TableBody>
       </Table>

--- a/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, PropsWithChildren, ReactElement, useEffect } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { alpha } from '@mui/material/styles';
@@ -11,6 +11,7 @@ import {
   useRowStyle,
 } from '../../context';
 import { Fade, Tooltip } from '@mui/material';
+import { TypedTFunction, LocaleKey } from '@common/intl';
 
 interface DataRowProps<T extends RecordWithId> {
   columns: Column<T>[];
@@ -23,6 +24,9 @@ interface DataRowProps<T extends RecordWithId> {
   rowIndex: number;
   keyboardActivated?: boolean;
   generateRowTooltip: (row: T) => string;
+  t: TypedTFunction<LocaleKey>;
+  localisedDate: (date: string | number | Date) => string;
+  isAnimated: boolean;
 }
 
 export const DataRow = <T extends RecordWithId>({
@@ -36,6 +40,9 @@ export const DataRow = <T extends RecordWithId>({
   rows,
   keyboardActivated,
   generateRowTooltip,
+  t,
+  localisedDate,
+  isAnimated,
 }: DataRowProps<T>): JSX.Element => {
   const hasOnClick = !!onClick;
   const { isExpanded } = useExpanded(rowData.id);
@@ -46,6 +53,14 @@ export const DataRow = <T extends RecordWithId>({
   const onRowClick = () => onClick && onClick(rowData);
   const paddingX = dense ? '12px' : '16px';
   const paddingY = dense ? '4px' : 0;
+  const Animation: FC<PropsWithChildren> = ({ children }) =>
+    isAnimated ? (
+      <Fade in={true} timeout={500}>
+        {children as ReactElement}
+      </Fade>
+    ) : (
+      <>{children}</>
+    );
 
   useEffect(() => {
     if (isFocused) onRowClick();
@@ -53,7 +68,7 @@ export const DataRow = <T extends RecordWithId>({
 
   return (
     <>
-      <Fade in={true} timeout={500}>
+      <Animation>
         <Tooltip
           title={generateRowTooltip(rowData)}
           followCursor
@@ -109,23 +124,27 @@ export const DataRow = <T extends RecordWithId>({
                     fontWeight: 'normal',
                   }}
                 >
-                  <column.Cell
-                    isDisabled={isDisabled}
-                    rows={rows}
-                    rowData={rowData}
-                    columns={columns}
-                    column={column}
-                    rowKey={rowKey}
-                    columnIndex={columnIndex}
-                    rowIndex={rowIndex}
-                    autocompleteName={column.autocompleteProvider?.(rowData)}
-                  />
+                  {
+                    <column.Cell
+                      isDisabled={isDisabled}
+                      rows={rows}
+                      rowData={rowData}
+                      columns={columns}
+                      column={column}
+                      rowKey={rowKey}
+                      columnIndex={columnIndex}
+                      rowIndex={rowIndex}
+                      autocompleteName={column.autocompleteProvider?.(rowData)}
+                      t={t}
+                      d={localisedDate}
+                    />
+                  }
                 </TableCell>
               );
             })}
           </TableRow>
         </Tooltip>
-      </Fade>
+      </Animation>
       {isExpanded && !!ExpandContent ? (
         <tr>
           <td colSpan={columns.length}>

--- a/client/packages/common/src/ui/layout/tables/components/index.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { CellProps, HeaderProps } from '../columns/types';
 import { RecordWithId } from '@common/types';
-import { useTranslation, useFormatDateTime } from '@common/intl';
+import { useTranslation } from '@common/intl';
 
 export * from './DataRow';
 export * from './Cells';
@@ -12,21 +12,19 @@ export const BasicCell = <T extends RecordWithId>({
   column,
   rowData,
   rows,
-}: CellProps<T>): ReactElement => {
-  const t = useTranslation();
-  const { localisedDate: d } = useFormatDateTime();
-
-  return (
-    <div
-      style={{
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      }}
-    >
-      {column.formatter(column.accessor({ rowData, rows }), { t, d })}
-    </div>
-  );
-};
+  t,
+  d,
+}: CellProps<T>): ReactElement => (
+  <div
+    style={{
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    }}
+    className="basic-cell"
+  >
+    {column.formatter(column.accessor({ rowData, rows }), { t, d })}
+  </div>
+);
 
 export const BasicHeader = <T extends RecordWithId>({
   column,

--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -26,6 +26,7 @@ export interface TableProps<T extends RecordWithId> {
   isDisabled?: boolean;
   isError?: boolean;
   isLoading?: boolean;
+  isRowAnimated?: boolean;
   noDataMessage?: string;
   noDataElement?: JSX.Element;
   overflowX?:

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -115,6 +115,7 @@ export const ContentArea: FC<ContentAreaProps> = ({
       <DataTable<StocktakeSummaryItem | StocktakeLineFragment>
         onRowClick={onRowClick}
         ExpandContent={Expando}
+        isRowAnimated={true}
         columns={columns}
         data={rows}
         id="stocktake-detail"

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
@@ -109,6 +109,7 @@ export const ContentArea: FC<ContentAreaProps> = React.memo(
               buttonText={t('button.add-item')}
             />
           }
+          isRowAnimated={true}
         />
       </Box>
     );

--- a/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -148,6 +148,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
             buttonText={t('button.add-item')}
           />
         }
+        isRowAnimated={true}
       />
     </Box>
   );

--- a/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
+++ b/client/packages/system/src/Item/api/hooks/useStockItemsWithStats/useStockItemsWithStats.tsx
@@ -5,7 +5,7 @@ export const useStockItemsWithStats = () => {
   const queryParams = {
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
     offset: 0,
-    first: 5000, // TODO: remove arbitrary limit
+    first: 1000, // TODO: remove arbitrary limit
   };
   const api = useItemApi();
   return useQuery(api.keys.paramList(queryParams), () =>

--- a/server/repository/src/migrations/v1_01_01/mod.rs
+++ b/server/repository/src/migrations/v1_01_01/mod.rs
@@ -13,6 +13,8 @@ impl Migration for V1_01_01 {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        use crate::migrations::sql;
+
         // Remove Check
         #[cfg(not(feature = "postgres"))]
         remove_sqlite_check::migrate(connection)?;


### PR DESCRIPTION
Closes #912 ( well.. not exactly )

Basically, trying to render 500 rows in the datatable is slow. This is worse on a slow tablet such as the lenovo TB-X304L
I've worked through a range of options - and this PR is compromise. it speeds things up, but not as much as I'd like. Have spent long enough working on it though.

The baseline I had was 2.328ms to render the table ( 500 rows of outbound shipments ) in a browser.
This is down to 1.884ms. Have had it down to 639ms but that requires removing functionality.

Likely that this could be faster - but it's actually looking ok on android atm.