### PR TITLE
1014 patient search query

### DIFF
--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -112,6 +112,7 @@ pub struct NameFilterInput {
     pub address2: Option<SimpleStringFilterInput>,
     pub country: Option<SimpleStringFilterInput>,
     pub email: Option<SimpleStringFilterInput>,
+    pub identifier: Option<SimpleStringFilterInput>,
 }
 
 #[derive(SimpleObject)]
@@ -190,6 +191,7 @@ impl NameFilterInput {
             address2,
             country,
             email,
+            identifier,
         } = self;
 
         NameFilter {
@@ -213,6 +215,7 @@ impl NameFilterInput {
             address2: address2.map(SimpleStringFilter::from),
             country: country.map(SimpleStringFilter::from),
             email: email.map(SimpleStringFilter::from),
+            identifier: identifier.map(SimpleStringFilter::from),
         }
     }
 }

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -153,6 +153,9 @@ mod graphql {
             },
             "email": {
               "equalTo": "email"
+            },
+            "identifier": {
+              "equalTo": "identifier"
             }
           }
         });
@@ -204,6 +207,7 @@ mod graphql {
                 address2,
                 country,
                 email,
+                identifier,
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
@@ -240,6 +244,8 @@ mod graphql {
             assert_eq!(address2, Some(SimpleStringFilter::equal_to("address2")));
             assert_eq!(country, Some(SimpleStringFilter::equal_to("country")));
             assert_eq!(email, Some(SimpleStringFilter::equal_to("email")));
+
+            assert_eq!(identifier, Some(SimpleStringFilter::equal_to("identifier")));
 
             Ok(ListResult {
                 rows: vec![Name {

--- a/server/graphql/programs/src/queries/patient.rs
+++ b/server/graphql/programs/src/queries/patient.rs
@@ -175,6 +175,7 @@ pub struct PatientFilterInput {
     pub country: Option<SimpleStringFilterInput>,
     pub email: Option<SimpleStringFilterInput>,
     pub is_visible: Option<bool>,
+    pub identifier: Option<SimpleStringFilterInput>,
 }
 
 impl PatientFilterInput {
@@ -193,6 +194,7 @@ impl PatientFilterInput {
             country,
             email,
             is_visible,
+            identifier,
         } = self;
         PatientFilter {
             id: id.map(EqualFilter::from),
@@ -208,6 +210,7 @@ impl PatientFilterInput {
             country: country.map(SimpleStringFilter::from),
             email: email.map(SimpleStringFilter::from),
             is_visible,
+            identifier: identifier.map(SimpleStringFilter::from),
         }
     }
 }

--- a/server/repository/src/db_diesel/program_enrolment_row.rs
+++ b/server/repository/src/db_diesel/program_enrolment_row.rs
@@ -1,4 +1,6 @@
-use super::StorageConnection;
+use super::{
+    name_row::name, name_store_join::name_store_join, store_row::store, StorageConnection,
+};
 
 use crate::repository_error::RepositoryError;
 
@@ -15,6 +17,11 @@ table! {
         program_patient_id -> Nullable<Text>,
     }
 }
+
+joinable!(program_enrolment -> name (patient_id));
+allow_tables_to_appear_in_same_query!(program_enrolment, name);
+allow_tables_to_appear_in_same_query!(program_enrolment, name_store_join);
+allow_tables_to_appear_in_same_query!(program_enrolment, store);
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
 #[table_name = "program_enrolment"]

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -174,6 +174,8 @@ macro_rules! apply_simple_string_filter {
     }};
 }
 
+/// Warning: All OR filters need to be called before AND filters to work correctly.
+///
 /// Example expand, when called with:
 ///
 /// ```

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -110,6 +110,47 @@ macro_rules! apply_string_filter {
     }};
 }
 
+#[cfg(not(feature = "postgres"))]
+#[macro_export]
+macro_rules! apply_simple_string_filter_method {
+    ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        if let Some(string_filter) = $filter_field {
+            if let Some(value) = string_filter.equal_to {
+                $query = $query.$filter_method($dsl_field.eq(value));
+            }
+
+            if let Some(value) = string_filter.insensitive_equal_to {
+                $query = $query.$filter_method($dsl_field.like(value.replace("%", "")));
+            }
+
+            if let Some(value) = string_filter.like {
+                // in sqlite like is case insensitive (but on only works with ASCII chars)
+                $query = $query.$filter_method($dsl_field.like(format!("%{}%", value)));
+            }
+        }
+    }};
+}
+#[cfg(feature = "postgres")]
+#[macro_export]
+macro_rules! apply_simple_string_filter_method {
+    ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        if let Some(string_filter) = $filter_field {
+            if let Some(value) = string_filter.equal_to {
+                $query = $query.$filter_method($dsl_field.eq(value));
+            }
+
+            if let Some(value) = string_filter.insensitive_equal_to {
+                $query = $query.$filter_method($dsl_field.ilike(value.replace("%", "")));
+            }
+
+            if let Some(value) = string_filter.like {
+                // Use case insensitive like
+                $query = $query.$filter_method($dsl_field.ilike(format!("%{}%", value)));
+            }
+        }
+    }};
+}
+
 /// Example expand, when called with:
 ///
 /// ```
