### PR TITLE
Android external links

### DIFF
--- a/client/packages/android/app/src/main/assets/capacitor.config.json
+++ b/client/packages/android/app/src/main/assets/capacitor.config.json
@@ -8,9 +8,6 @@
 	},
 	"server": {
 		"url": "https://localhost:8000",
-		"hostname": "should.notmatch.localhost",
-		"allowNavigation": [
-			"*"
-		]
+		"hostname": "should.notmatch.localhost"
 	}
 }

--- a/client/packages/android/capacitor.config.ts
+++ b/client/packages/android/capacitor.config.ts
@@ -15,9 +15,8 @@ const config: CapacitorConfig = {
   },
   server: {
     url: 'https://localhost:8000',
-    // If hostname is kept as localhost then Capacitor localServer will try to use bundled web app vs web app from remote/wepack server
+    // If hostname is kept as localhost then Capacitor localServer will try to use bundled web app vs web app from remote/webpack server
     hostname: 'should.notmatch.localhost',
-    allowNavigation: ['*'],
   },
   // Below will turn on debug (uncomment and run `yarn apply-config`)
   // plugins: {
@@ -28,4 +27,3 @@ const config: CapacitorConfig = {
 };
 
 export default config;
-


### PR DESCRIPTION
Fixes #997 

This resolves the issue for me - the capacitor configuration option `allowNavigation` defines which urls are handled within the webview. The wildcard tells capacitor to open all links in the webview, when we only want the bundle to load. Internal navigation should be handled by react router once the bundle is loaded.

Have tested loading local and remote server bundles and they load fine, with external links ( e.g. the docs ) loading in chrome rather than the app.