### PR TITLE
#926 Practitioner input

### DIFF
--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -18,7 +18,7 @@
   "label.visit-date": "Visit Date",
   "label.visit-start": "Start",
   "label.visit-end": "End",
-  "label.seen-by": "Seen by",
+  "label.clinician": "Clinician",
   "messages.click-to-return-to-encounters": "Unable to find an encounter with that ID. Click OK to return to the encounter list",
   "messages.click-to-view": "Click to view the patient record for {{firstName}} {{lastName}}",
   "messages.no-matching-patients": "No matching patients! 😁",

--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -18,6 +18,7 @@
   "label.visit-date": "Visit Date",
   "label.visit-start": "Start",
   "label.visit-end": "End",
+  "label.seen-by": "Seen by",
   "messages.click-to-return-to-encounters": "Unable to find an encounter with that ID. Click OK to return to the encounter list",
   "messages.click-to-view": "Click to view the patient record for {{firstName}} {{lastName}}",
   "messages.no-matching-patients": "No matching patients! 😁",

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -75,7 +75,7 @@ export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
                 }
               />
               <Row
-                label={'Seen by'}
+                label={t('label.clinician')}
                 Input={
                   <BasicTextInput
                     disabled

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   UserIcon,
 } from '@openmsupply-client/common';
 import { EncounterFragment, useEncounter } from '@openmsupply-client/programs';