@@ -127,96 +168,32 @@ macro_rules! apply_string_filter {
 ///     }
 /// }
 /// ```
-#[cfg(not(feature = "postgres"))]
 macro_rules! apply_simple_string_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
-                $query = $query.filter($dsl_field.eq(value));
-            }
-
-            if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.filter($dsl_field.like(value.replace("%", "")));
-            }
-
-            if let Some(value) = string_filter.like {
-                // in sqlite like is case insensitive (but on only works with ASCII chars)
-                $query = $query.filter($dsl_field.like(format!("%{}%", value)));
-            }
-        }
-    }};
-}
-#[cfg(feature = "postgres")]
-macro_rules! apply_simple_string_filter {
-    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
-                $query = $query.filter($dsl_field.eq(value));
-            }
-
-            if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.filter($dsl_field.ilike(value.replace("%", "")));
-            }
-
-            if let Some(value) = string_filter.like {
-                // Use case insensitive like
-                $query = $query.filter($dsl_field.ilike(format!("%{}%", value)));
-            }
-        }
+        $crate::apply_simple_string_filter_method!($query, filter, $filter_field, $dsl_field);
     }};
 }
 
 /// Example expand, when called with:
 ///
 /// ```
-/// apply_simple_string_or_filter!(query, filter.code_or_name, item_dsl::code, item_dsl::name)
+/// apply_simple_string_or_filter!(query, filter.comment, invoice_dsl::comment)
 /// ```
 ///
 /// ```
-/// if let Some(string_filter) = filter.code_or_name {
+/// if let Some(string_filter) = filter.comment {
 ///     if let Some(value) = equal_filter.equal_to {
-///         query = query.filter(item_dsl::code.eq(value));
-///         query = query.or_filter(item_dsl::name.eq(value));
+///         query = query.or_filter(invoice_dsl::comment.eq(value));
 ///     }
 ///
 ///     if let Some(value) = equal_filter.like {
-///         query = query.filter(item_dsl::code.like(format!("%{}%", value)));
-///         query = query.or_filter(item_dsl::name.like(format!("%{}%", value)));
+///         query = query.or_filter(invoice_dsl::comment.like(format!("%{}%", value)));
 ///     }
 /// }
 /// ```
-#[cfg(not(feature = "postgres"))]
 macro_rules! apply_simple_string_or_filter {
-    ($query:ident, $filter_field:expr, $dsl_field_1:expr, $dsl_field_2:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
-                $query = $query.filter($dsl_field_1.eq(value.clone()));
-                $query = $query.or_filter($dsl_field_2.eq(value));
-            }
-
-            if let Some(value) = string_filter.like {
-                // in sqlite like is case insensitive (but on only works with ASCII chars)
-                $query = $query.filter($dsl_field_1.like(format!("%{}%", value.clone())));
-                $query = $query.or_filter($dsl_field_2.like(format!("%{}%", value)));
-            }
-        }
-    }};
-}
-#[cfg(feature = "postgres")]
-macro_rules! apply_simple_string_or_filter {
-    ($query:ident, $filter_field:expr, $dsl_field_1:expr, $dsl_field_2:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
-                $query = $query.filter($dsl_field_1.eq(value.clone()));
-                $query = $query.or_filter($dsl_field_2.eq(value));
-            }
-
-            if let Some(value) = string_filter.like {
-                // Use case insensitive like
-                $query = $query.filter($dsl_field_1.ilike(format!("%{}%", value.clone())));
-                $query = $query.or_filter($dsl_field_2.ilike(format!("%{}%", value)));
-            }
-        }
+    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        $crate::apply_simple_string_filter_method!($query, or_filter, $filter_field, $dsl_field);
     }};
 }
 

--- a/server/repository/src/mock/test_name_query.rs
+++ b/server/repository/src/mock/test_name_query.rs
@@ -60,6 +60,7 @@ pub fn mock_name_2() -> NameRow {
         r.id = "name2".to_string();
         r.name = "name_2".to_string();
         r.code = "code2".to_string();
+        r.national_health_number = Some("nhn2".to_string());
     })
 }
 

--- a/server/service/src/programs/patient/query.rs
+++ b/server/service/src/programs/patient/query.rs
@@ -22,6 +22,7 @@ pub struct PatientFilter {
     pub country: Option<SimpleStringFilter>,
     pub email: Option<SimpleStringFilter>,
     pub is_visible: Option<bool>,
+    pub identifier: Option<SimpleStringFilter>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -112,6 +113,7 @@ impl PatientFilter {
             country,
             email,
             is_visible,
+            identifier,
         } = self;
 
         NameFilter {
@@ -135,6 +137,7 @@ impl PatientFilter {
             address2,
             country,
             email,
+            identifier,
         }
     }
 }


### PR DESCRIPTION
Part of #1014 

- Add an `identifier` filter to search names / patient by (`code` OR `national_health_number` OR `program_patient_id`)
- Make `apply_simple_string_or_filter!` more low level. Previously it operated on two table columns. Now it just works like `apply_simple_string_filter!` only with `or_filter`, `apply_simple_string_or_filter` is than used in the repo to have ORs for three table columns for the identifier filter.
- ORs need to be applied before AND queries. A test and fix has been applied for the `item` table `code_or_name` filter.

Note, with the dynamic diesel `or_filter` and `filter` method you can't actually do arbitrary AND / OR filters (I previously thought you can). For example: (a OR b) AND (c OR d) can't be expressed; `query.filter(a).or_filter(b).filter(c).or_filter(d)` would result in:
`(a OR b) AND c OR d`
