### PR TITLE
1045 fix sync integration tests

### DIFF
--- a/server/service/src/sync/test/integration/errors.rs
+++ b/server/service/src/sync/test/integration/errors.rs
@@ -73,6 +73,11 @@ mod tests {
             .request_and_set_site_info(&service_provider, &sync_settings)
             .await
             .unwrap();
+        service_provider
+            .settings
+            .update_sync_settings(&service_context, &sync_settings)
+            .unwrap();
+
         let synchroniser =
             get_synchroniser_with_hardware_id(&connection_manager, &sync_settings, "id1");
         synchroniser.sync().await.unwrap();

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -34,6 +34,7 @@ async fn init_test_context(
         connection,
         service_provider,
         processors_task,
+        service_context,
         ..
     } = setup_all_and_service_provider(
         &format!("sync_integration_{}_tests", identifier),
@@ -46,6 +47,11 @@ async fn init_test_context(
         .request_and_set_site_info(&service_provider, &sync_settings)
         .await
         .unwrap();
+    service_provider
+        .settings
+        .update_sync_settings(&service_context, sync_settings)
+        .unwrap();
+
     let synchroniser =
         Synchroniser::new(sync_settings.clone(), service_provider.clone().into()).unwrap();
 

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -46,7 +46,8 @@ impl SyncRecordTester for InvoiceRecordTester {
             colour: None,
             requisition_id: None,
             linked_invoice_id: None,
-            tax: None,
+            // Tax on invoice/transact is not nullable in mSupply
+            tax: Some(0.0),
         };
         let base_invoice_line_row = InvoiceLineRow {
             id: uuid(),
@@ -103,21 +104,28 @@ impl SyncRecordTester for InvoiceRecordTester {
         });
         let invoice_row_3 = inline_edit(&base_invoice_row, |mut d| {
             d.id = uuid();
-            d.r#type = InvoiceRowType::InventoryAdjustment;
-            d.status = InvoiceRowStatus::Picked;
-            d
-        });
-        let invoice_row_4 = inline_edit(&base_invoice_row, |mut d| {
-            d.id = uuid();
             d.r#type = InvoiceRowType::OutboundShipment;
             d.status = InvoiceRowStatus::Shipped;
             d
         });
 
-        let invoice_row_5 = inline_edit(&base_invoice_row, |mut d| {
+        let invoice_row_4 = inline_edit(&base_invoice_row, |mut d| {
             d.id = uuid();
             d.r#type = InvoiceRowType::OutboundShipment;
             d.status = InvoiceRowStatus::Delivered;
+            d
+        });
+        // Inventory adjustments should link to correct name
+        let invoice_row_5 = inline_edit(&base_invoice_row, |mut d| {
+            d.id = uuid();
+            d.r#type = InvoiceRowType::InventoryAddition;
+            d.status = InvoiceRowStatus::Picked;
+            d
+        });
+        let invoice_row_6 = inline_edit(&base_invoice_row, |mut d| {
+            d.id = uuid();
+            d.r#type = InvoiceRowType::InventoryReduction;
+            d.status = InvoiceRowStatus::Picked;
             d
         });
 
@@ -147,6 +155,7 @@ impl SyncRecordTester for InvoiceRecordTester {
                 PullUpsertRecord::Invoice(invoice_row_3),
                 PullUpsertRecord::Invoice(invoice_row_4),
                 PullUpsertRecord::Invoice(invoice_row_5),
+                PullUpsertRecord::Invoice(invoice_row_6),
                 PullUpsertRecord::InvoiceLine(invoice_line_row_1.clone()),
                 PullUpsertRecord::InvoiceLine(invoice_line_row_2),
                 PullUpsertRecord::InvoiceLine(invoice_line_row_3),
@@ -206,9 +215,6 @@ impl SyncRecordTester for InvoiceRecordTester {
             d.sell_price_per_pack = 15.0;
             d.total_before_tax = 10.0;
             d.total_after_tax = 15.0;
-            // TODO test to unset the tax, this is currently not working but should
-            // work with the new push endpoint
-            // d.tax = None;
             d.tax = Some(0.0);
             d.number_of_packs = 15.120;
             d.note = Some("invoice line note".to_string());

--- a/server/service/src/sync/test/integration/remote/mod.rs
+++ b/server/service/src/sync/test/integration/remote/mod.rs
@@ -6,12 +6,18 @@ pub(crate) mod stock_line;
 pub(crate) mod stocktake;
 mod test;
 
-use crate::sync::test::{
-    check_records_against_database,
-    integration::{
-        central_server_configurations::{ConfigureCentralServer, SiteConfiguration},
-        init_test_context, SyncIntegrationContext,
+use repository::{InvoiceRowType, NameRowRepository, StorageConnection};
+use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
+
+use crate::sync::{
+    test::{
+        check_records_against_database,
+        integration::{
+            central_server_configurations::{ConfigureCentralServer, SiteConfiguration},
+            init_test_context, SyncIntegrationContext,
+        },
     },
+    translations::{IntegrationRecords, PullUpsertRecord},
 };
 
 use super::SyncRecordTester;
@@ -60,11 +66,14 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
 
         // Pull required central data
         previous_synchroniser.sync().await.unwrap();
+
+        let mut integration_records = step_data.integration_records;
+        // Replace system name codes (for inventory adjustment name etc..)
+        replace_system_name_ids(&mut integration_records, &previous_connection);
+
         // Integrate
-        step_data
-            .integration_records
-            .integrate(&previous_connection)
-            .unwrap();
+
+        integration_records.integrate(&previous_connection).unwrap();
         // Push integrated changes
         previous_synchroniser.sync().await.unwrap();
         // Re initialise
@@ -77,6 +86,24 @@ async fn test_remote_sync_record(identifier: &str, tester: &dyn SyncRecordTester
         previous_synchroniser = synchroniser;
         previous_synchroniser.sync().await.unwrap();
         // Confirm records have synced back correctly
-        check_records_against_database(&previous_connection, step_data.integration_records).await;
+        check_records_against_database(&previous_connection, integration_records).await;
+    }
+}
+
+fn replace_system_name_ids(records: &mut IntegrationRecords, connection: &StorageConnection) {
+    let inventory_adjustment_name = NameRowRepository::new(connection)
+        .find_one_by_code(INVENTORY_ADJUSTMENT_NAME_CODE)
+        .unwrap()
+        .expect("Cannont find intenvory adjustment name");
+
+    for mut record in records.upserts.iter_mut() {
+        if let PullUpsertRecord::Invoice(invoice) = &mut record {
+            if invoice.r#type == InvoiceRowType::InventoryAddition
+                || invoice.r#type == InvoiceRowType::InventoryReduction
+            {
+                invoice.name_id = inventory_adjustment_name.id.clone();
+                invoice.name_store_id = None;
+            }
+        }
     }
 }

--- a/server/service/src/sync/test/integration/remote/stocktake.rs
+++ b/server/service/src/sync/test/integration/remote/stocktake.rs
@@ -38,7 +38,8 @@ impl SyncRecordTester for StocktakeRecordTester {
             created_datetime: NaiveDate::from_ymd(2022, 03, 22).and_hms(9, 51, 0),
             stocktake_date: None,
             finalised_datetime: None,
-            inventory_adjustment_id: None,
+            inventory_addition_id: None,
+            inventory_reduction_id: None,
             is_locked: true,
         };
         let stocktake_line_row = StocktakeLineRow {
@@ -90,7 +91,9 @@ impl SyncRecordTester for StocktakeRecordTester {
             d.status = StocktakeStatus::Finalised;
             d.stocktake_date = Some(NaiveDate::from_ymd(2022, 03, 23));
             d.finalised_datetime = Some(NaiveDate::from_ymd(2022, 03, 24).and_hms(8, 15, 30));
-            d.inventory_adjustment_id = Some(invoice_row.id.clone());
+            // Not testing that logically invoices are correct inventory adjustments just testing they sync corrrectly
+            d.inventory_addition_id = Some(invoice_row.id.clone());
+            d.inventory_reduction_id = Some(invoice_row.id.clone());
             d.is_locked = true;
             d
         });

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -37,9 +37,10 @@ pub enum LegacyTransactType {
     Ci,
     /// Supplier credit
     #[serde(rename = "sc")]
+    #[serde(alias = "Sc")]
     Sc,
     /// Bucket to catch all other variants
-    /// E.g. "cc" (customer credit), "sc" (supplier credit), "sr" (repack), "bu" (build),
+    /// E.g. "cc" (customer credit), "sr" (repack), "bu" (build),
     /// "rc" (cash receipt), "ps" (cash payment)
     #[serde(other)]
     Others,


### PR DESCRIPTION
closes #1045 

Sync settings need to be in database when syncing, added in both types of integration tests

Tax field is not nullable in mSupply, for now not testing `None` variant for tax. (this potentially affects UI if `null` on tax is shown differently to 0, but not much can be done unless new om_tax field is added to transact)

Added inventory adjustments to tests, which also required `name` to be inventory adjustments (otherwise invoice translation fails as it is quite strict on types, i.e. invoices with inventory adjustment name will only match `sc` or `si` type). This required knowing what inventory adjustment name is, and since test data is generated before sync, have to patch test data for InventoryAddition/Reduction after first sync (when inventory adjustment name is known)

Did a full test via `SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test  --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test --features integration_test,postgres ` as per [readme](https://github.com/openmsupply/open-msupply/blob/develop/server/service/src/sync/test/integration/README.MD)



