### PR TITLE
#1120 If you group rows by item, the unit quantity of each batch shows the total for item rather than the batch

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -4,13 +4,11 @@ import {
   useTranslation,
   Box,
   Switch,
-  useColumns,
   MiniTable,
   useIsGrouped,
   InvoiceLineNodeType,
   useRowStyle,
   AppSxProp,
-  ArrayUtils,
   NothingHere,
   useUrlQueryParams,
 } from '@openmsupply-client/common';
@@ -18,6 +16,7 @@ import { OutboundItem } from '../../types';
 import { useOutbound } from '../api';
 import { useOutboundColumns } from './columns';
 import { OutboundLineFragment } from '../api/operations.generated';
+import { useExpansionColumns } from './OutboundLineEdit/columns';
 
 interface ContentAreaProps {
   onAddItem: () => void;
@@ -27,31 +26,10 @@ interface ContentAreaProps {
 const Expand: FC<{
   rowData: OutboundLineFragment | OutboundItem;
 }> = ({ rowData }) => {
-  const columns = useColumns([
-    'batch',
-    'expiryDate',
-    'locationName',
-    'itemUnit',
-    'numberOfPacks',
-    'packSize',
-    [
-      'unitQuantity',
-      {
-        accessor: () => {
-          if ('lines' in rowData) {
-            const { lines } = rowData;
-            return ArrayUtils.getUnitQuantity(lines);
-          } else {
-            return rowData.packSize * rowData.numberOfPacks;
-          }
-        },
-      },
-    ],
-    'sellPricePerUnit',
-  ]);
+  const expandoColumns = useExpansionColumns();
 
   if ('lines' in rowData && rowData.lines.length > 1) {
-    return <MiniTable rows={rowData.lines} columns={columns} />;
+    return <MiniTable rows={rowData.lines} columns={expandoColumns} />;
   } else {
     return null;
   }

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -104,8 +104,18 @@ export const useExpansionColumns = (): Column<OutboundLineFragment>[] =>
   useColumns([
     'batch',
     'expiryDate',
-    'locationName',
-    'itemUnit',
+    [
+      'locationName',
+      {
+        accessor: ({ rowData }) => rowData.location?.name,
+      },
+    ],
+    [
+      'itemUnit',
+      {
+        accessor: ({ rowData }) => rowData.item?.unitName,
+      },
+    ],
     'numberOfPacks',
     'packSize',
     [
@@ -114,5 +124,10 @@ export const useExpansionColumns = (): Column<OutboundLineFragment>[] =>
         accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
       },
     ],
-    'sellPricePerUnit',
+    [
+      'sellPricePerUnit',
+      {
+        accessor: ({ rowData }) => rowData.sellPricePerPack,
+      },
+    ],
   ]);

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -7,8 +7,10 @@ import {
   CheckCell,
   CurrencyCell,
   NonNegativeIntegerCell,
+  Column,
 } from '@openmsupply-client/common';
 import { DraftOutboundLine } from '../../../types';
+import { OutboundLineFragment } from '../../api';
 
 export const useOutboundLineEditColumns = ({
   onChange,
@@ -97,3 +99,20 @@ export const useOutboundLineEditColumns = ({
 
   return columns;
 };
+
+export const useExpansionColumns = (): Column<OutboundLineFragment>[] =>
+  useColumns([
+    'batch',
+    'expiryDate',
+    'locationName',
+    'itemUnit',
+    'numberOfPacks',
+    'packSize',
+    [
+      'unitQuantity',
+      {
+        accessor: ({ rowData }) => rowData.packSize * rowData.numberOfPacks,
+      },
+    ],
+    'sellPricePerUnit',
+  ]);


### PR DESCRIPTION
Closes #1120 

Outbound shipment lines return correct unit quantity now when grouped by item + show location, item unit and sell price on expansion