+import { getClinicianName } from '../../Patient/Encounter';
 
 const Row = ({ label, Input }: { label: string; Input: ReactNode }) => (
   <InputWithLabelRow labelWidth="90px" label={label} Input={Input} />
@@ -26,6 +27,8 @@ export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
   const [startDatetime, setStartDatetime] = useState<string | undefined>();
   const [endDatetime, setEndDatetime] = useState<string | undefined | null>();
   const t = useTranslation('patients');
+
+  console.log('encounter', encounter);
 
   useEffect(() => fetchEncounter(), []);
 
@@ -66,12 +69,24 @@ export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
         </Grid>
         <Grid item display="flex" flex={1}>
           <Box display="flex" flex={1} flexDirection="column" gap={0.5}>
-            <Row
-              label={t('label.patient')}
-              Input={
-                <BasicTextInput disabled value={encounter?.patient.name} />
-              }
-            />
+            <Box display="flex" gap={1}>
+              <InputWithLabelRow
+                label={t('label.patient')}
+                Input={
+                  <BasicTextInput disabled value={encounter?.patient.name} />
+                }
+              />
+              <InputWithLabelRow
+                label={'Seen by'}
+                Input={
+                  <BasicTextInput
+                    disabled
+                    value={getClinicianName(encounter?.document.data.clinician)}
+                  />
+                }
+              />
+            </Box>
+
             <Box display="flex" gap={1}>
               <Row
                 label={t('label.visit-date')}

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -28,8 +28,6 @@ export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
   const [endDatetime, setEndDatetime] = useState<string | undefined | null>();
   const t = useTranslation('patients');
 
-  console.log('encounter', encounter);
-
   useEffect(() => fetchEncounter(), []);
 
   useEffect(() => {
@@ -70,13 +68,13 @@ export const Toolbar: FC<ToolbarProps> = ({ onChange }) => {
         <Grid item display="flex" flex={1}>
           <Box display="flex" flex={1} flexDirection="column" gap={0.5}>
             <Box display="flex" gap={1}>
-              <InputWithLabelRow
+              <Row
                 label={t('label.patient')}
                 Input={
                   <BasicTextInput disabled value={encounter?.patient.name} />
                 }
               />
-              <InputWithLabelRow
+              <Row
                 label={'Seen by'}
                 Input={
                   <BasicTextInput

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -176,7 +176,7 @@ export const CreateEncounterModal: FC = () => {
                   }
                 />
                 <InputWithLabelRow
-                  label={t('label.seen-by')}
+                  label={t('label.clinician')}
                   Input={
                     <Autocomplete
                       value={{

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -32,13 +32,15 @@ interface Encounter {
   status?: EncounterNodeStatus;
   startDatetime?: string;
   endDatetime?: string;
-  clinician?: ClinicianFragment;
+  clinician?: Clinician;
 }
 
 type ClinicianAutocompleteOption = {
   label: string;
-  value?: ClinicianFragment;
+  value?: Clinician;
 };
+
+type Clinician = Pick<ClinicianFragment, 'firstName' | 'lastName' | 'id'>;
 
 export const CreateEncounterModal: FC = () => {
   const patientId = usePatient.utils.id();
@@ -199,8 +201,12 @@ export const CreateEncounterModal: FC = () => {
                       }}
                       options={clinicians.map(
                         (clinician): ClinicianAutocompleteOption => ({
-                          label: `${clinician.firstName} ${clinician.lastName}`,
-                          value: clinician,
+                          label: getClinicianName(clinician),
+                          value: {
+                            firstName: clinician.firstName ?? '',
+                            lastName: clinician.lastName ?? '',
+                            id: clinician.id,
+                          },
                         })
                       )}
                     />
@@ -240,7 +246,9 @@ const RenderForm = ({
   return <>{form}</>;
 };
 
-export const getClinicianName = (clinician: ClinicianFragment | undefined) => {
+export const getClinicianName = (
+  clinician: ClinicianFragment | Clinician | undefined
+) => {
   if (clinician === undefined) return '';
-  return `${clinician.firstName} ${clinician.lastName}`;
+  return `${clinician.firstName || ''} ${clinician.lastName || ''}`;
 };

--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -78,7 +78,7 @@ mod hiv_testing_encounter {
             Self {
                 end_datetime: Default::default(),
                 family_planning: Default::default(),
-                practitioner: Default::default(),
+                clinician: Default::default(),
                 risk_behaviour: Default::default(),
                 start_datetime: Default::default(),
                 status: Default::default(),
@@ -100,7 +100,7 @@ mod hiv_care_encounter {
                 family_planning: Default::default(),
                 gender_based_violence: Default::default(),
                 physical_examination: Default::default(),
-                practitioner: Default::default(),
+                clinician: Default::default(),
                 start_datetime: Default::default(),
                 status: Default::default(),
                 tuberculosis: Default::default(),

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -1,6 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Clinician": {
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "EncounterStatus": {
       "enum": ["SCHEDULED", "DONE", "CANCELLED"],
       "type": "string"
@@ -185,6 +199,9 @@
             }
           },
           "type": "object"
+        },
+        "clinician": {
+          "$ref": "#/definitions/Clinician"
         },
         "endDatetime": {
           "description": "Encounter end date and time",
@@ -418,9 +435,6 @@
           },
           "type": "object"
         },
-        "practitioner": {
-          "$ref": "#/definitions/Practitioner"
-        },
         "startDatetime": {
           "description": "Encounter start date and time",
           "format": "date-time",
@@ -440,11 +454,7 @@
               "type": "string"
             },
             "tbGeneXpert": {
-              "enum": [
-                "NOT_DETECTED",
-                "POSITIVE_RIF_SENSITIVE",
-                "POSITIVE_RIF_RESISTANT"
-              ],
+              "enum": ["NOT_DETECTED", "POSITIVE_RIF_SENSITIVE", "POSITIVE_RIF_RESISTANT"],
               "type": "string"
             },
             "tbSputum": {
@@ -500,20 +510,6 @@
         }
       },
       "required": ["startDatetime"],
-      "type": "object"
-    },
-    "Practitioner": {
-      "properties": {
-        "firstName": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        }
-      },
       "type": "object"
     }
   },

--- a/server/service/src/sync/program_schemas/hiv_care_program.json
+++ b/server/service/src/sync/program_schemas/hiv_care_program.json
@@ -107,8 +107,8 @@
         "mother": {
           "$ref": "#/definitions/HIVRelation"
         },
-        "partnerHivStatus": {
-          "$ref": "#/definitions/HIVPartnerStatus"
+        "partnerHIVStatus": {
+          "$ref": "#/definitions/HIVTestingStatus"
         },
         "priorART": {
           "enum": ["TRANSFER_IN_WITH_RECORDS", "TRANSFER_IN_WITHOUT_RECORDS", "PPTCT_PROPHYLAXIS", "PEP", "PrEP"],
@@ -131,10 +131,6 @@
       "required": ["enrolmentDatetime"],
       "type": "object"
     },
-    "HIVPartnerStatus": {
-      "enum": ["POSITIVE", "NEGATIVE", "UNKNOWN", "NOT_DONE"],
-      "type": "string"
-    },
     "HIVRelation": {
       "properties": {
         "clinic": {
@@ -152,6 +148,10 @@
     },
     "HIVTestType": {
       "enum": ["PCR", "ANTIBODY"],
+      "type": "string"
+    },
+    "HIVTestingStatus": {
+      "enum": ["POSITIVE", "NEGATIVE", "UNKNOWN", "NOT_DONE"],
       "type": "string"
     },
     "Note": {
@@ -173,7 +173,7 @@
           "type": "string"
         }
       },
-      "required": ["text", "created", "authorId"],
+      "required": ["text", "created", "authorId", "authorName"],
       "type": "object"
     },
     "Person": {
@@ -246,7 +246,7 @@
           "$ref": "#/definitions/SocioEconomics"
         }
       },
-      "required": ["isDeceased", "contactDetails", "socioEconomics"],
+      "required": ["contactDetails"],
       "type": "object"
     },
     "ProgramEnrolmentStatus": {

--- a/server/service/src/sync/program_schemas/hiv_care_program_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_care_program_ui_schema.json
@@ -67,7 +67,7 @@
     },
     {
       "type": "Control",
-      "scope": "#/properties/partnerHivStatus",
+      "scope": "#/properties/partnerHIVStatus",
       "label": "Partner HIV Status",
       "options": {
         "show": [
@@ -138,10 +138,7 @@
               ["TRANSFER_IN", "Transfer in"],
               ["STI", "STI"],
               ["ANC", "ANC"],
-              [
-                "EXPOSED_INFANT_WELL_BABY_CLINIC",
-                "Exposed infant well baby clinic"
-              ],
+              ["EXPOSED_INFANT_WELL_BABY_CLINIC", "Exposed infant well baby clinic"],
               ["IN_PATIENT", "In patient"]
             ]
           }

--- a/server/service/src/sync/program_schemas/hiv_testing_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_testing_encounter.json
@@ -1,6 +1,24 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "ARTFacilityLocation": {
+      "enum": ["CURRENT_FACILITY", "EXTERNAL_FACILITY"],
+      "type": "string"
+    },
+    "Clinician": {
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "EncounterStatus": {
       "enum": ["SCHEDULED", "DONE", "CANCELLED"],
       "type": "string"
@@ -18,19 +36,12 @@
       },
       "type": "object"
     },
+    "GBVScreeningOutcome": {
+      "enum": ["POSITIVE", "NEGATIVE", "NOT_DONE", "DECLINED"],
+      "type": "string"
+    },
     "HIVRiskGroup": {
-      "enum": [
-        "LRM",
-        "MSM",
-        "MSW",
-        "MSMSW",
-        "HRM",
-        "LRW",
-        "HRW",
-        "FSW",
-        "TG",
-        "TGSW"
-      ],
+      "enum": ["LRM", "MSM", "MSW", "MSMSW", "HRM", "LRW", "HRW", "FSW", "TG", "TGSW"],
       "type": "string"
     },
     "HIVStatus": {
@@ -43,6 +54,9 @@
     },
     "HIVTestingEncounter": {
       "properties": {
+        "clinician": {
+          "$ref": "#/definitions/Clinician"
+        },
         "endDatetime": {
           "description": "Encounter end date and time",
           "format": "date-time",
@@ -53,13 +67,70 @@
         },
         "hivTesting": {
           "properties": {
+            "clientEscorted": {
+              "description": "Was the client escorted?",
+              "type": "boolean"
+            },
+            "condomDemonstration": {
+              "description": "Did you conduct condom demonstration?",
+              "type": "boolean"
+            },
+            "condomsLubricantsOffered": {
+              "description": "6. Where condoms and/or lubricants offered to the client?",
+              "type": "boolean"
+            },
             "datetime": {
               "description": "Date of HIV Test done",
               "format": "date-time",
               "type": "string"
             },
+            "numberOfFemaleCondoms": {
+              "type": "number"
+            },
+            "numberOfLubricants": {
+              "type": "number"
+            },
+            "numberOfMaleCondoms": {
+              "description": "6a. If yes number of males condoms provided?",
+              "type": "number"
+            },
+            "otherServiceName": {
+              "description": "5aa. If other, specify:",
+              "type": "string"
+            },
+            "otherServices": {
+              "description": "5a. If yes, which one(s): TB, STI, GBV, PEP, Other",
+              "items": {
+                "$ref": "#/definitions/OtherServiceType"
+              },
+              "type": "array"
+            },
+            "postTestCounsellingDone": {
+              "description": "Post-test counselling done?",
+              "type": "boolean"
+            },
+            "referredARTFacility": {
+              "$ref": "#/definitions/ARTFacilityLocation",
+              "description": "2aa. Where ? This facility or Another Facility"
+            },
+            "referredARTFacilityName": {
+              "description": "2aaa. If another facility, name of the facility",
+              "type": "string"
+            },
+            "referredForARTServices": {
+              "description": "2. Did you refer the patient for ART services?",
+              "type": "boolean"
+            },
             "result": {
               "$ref": "#/definitions/HIVStatus"
+            },
+            "screenedAndReferredForOtherServices": {
+              "description": "5. Was client screened and referred for other services?",
+              "type": "boolean"
+            },
+            "serodiscordantCoupleCounsellingProvided": {
+              "$ref": "#/definitions/YesNoNA",
+              "description": "If serodiscordant, was couple counselling provided?"
             },
             "type": {
               "$ref": "#/definitions/HIVTestType"
@@ -67,9 +138,6 @@
           },
           "required": ["datetime", "type", "result"],
           "type": "object"
-        },
-        "practitioner": {
-          "$ref": "#/definitions/Practitioner"
         },
         "riskBehaviour": {
           "properties": {
@@ -93,6 +161,14 @@
               "description": "How many male sexual partners have you had in the last 6 months ?",
               "type": "number"
             },
+            "previousHIVTestDate": {
+              "description": "Date of a previous HIV test",
+              "format": "date",
+              "type": "string"
+            },
+            "previousHIVTestResult": {
+              "$ref": "#/definitions/HIVTestingStatus"
+            },
             "prostitution": {
               "description": "Have you received any of the following in the past 12 months ?: Sex in exchange for money/goods/services ?",
               "type": "boolean"
@@ -101,8 +177,15 @@
               "description": "Have you received any of the following in the past 12 months ?: Received a blood transfusion ?",
               "type": "boolean"
             },
+            "referredToGBVService": {
+              "description": "If GBV screening = positive, referred for GBV services ? Yes or No",
+              "type": "boolean"
+            },
             "riskGroup": {
               "$ref": "#/definitions/HIVRiskGroup"
+            },
+            "screeningOutcomeGBV": {
+              "$ref": "#/definitions/GBVScreeningOutcome"
             },
             "sexWithSameSex": {
               "description": "Have you received any of the following in the past 12 months ?: Had sex with someone of the same sex ?",
@@ -135,19 +218,17 @@
       "required": ["startDatetime"],
       "type": "object"
     },
-    "Practitioner": {
-      "properties": {
-        "firstName": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        }
-      },
-      "type": "object"
+    "HIVTestingStatus": {
+      "enum": ["POSITIVE", "NEGATIVE", "UNKNOWN", "NOT_DONE"],
+      "type": "string"
+    },
+    "OtherServiceType": {
+      "enum": ["TB", "STI", "GBV", "PEP", "OTHER"],
+      "type": "string"
+    },
+    "YesNoNA": {
+      "enum": ["Yes", "No", "N/A"],
+      "type": "string"
     }
   },
   "type": "object",


### PR DESCRIPTION
Just putting this in Draft for now cos there's a couple of things not working properly (doesn't currently compile in front-end).

@clemens-msupply Could use your help figuring out how to add the "clinician" property to the "Encounter" type. You'll notice in "CreateEncounterModal" that there is an error with `draft?.clinician` as property is not defined in "EncounterFragment", but this comes from database types as far as I could tell.

Also -- I'm currently just saving the whole "clinician" object in the Encounter document, but should it also be at the "root" level of the Encounter data?

Currently this is very basic -- it just displays a "clinician" drop-down on the Encounter create modal, and then displays that value on the Encounter details page. Should this be editable on the Details page? (It's currently displayed as a disabled input like the Patient name is)
![Screenshot 2023-02-02 at 11 38 07 AM](https://user-images.githubusercontent.com/5456533/216180094-83d40147-7feb-494a-8e0b-821ed374269f.png)
![Screenshot 2023-02-02 at 11 38 20 AM](https://user-images.githubusercontent.com/5456533/216180106-ced96217-ad5a-447e-a8ab-325282e81416.png)
