### PR TITLE
Add a discovery flag (workarround for windows build problems)

### DIFF
--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -61,7 +61,8 @@ httpmock = "0.6"
 winres = "0.1"
 
 [features]
-default = ["sqlite", "dep:async-dnssd", "dep:machine-uid"]
+default = ["sqlite", "dep:machine-uid"]
+discovery = ["dep:async-dnssd"]
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]
 # See openssl comment regarding the "openssl/vendored" feature

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -37,7 +37,7 @@ pub mod static_files;
 pub use self::logging::*;
 
 // Only import discovery for non android features (otherwise build for android targets would fail due to local-ip-address)
-#[cfg(not(target_os = "android"))]
+#[cfg(all(not(target_os = "android"), feature = "discovery"))]
 mod discovery;
 
 /// Starts the server
@@ -196,7 +196,7 @@ pub async fn start_server(
 
     // START DISCOVERY
     // Don't do discovery in android
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"), feature = "discovery"))]
     {
         info!("Starting server discovery",);
         discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);


### PR DESCRIPTION
Tested on windows:
- `cargo build` works now
- `cargo build --features discovery` keeps fails