### PR TITLE
Update Create Shipment message

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -79,7 +79,7 @@
   "messages.edit-service-charges": "Edit service charges",
   "messages.stock-charges-description": "Total charges for stock lines. The calculated tax amount is an effective tax rate using the total tax paid over the subtotal of all stock lines.",
   "messages.service-charges-description": "Total amounts of service charges. The calculated tax amount is an effective tax rate using the total tax paid over the subtotal of all service charges.",
-  "message.all-lines-have-been-fulfilled": "All of the lines of this requisition already have a matching shipment line.",
+  "message.all-lines-have-been-fulfilled": "All of the lines of this requisition with a supply quantity specified already have a matching shipment line.",
   "message.all-lines-have-no-supply-quantity": "There is no supply quantity specified for all of the unfulfilled lines of this requisition. Please specify a supply quantity for at least one line.",
   "messages.no-shipments-yet": "No shipments created yet.",
   "messages.no-related-documents": "No related documents.",

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -80,6 +80,7 @@
   "messages.stock-charges-description": "Total charges for stock lines. The calculated tax amount is an effective tax rate using the total tax paid over the subtotal of all stock lines.",
   "messages.service-charges-description": "Total amounts of service charges. The calculated tax amount is an effective tax rate using the total tax paid over the subtotal of all service charges.",
   "message.all-lines-have-been-fulfilled": "All of the lines of this requisition already have a matching shipment line.",
+  "message.all-lines-have-no-supply-quantity": "There is no supply quantity specified for all of the unfulfilled lines of this requisition. Please specify a supply quantity for at least one line.",
   "messages.no-shipments-yet": "No shipments created yet.",
   "messages.no-related-documents": "No related documents.",
   "messages.by-user": "by {{username}}",

--- a/client/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
+++ b/client/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
@@ -59,7 +59,7 @@ export const AlertModalProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       setMessage: (message: string | React.ReactNode) =>
         setState(state => ({ ...state, message })),
       setTitle: (title: string) => setState(state => ({ ...state, title })),
-      setOnOk: () => {},
+      setOnOk: (onOk: () => void) => setState(state => ({ ...state, onOk })),
       setOpen: (open: boolean) => setState(state => ({ ...state, open })),
       ...alertModalState,
       setImportant: (important: boolean) =>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
@@ -23,7 +23,7 @@ export const CreateShipmentButtonComponent = () => {
   const alert = useAlertModal({
     title: t('heading.cannot-do-that'),
     message: t(
-      lines?.nodes.every(line => !line?.remainingQuantityToSupply)
+      lines?.nodes.every(line => !line?.supplyQuantity)
         ? 'message.all-lines-have-no-supply-quantity'
         : 'message.all-lines-have-been-fulfilled'
     ),

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
@@ -9,9 +9,10 @@ import {
 import { useResponse } from '../../api';
 
 export const CreateShipmentButtonComponent = () => {
-  const { linesRemainingToSupply } = useResponse.document.fields(
-    'linesRemainingToSupply'
-  );
+  const { lines, linesRemainingToSupply } = useResponse.document.fields([
+    'lines',
+    'linesRemainingToSupply',
+  ]);
   const t = useTranslation('distribution');
   const { mutate: createOutbound } = useResponse.utils.createOutbound();
   const getConfirmation = useConfirmationModal({
@@ -21,10 +22,13 @@ export const CreateShipmentButtonComponent = () => {
   });
   const alert = useAlertModal({
     title: t('heading.cannot-do-that'),
-    message: t('message.all-lines-have-been-fulfilled'),
+    message: t(
+      lines?.nodes.every(line => !line?.remainingQuantityToSupply)
+        ? 'message.all-lines-have-no-supply-quantity'
+        : 'message.all-lines-have-been-fulfilled'
+    ),
     onOk: () => {},
   });
-
   const onCreateShipment = () => {
     if (linesRemainingToSupply.totalCount > 0) {
       getConfirmation();


### PR DESCRIPTION
Fixes #1021 

The message was correct and misleading at the same time.
Have created a new message which explains the situation when all supply quantity values are zero, and have updated the wording of the previous message.

<img width="778" alt="Screenshot 2023-01-24 at 6 08 17 PM" src="https://user-images.githubusercontent.com/9192912/214217598-4354e33d-0a26-4472-81eb-e6276aa6e1d0.png">

Have also fixed the onOk handler, so that you don't get redirected to login
