### PR TITLE
1027 report arguments UI

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -28,14 +28,6 @@ export type Scalars = {
    * * `2000-02-24`
    */
   NaiveDate: string;
-  /**
-   * ISO 8601 combined date and time without timezone.
-   *
-   * # Examples
-   *
-   * * `2015-07-01T08:59:60.123`,
-   */
-  NaiveDateTime: string;
 };
 
 export type ActivityLogConnector = {
@@ -54,7 +46,7 @@ export type ActivityLogFilterInput = {
 
 export type ActivityLogNode = {
   __typename: 'ActivityLogNode';
-  datetime: Scalars['NaiveDateTime'];
+  datetime: Scalars['DateTime'];
   event?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   recordId?: Maybe<Scalars['String']>;
@@ -2950,7 +2942,8 @@ export type QueriesPatientsArgs = {
 
 
 export type QueriesPrintReportArgs = {
-  dataId: Scalars['String'];
+  arguments?: InputMaybe<Scalars['JSON']>;
+  dataId?: InputMaybe<Scalars['String']>;
   format?: InputMaybe<PrintFormat>;
   reportId: Scalars['String'];
   storeId: Scalars['String'];
@@ -2958,7 +2951,8 @@ export type QueriesPrintReportArgs = {
 
 
 export type QueriesPrintReportDefinitionArgs = {
-  dataId: Scalars['String'];
+  arguments?: InputMaybe<Scalars['JSON']>;
+  dataId?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
   report: Scalars['JSON'];
   storeId: Scalars['String'];
@@ -3131,13 +3125,16 @@ export enum ReportContext {
 
 export type ReportFilterInput = {
   context?: InputMaybe<EqualFilterReportContextInput>;
+  context2?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   name?: InputMaybe<SimpleStringFilterInput>;
 };
 
 export type ReportNode = {
   __typename: 'ReportNode';
+  argumentSchema?: Maybe<FormSchemaNode>;
   context: ReportContext;
+  context2?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   /** Human readable name of the report */
   name: Scalars['String'];

--- a/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
@@ -16,6 +16,7 @@ import {
   ReportSelector,
   useReport,
 } from '@openmsupply-client/system';
+import { JsonData } from '@openmsupply-client/programs';
 
 interface AppBarButtonProps {
   onAddItem: (newState: boolean) => void;
@@ -30,9 +31,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const { data } = useStocktake.document.get();
   const { print, isPrinting } = useReport.utils.print();
 
-  const printReport = (report: ReportRowFragment) => {
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
     if (!data) return;
-    print({ reportId: report.id, dataId: data?.id || '' });
+    print({ reportId: report.id, dataId: data?.id, args });
   };
 
   return (
@@ -44,10 +48,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem(true)}
         />
-        <ReportSelector
-          context={ReportContext.Stocktake}
-          onClick={printReport}
-        >
+        <ReportSelector context={ReportContext.Stocktake} onClick={printReport}>
           <LoadingButton
             variant="outlined"
             startIcon={<PrinterIcon />}

--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -17,6 +17,7 @@ import {
   useReport,
 } from '@openmsupply-client/system';
 import { AddFromMasterListButton } from './AddFromMasterListButton';
+import { JsonData } from '@openmsupply-client/programs';
 
 interface AppBarButtonProps {
   onAddItem: (newState: boolean) => void;
@@ -31,9 +32,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const t = useTranslation('common');
   const { print, isPrinting } = useReport.utils.print();
 
-  const printReport = (report: ReportRowFragment) => {
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
     if (!data) return;
-    print({ reportId: report.id, dataId: data?.id || '' });
+    print({ reportId: report.id, dataId: data?.id, args });
   };
 
   return (

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
@@ -17,6 +17,7 @@ import {
   ReportSelector,
 } from '@openmsupply-client/system';
 import { AddFromMasterListButton } from './AddFromMasterListButton';
+import { JsonData } from '@openmsupply-client/programs';
 
 interface AppBarButtonProps {
   onAddItem: () => void;
@@ -31,9 +32,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const t = useTranslation('common');
   const { print, isPrinting } = useReport.utils.print();
 
-  const printReport = (report: ReportRowFragment) => {
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
     if (!data) return;
-    print({ reportId: report.id, dataId: data?.id || '' });
+    print({ reportId: report.id, dataId: data?.id, args });
   };
 
   return (

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -18,6 +18,7 @@ import {
 import { useRequest } from '../../api';
 import { UseSuggestedQuantityButton } from './UseSuggestedQuantityButton';
 import { AddFromMasterListButton } from './AddFromMasterListButton';
+import { JsonData } from '@openmsupply-client/programs';
 
 interface AppBarButtonProps {
   isDisabled: boolean;
@@ -33,9 +34,12 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   const { data } = useRequest.document.get();
   const { print, isPrinting } = useReport.utils.print();
 
-  const printReport = (report: ReportRowFragment) => {
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
     if (!data) return;
-    print({ reportId: report.id, dataId: data?.id || '' });
+    print({ reportId: report.id, dataId: data?.id, args });
   };
 
   return (

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -16,6 +16,7 @@ import {
 import { CreateShipmentButton } from './CreateShipmentButton';
 import { SupplyRequestedQuantityButton } from './SupplyRequestedQuantityButton';
 import { useResponse } from '../../api';
+import { JsonData } from '@openmsupply-client/programs';
 
 export const AppBarButtonsComponent = () => {
   const { OpenButton } = useDetailPanel();
@@ -23,9 +24,12 @@ export const AppBarButtonsComponent = () => {
   const { print, isPrinting } = useReport.utils.print();
   const t = useTranslation('common');
 
-  const printReport = (report: ReportRowFragment) => {
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
     if (!data) return;
-    print({ reportId: report.id, dataId: data?.id || '' });
+    print({ reportId: report.id, dataId: data?.id, args });
   };
 
   return (

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -10,13 +10,17 @@ import React, { FC } from 'react';
 import { AddButton } from './AddButton';
 import { ReportRowFragment, ReportSelector, useReport } from '../../Report';
 import { usePatient } from '../api';
+import { JsonData } from 'packages/programs/src';
 
 export const AppBarButtons: FC = () => {
   const t = useTranslation('common');
   const { print, isPrinting } = useReport.utils.print();
   const patientId = usePatient.utils.id();
-  const printReport = (report: ReportRowFragment) => {
-    print({ reportId: report.id, dataId: patientId });
+  const printReport = (
+    report: ReportRowFragment,
+    args: JsonData | undefined
+  ) => {
+    print({ reportId: report.id, dataId: patientId, args });
   };
 
   return (

--- a/client/packages/system/src/Report/api/api.ts
+++ b/client/packages/system/src/Report/api/api.ts
@@ -1,4 +1,5 @@
 import { EnvUtils, FilterBy, SortBy } from '@openmsupply-client/common';
+import { JsonData } from '@openmsupply-client/programs';
 import { ReportRowFragment, Sdk } from './operations.generated';
 
 export type ReportListParams = {
@@ -20,11 +21,13 @@ export const getReportQueries = (sdk: Sdk, storeId: string) => ({
       return result?.reports || [];
     },
     print: async ({
-      dataId,
       reportId,
+      dataId,
+      args,
     }: {
-      dataId: string;
       reportId: string;
+      dataId: string | undefined;
+      args: JsonData | undefined;
     }) => {
       const format = EnvUtils.printFormat;
       const result = await sdk.printReport({
@@ -32,6 +35,7 @@ export const getReportQueries = (sdk: Sdk, storeId: string) => ({
         reportId,
         storeId,
         format,
+        arguments: args,
       });
       if (result?.printReport.__typename === 'PrintReportNode') {
         return result.printReport.fileId;

--- a/client/packages/system/src/Report/api/hooks/document/useReports.ts
+++ b/client/packages/system/src/Report/api/hooks/document/useReports.ts
@@ -1,9 +1,15 @@
 import { useQuery, ReportContext } from '@openmsupply-client/common';
 import { useReportApi } from '../utils/useReportApi';
 
-export const useReports = (context?: ReportContext) => {
+export const useReports = (context?: ReportContext, context2?: string) => {
   const api = useReportApi();
-  const filterBy = context ? { context: { equalTo: context } } : null;
+  const filterBy =
+    context || context2
+      ? {
+          context: context ? { equalTo: context } : null,
+          context2: context2 ? { equalTo: context2 } : null,
+        }
+      : null;
   const queryParams = {
     filterBy,
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },

--- a/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
+++ b/client/packages/system/src/Report/api/hooks/utils/usePrintReport.ts
@@ -8,10 +8,12 @@ import {
 import { Environment } from '@openmsupply-client/config';
 import { useReportApi } from './useReportApi';
 import { Printer } from '@awesome-cordova-plugins/printer';
+import { JsonData } from '@openmsupply-client/programs';
 
 type PrintReportParams = {
   reportId: string;
-  dataId: string;
+  dataId: string | undefined;
+  args: JsonData | undefined;
 };
 
 const setClose = (frame: HTMLIFrameElement) => () => {

--- a/client/packages/system/src/Report/api/operations.generated.ts
+++ b/client/packages/system/src/Report/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type ReportRowFragment = { __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string };
+export type ReportRowFragment = { __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string, context2?: string | null, argumentSchema?: { __typename: 'FormSchemaNode', id: string, type: string, jsonSchema: any, uiSchema: any } | null };
 
 export type ReportsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -14,12 +14,13 @@ export type ReportsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ReportsQuery = { __typename: 'Queries', reports: { __typename: 'ReportConnector', totalCount: number, nodes: Array<{ __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string }> } };
+export type ReportsQuery = { __typename: 'Queries', reports: { __typename: 'ReportConnector', totalCount: number, nodes: Array<{ __typename: 'ReportNode', context: Types.ReportContext, id: string, name: string, context2?: string | null, argumentSchema?: { __typename: 'FormSchemaNode', id: string, type: string, jsonSchema: any, uiSchema: any } | null }> } };
 
 export type PrintReportQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
-  dataId: Types.Scalars['String'];
   reportId: Types.Scalars['String'];
+  dataId?: Types.InputMaybe<Types.Scalars['String']>;
+  arguments?: Types.InputMaybe<Types.Scalars['JSON']>;
   format?: Types.InputMaybe<Types.PrintFormat>;
 }>;
 
@@ -31,6 +32,13 @@ export const ReportRowFragmentDoc = gql`
   context
   id
   name
+  context2
+  argumentSchema {
+    id
+    type
+    jsonSchema
+    uiSchema
+  }
 }
     `;
 export const ReportsDocument = gql`
@@ -47,12 +55,13 @@ export const ReportsDocument = gql`
 }
     ${ReportRowFragmentDoc}`;
 export const PrintReportDocument = gql`
-    query printReport($storeId: String!, $dataId: String!, $reportId: String!, $format: PrintFormat) {
+    query printReport($storeId: String!, $reportId: String!, $dataId: String, $arguments: JSON, $format: PrintFormat) {
   printReport(
     dataId: $dataId
     reportId: $reportId
     storeId: $storeId
     format: $format
+    arguments: $arguments
   ) {
     ... on PrintReportNode {
       __typename
@@ -112,7 +121,7 @@ export const mockReportsQuery = (resolver: ResponseResolver<GraphQLRequest<Repor
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockPrintReportQuery((req, res, ctx) => {
- *   const { storeId, dataId, reportId, format } = req.variables;
+ *   const { storeId, reportId, dataId, arguments, format } = req.variables;
  *   return res(
  *     ctx.data({ printReport })
  *   )

--- a/client/packages/system/src/Report/api/operations.graphql
+++ b/client/packages/system/src/Report/api/operations.graphql
@@ -2,6 +2,13 @@ fragment ReportRow on ReportNode {
   context
   id
   name
+  context2
+  argumentSchema {
+    id
+    type
+    jsonSchema
+    uiSchema
+  }
 }
 
 query reports(
@@ -27,8 +34,9 @@ query reports(
 
 query printReport(
   $storeId: String!
-  $dataId: String!
   $reportId: String!
+  $dataId: String
+  $arguments: JSON
   $format: PrintFormat
 ) {
   printReport(
@@ -36,6 +44,7 @@ query printReport(
     reportId: $reportId
     storeId: $storeId
     format: $format
+    arguments: $arguments
   ) {
     ... on PrintReportNode {
       __typename

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -39,6 +39,7 @@ export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
     <Modal
       title="Report arguments"
       cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
+      slideAnimation={false}
       okButton={
         <DialogButton
           variant="ok"

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -1,0 +1,66 @@
+import React, { FC, useState } from 'react';
+
+import { JsonData, JsonForm } from '@openmsupply-client/programs';
+import { ReportRowFragment } from '../api';
+import { useDialog } from '@common/hooks';
+import { DialogButton } from '@common/components';
+
+export type ReportArgumentsModalProps = {
+  /** Modal is shown if there is an argument schema present */
+  report: ReportRowFragment | undefined;
+  onReset: () => void;
+  onArgumentsSelected: (report: ReportRowFragment, args: JsonData) => void;
+};
+
+export const ReportArgumentsModal: FC<ReportArgumentsModalProps> = ({
+  report,
+  onReset,
+  onArgumentsSelected,
+}) => {
+  const [data, setData] = useState<JsonData>({});
+  const [error, setError] = useState<string | false>(false);
+
+  // clean up when modal is closed
+  const cleanUp = () => {
+    setData({});
+    onReset();
+  };
+
+  const { Modal } = useDialog({
+    isOpen: !!report?.argumentSchema,
+    onClose: cleanUp,
+  });
+
+  if (!report?.argumentSchema) {
+    return null;
+  }
+
+  return (
+    <Modal
+      title="Report arguments"
+      cancelButton={<DialogButton variant="cancel" onClick={cleanUp} />}
+      okButton={
+        <DialogButton
+          variant="ok"
+          disabled={!!error}
+          onClick={async () => {
+            onArgumentsSelected(report, data);
+            cleanUp();
+          }}
+        />
+      }
+    >
+      <JsonForm
+        data={data}
+        jsonSchema={report.argumentSchema.jsonSchema}
+        uiSchema={report.argumentSchema.uiSchema}
+        isError={false}
+        isLoading={false}
+        setError={err => setError(err)}
+        updateData={(newData: JsonData) => {
+          setData(newData);
+        }}
+      />
+    </Modal>
+  );
+};

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react';
+import React, { FC, PropsWithChildren, useCallback, useState } from 'react';
 import { Box, ReportContext, Typography } from '@openmsupply-client/common';
 import { AlertIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
@@ -9,10 +9,13 @@ import {
   usePaperClickPopover,
 } from '@common/components';
 import { ReportRowFragment, useReport } from '../api';
+import { ReportArgumentsModal } from './ReportArgumentsModal';
+import { JsonData } from 'packages/programs/src';
 
 interface ReportSelectorProps {
   context?: ReportContext;
-  onClick: (report: ReportRowFragment) => void;
+  context2?: string;
+  onClick: (report: ReportRowFragment, args: JsonData | undefined) => void;
 }
 
 const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
@@ -35,19 +38,36 @@ const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
 
 export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   context,
+  context2,
   children,
   onClick,
 }) => {
   const { hide, PaperClickPopover } = usePaperClickPopover();
-  const { data, isLoading } = useReport.document.list(context);
+  const { data, isLoading } = useReport.document.list(context, context2);
   const t = useTranslation('app');
+  const [reportWithArgs, setReportWithArgs] = useState<
+    ReportRowFragment | undefined
+  >();
+  const onReportSelected = useCallback(
+    (report: ReportRowFragment | undefined) => {
+      if (report === undefined) {
+        return;
+      }
+      if (report.argumentSchema) {
+        setReportWithArgs(report);
+      } else {
+        onClick(report, undefined);
+      }
+    },
+    []
+  );
 
   const reportButtons = data?.nodes?.map(report => (
     <FlatButton
       label={report.name}
       onClick={() => {
         hide();
-        onClick(report);
+        onReportSelected(report);
       }}
       key={report.id}
       sx={{ textAlign: 'left', justifyContent: 'left' }}
@@ -57,42 +77,52 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   const hasPermission = !isLoading && data !== undefined;
   const noReports = !isLoading && !data?.nodes?.length;
   const oneReport =
-    !isLoading && data?.nodes?.length === 1 ? data.nodes[0] : null;
+    !isLoading && data?.nodes?.length === 1 ? data.nodes[0] : undefined;
 
-  return !!oneReport ? (
-    <div onClick={() => onClick(oneReport)}>{children}</div>
-  ) : (
-    <PaperClickPopover
-      placement="bottom"
-      width={350}
-      Content={
-        <PaperPopoverSection
-          label={t('select-report')}
-          labelStyle={{ width: '100%' }}
-          alignItems="center"
-        >
-          {isLoading ? (
-            <CircularProgress size={12} />
-          ) : (
-            <Box
-              style={{
-                maxHeight: '200px',
-                overflowY: 'auto',
-              }}
-              display="flex"
-              flexDirection="column"
+  return (
+    <>
+      {!!oneReport ? (
+        <div onClick={() => onReportSelected(oneReport)}>{children}</div>
+      ) : (
+        <PaperClickPopover
+          placement="bottom"
+          width={350}
+          Content={
+            <PaperPopoverSection
+              label={t('select-report')}
+              labelStyle={{ width: '100%' }}
+              alignItems="center"
             >
-              {noReports ? (
-                <NoReports hasPermission={hasPermission} />
+              {isLoading ? (
+                <CircularProgress size={12} />
               ) : (
-                reportButtons
+                <Box
+                  style={{
+                    maxHeight: '200px',
+                    overflowY: 'auto',
+                  }}
+                  display="flex"
+                  flexDirection="column"
+                >
+                  {noReports ? (
+                    <NoReports hasPermission={hasPermission} />
+                  ) : (
+                    reportButtons
+                  )}
+                </Box>
               )}
-            </Box>
-          )}
-        </PaperPopoverSection>
-      }
-    >
-      {children}
-    </PaperClickPopover>
+            </PaperPopoverSection>
+          }
+        >
+          {children}
+        </PaperClickPopover>
+      )}
+
+      <ReportArgumentsModal
+        report={reportWithArgs}
+        onReset={() => setReportWithArgs(undefined)}
+        onArgumentsSelected={(report, args) => onClick(report, args)}
+      ></ReportArgumentsModal>
+    </>
   );
 };

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -121,7 +121,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
       <ReportArgumentsModal
         report={reportWithArgs}
         onReset={() => setReportWithArgs(undefined)}
-        onArgumentsSelected={(report, args) => onClick(report, args)}
+        onArgumentsSelected={onClick}
       ></ReportArgumentsModal>
     </>
   );

--- a/server/report_builder/arguments.json
+++ b/server/report_builder/arguments.json
@@ -1,3 +1,0 @@
-{
-  "creationDatetimeBeforeOrEqual": "2023-01-16T01:35:39.770Z"
-}


### PR DESCRIPTION
Adds the UI part for report arguments.

- Show a JSONForms modal to retrieve report arguments (if the reports requires some)
- Print the report with the arguments
- Testing: there is demo report (select a patient -> print) that takes an argument. The report query uses this argument...

TODOs:
- Move common JSONForms control out of the programs packages.
- Move program patient report to make use of the secondary context

Closes #1027 
Closes #946