### PR TITLE
Make the array `detail` option optional. Not needed for enum arrays.

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
@@ -53,7 +53,9 @@ export interface ArrayControlCustomProps extends ArrayControlProps {
 
 export const CommonOptions = z
   .object({
-    detail: z.object({ type: z.string(), elements: z.array(z.any()) }),
+    detail: z
+      .object({ type: z.string(), elements: z.array(z.any()) })
+      .optional(),
     /**
      * If true, display items in reverse order (newest first)
      */


### PR DESCRIPTION
Fix for #1015 

This causes a config error for a string array (if I don't miss anything)...