### PR TITLE
Enable discovery in windows server

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -438,6 +438,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "astro-dnssd"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba40a960b341f156b5123e823c7589d0850f4e6bd46a206106f5b2a5b8a73de"
+dependencies = [
+ "libc",
+ "log 0.4.16",
+ "pkg-config",
+ "thiserror",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,6 +4202,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "assert-json-diff",
+ "astro-dnssd",
  "async-dnssd",
  "chrono",
  "clap",

--- a/server/README.md
+++ b/server/README.md
@@ -15,6 +15,7 @@ Remote server can use `sqlite` or `postgres`, quick start guide is for `sqlite` 
 ### Windows
 - [Follow this guide](https://docs.microsoft.com/en-us/windows/dev-environment/rust/setup)
 - Install [perl](https://learn.perl.org/installing/windows.html)
+- For building the windows binary, you'll need to install the [Bonjour Windows SDK](https://developer.apple.com/bonjour/) and configure the environment variable `BONJOUR_SDK_HOME` to point to the installation location. This is required for the dns-sd implementation on windows, used for server discovery.
 
 ### Mac
 

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -63,6 +63,8 @@ async-dnssd = { version = "0.5.0" }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
+
+[target.'cfg(windows)'.dependencies]
 astro-dnssd = { version = "0.3.2" }
 
 [features]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -58,7 +58,7 @@ actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 httpmock = "0.6"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 async-dnssd = { version = "0.5.0" }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -47,8 +47,6 @@ thiserror = "1"
 clap = { version = "3.1.8", features = ["derive"] }
 rust-embed = "6.4.0"
 mime_guess = "2.0.4"
-# async-dnssd = { version = "0.5.0", optional = true }
-# astro-dnssd = { version = "0.3.2", optional = true }
 futures = "0.3"
 fast_log = { version = "1.5" }
 rcgen = "0.9.2"
@@ -69,7 +67,6 @@ astro-dnssd = { version = "0.3.2" }
 
 [features]
 default = ["sqlite", "dep:machine-uid"]
-# discovery = ["dep:async-dnssd", "dep:astro-dnssd"]
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]
 # See openssl comment regarding the "openssl/vendored" feature

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -47,8 +47,8 @@ thiserror = "1"
 clap = { version = "3.1.8", features = ["derive"] }
 rust-embed = "6.4.0"
 mime_guess = "2.0.4"
-async-dnssd = { version = "0.5.0", optional = true }
-astro-dnssd = { version = "0.3.2", optional = true }
+# async-dnssd = { version = "0.5.0", optional = true }
+# astro-dnssd = { version = "0.3.2", optional = true }
 futures = "0.3"
 fast_log = { version = "1.5" }
 rcgen = "0.9.2"
@@ -58,12 +58,16 @@ actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 httpmock = "0.6"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+async-dnssd = { version = "0.5.0" }
+
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
+astro-dnssd = { version = "0.3.2" }
 
 [features]
 default = ["sqlite", "dep:machine-uid"]
-discovery = ["dep:async-dnssd", "dep:astro-dnssd"]
+# discovery = ["dep:async-dnssd", "dep:astro-dnssd"]
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]
 # See openssl comment regarding the "openssl/vendored" feature

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -48,6 +48,7 @@ clap = { version = "3.1.8", features = ["derive"] }
 rust-embed = "6.4.0"
 mime_guess = "2.0.4"
 async-dnssd = { version = "0.5.0", optional = true }
+astro-dnssd = { version = "0.3.2", optional = true }
 futures = "0.3"
 fast_log = { version = "1.5" }
 rcgen = "0.9.2"
@@ -62,7 +63,7 @@ winres = "0.1"
 
 [features]
 default = ["sqlite", "dep:machine-uid"]
-discovery = ["dep:async-dnssd"]
+discovery = ["dep:async-dnssd", "dep:astro-dnssd"]
 sqlite = ["repository/sqlite"]
 postgres = ["repository/postgres"]
 # See openssl comment regarding the "openssl/vendored" feature

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -1,65 +1,63 @@
 use crate::certs::Protocol;
-use astro_dnssd::DNSServiceBuilder;
-// use async_dnssd::{RegisterData, TxtRecord};
-use std::collections::HashMap;
-use std::thread::sleep;
-use std::time::Duration;
+#[cfg(target_os = "macos")]
+use async_dnssd::{RegisterData, TxtRecord};
+#[cfg(target_os = "windows")]
+use {astro_dnssd::DNSServiceBuilder, std::collections::HashMap};
 
 const SERVICE_NAME: &'static str = "_omsupply._tcp";
-// const NAME: &'static str = "omSupplyServer";
-
+#[cfg(target_os = "macos")]
+const NAME: &'static str = "omSupplyServer";
 const PROTOCOL_KEY: &'static str = "protocol";
 const CLIENT_VERSION_KEY: &'static str = "client_version";
 const HARDWARE_ID_KEY: &'static str = "hardware_id";
-
 const CLIENT_VERSION: &'static str = "unspecified";
 
 pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String) {
     tokio::task::spawn(async move {
-        // let mut txt: TxtRecord = TxtRecord::new();
-        // txt.set_value(HARDWARE_ID_KEY.as_bytes(), hardware_id.as_bytes())
-        //     .unwrap();
-        // txt.set_value(CLIENT_VERSION_KEY.as_bytes(), CLIENT_VERSION.as_bytes())
-        //     .unwrap();
-        // txt.set_value(PROTOCOL_KEY.as_bytes(), protocol.to_string().as_bytes())
-        //     .unwrap();
-
-        let mut text_record = HashMap::<String, String>::new();
-        text_record.insert(HARDWARE_ID_KEY.to_string(), hardware_id.to_string());
-        text_record.insert(CLIENT_VERSION_KEY.to_string(), CLIENT_VERSION.to_string());
-        text_record.insert(PROTOCOL_KEY.to_string(), protocol.to_string());
-
-        let service = DNSServiceBuilder::new(SERVICE_NAME, port)
-            .with_txt_record(text_record)
-            .register();
-
+        #[cfg(target_os = "macos")]
         {
-            match service {
-                Ok(_service) => {
-                    println!("Registered... waiting 20s");
-                    sleep(Duration::from_secs(20));
-                }
-                Err(e) => {
-                    println!("Error registering: {:?}", e);
+            let mut txt: TxtRecord = TxtRecord::new();
+            txt.set_value(HARDWARE_ID_KEY.as_bytes(), hardware_id.as_bytes())
+                .unwrap();
+            txt.set_value(CLIENT_VERSION_KEY.as_bytes(), CLIENT_VERSION.as_bytes())
+                .unwrap();
+            txt.set_value(PROTOCOL_KEY.as_bytes(), protocol.to_string().as_bytes())
+                .unwrap();
+            let (_registration, _) = async_dnssd::register_extended(
+                SERVICE_NAME,
+                port,
+                RegisterData {
+                    txt: txt.rdata(),
+                    name: Some(NAME),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .await
+            .unwrap();
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let mut text_record = HashMap::<String, String>::new();
+            text_record.insert(HARDWARE_ID_KEY.to_string(), hardware_id.to_string());
+            text_record.insert(CLIENT_VERSION_KEY.to_string(), CLIENT_VERSION.to_string());
+            text_record.insert(PROTOCOL_KEY.to_string(), protocol.to_string());
+            let service = DNSServiceBuilder::new(SERVICE_NAME, port)
+                .with_txt_record(text_record)
+                .register();
+            {
+                match service {
+                    Ok(_service) => {
+                        println!("Discovery registered");
+                    }
+                    Err(e) => {
+                        println!("Error registering: {:?}", e);
+                    }
                 }
             }
         }
-        //         let (_registration, _) = async_dnssd::register_extended(
-        //     SERVICE_NAME,
-        //     port,
-        //     RegisterData {
-        //         txt: txt.rdata(),
-        //         name: Some(NAME),
-        //         ..Default::default()
-        //     },
-        // )
-        // .unwrap()
-        // .await
-        // .unwrap();
-
         // Without this discovery stops (even if result of register_extended is kept and passed to caller)
         futures::future::pending::<()>().await;
-
-        println!("Discovery says bye now");
     });
 }

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -55,7 +55,7 @@ pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String
                         log::info!("Discovery registered");
                         loop {
                             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-\                        }
+                        }
                     }
                     Err(e) => {
                         log::error!("Error registering discovery: {:?}", e);

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -1,5 +1,5 @@
 use crate::certs::Protocol;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use async_dnssd::{RegisterData, TxtRecord};
 #[cfg(target_os = "windows")]
 use {astro_dnssd::DNSServiceBuilder, std::collections::HashMap};
@@ -13,7 +13,7 @@ const CLIENT_VERSION: &'static str = "unspecified";
 
 pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String) {
     tokio::task::spawn(async move {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             let mut txt: TxtRecord = TxtRecord::new();
             txt.set_value(HARDWARE_ID_KEY.as_bytes(), hardware_id.as_bytes())

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -37,7 +37,7 @@ pub mod static_files;
 pub use self::logging::*;
 
 // Only import discovery for non android features (otherwise build for android targets would fail due to local-ip-address)
-#[cfg(all(not(target_os = "android"), feature = "discovery"))]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 mod discovery;
 
 /// Starts the server
@@ -196,7 +196,7 @@ pub async fn start_server(
 
     // START DISCOVERY
     // Don't do discovery in android
-    #[cfg(all(not(target_os = "android"), feature = "discovery"))]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     {
         info!("Starting server discovery",);
         discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -37,7 +37,7 @@ pub mod static_files;
 pub use self::logging::*;
 
 // Only import discovery for non android features (otherwise build for android targets would fail due to local-ip-address)
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 mod discovery;
 
 /// Starts the server
@@ -196,7 +196,7 @@ pub async fn start_server(
 
     // START DISCOVERY
     // Don't do discovery in android
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
     {
         info!("Starting server discovery",);
         discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);


### PR DESCRIPTION
Fixes #1058 

Implemented dns-sd using astro and removed the `discovery` feature.
Astro was throwing this error at times on mac:

```
2023-02-06 18:10:41.420171 ERROR astro_dnssd::os::apple::register - Error processing: -65563, exiting thread  /Users/m2/.cargo/registry/src/github.com-1ecc6299db9ec823/astro-dnssd-0.3.2/src/os/apple/register.rs:156
2023-02-06 18:10:41.420497 ERROR server::discovery - Error registering discovery: ServiceError(-65563)  server/src/discovery.rs:32
```

I've implement `target_os` specific versions. Didn't find the cause of the above error - and though we aren't specifically using macOS servers.. might as well have it working just in case.
