### PR TITLE
Update back end pagination of item to match front end

### DIFF
--- a/server/service/src/item.rs
+++ b/server/service/src/item.rs
@@ -3,7 +3,7 @@ use repository::{Item, ItemFilter, ItemRepository, ItemSort, StorageConnectionMa
 
 use super::{get_default_pagination, i64_to_u32, ListError, ListResult};
 
-pub const MAX_LIMIT: u32 = 1000;
+pub const MAX_LIMIT: u32 = 5000;
 pub const MIN_LIMIT: u32 = 1;
 
 pub fn get_items(


### PR DESCRIPTION
closes #1040 

Made an android [built](https://drive.google.com/file/d/1CtYhwR0JXSzIrjPHy6o-DecV14_3fxxK/view?usp=share_link), still not sure why in built version served through remote server we not getting `toast` error but just `loading` display