### PR TITLE
976 remove transaction from sync initialisation integration

### DIFF
--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -267,7 +267,7 @@ async fn main() -> anyhow::Result<()> {
                 .collect();
             buffer_repo.upsert_many(&buffer_rows)?;
 
-            integrate_and_translate_sync_buffer(&ctx.connection)?;
+            integrate_and_translate_sync_buffer(&ctx.connection, false)?;
 
             info!("Initialising users");
             for (input, user_info) in data.users {

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -174,8 +174,10 @@ impl Synchroniser {
 
         // INTEGRATE RECORDS
         logger.start_step(SyncStep::Integrate)?;
-        let (upserts, deletes) = integrate_and_translate_sync_buffer(&ctx.connection)
-            .map_err(SyncError::IntegrationError)?;
+        //
+        let (upserts, deletes) =
+            integrate_and_translate_sync_buffer(&ctx.connection, is_initialised)
+                .map_err(SyncError::IntegrationError)?;
         info!("Upsert Integration result: {:?}", upserts);
         info!("Delete Integration result: {:?}", deletes);
         logger.done_step(SyncStep::Integrate)?;
@@ -197,32 +199,48 @@ impl Synchroniser {
 /// Translation And Integration of sync buffer, pub since used in CLI
 pub fn integrate_and_translate_sync_buffer(
     connection: &StorageConnection,
+    is_initialised: bool,
 ) -> anyhow::Result<(
     TranslationAndIntegrationResults,
     TranslationAndIntegrationResults,
 )> {
     // Integration is done inside of transaction, to make sure all records are available at the same time
-    // and maintain logical data integrity
-    let result = connection
-        .transaction_sync(|connection| {
-            let sync_buffer = SyncBuffer::new(connection);
-            let translation_and_integration =
-                TranslationAndIntegration::new(connection, &sync_buffer);
-            // Translate and integrate upserts (ordered by referential database constraints)
-            let upsert_sync_buffer_records =
-                sync_buffer.get_ordered_sync_buffer_records(SyncBufferAction::Upsert)?;
-            let upsert_integration_result = translation_and_integration
-                .translate_and_integrate_sync_records(upsert_sync_buffer_records)?;
+    // and maintain logical data integrity. During initialisation nested transactions cause significant
+    // reduction in speed of this operation, since the system is not available during initialisation don't need
+    // overall transaction.
 
-            // Translate and integrate delete (ordered by referential database constraints, in reverse)
-            let delete_sync_buffer_records =
-                sync_buffer.get_ordered_sync_buffer_records(SyncBufferAction::Delete)?;
-            let delete_integration_result = translation_and_integration
-                .translate_and_integrate_sync_records(delete_sync_buffer_records)?;
+    // Closure, to be run in a transaction or without a transaction
+    let integrate_and_translate = |connection: &StorageConnection| -> Result<
+        (
+            TranslationAndIntegrationResults,
+            TranslationAndIntegrationResults,
+        ),
+        RepositoryError,
+    > {
+        let sync_buffer = SyncBuffer::new(connection);
+        let translation_and_integration = TranslationAndIntegration::new(connection, &sync_buffer);
+        // Translate and integrate upserts (ordered by referential database constraints)
+        let upsert_sync_buffer_records =
+            sync_buffer.get_ordered_sync_buffer_records(SyncBufferAction::Upsert)?;
+        let upsert_integration_result = translation_and_integration
+            .translate_and_integrate_sync_records(upsert_sync_buffer_records)?;
 
-            Ok((upsert_integration_result, delete_integration_result))
-        })
-        .map_err::<RepositoryError, _>(|e| e.to_inner_error())?;
+        // Translate and integrate delete (ordered by referential database constraints, in reverse)
+        let delete_sync_buffer_records =
+            sync_buffer.get_ordered_sync_buffer_records(SyncBufferAction::Delete)?;
+        let delete_integration_result = translation_and_integration
+            .translate_and_integrate_sync_records(delete_sync_buffer_records)?;
+
+        Ok((upsert_integration_result, delete_integration_result))
+    };
+
+    let result = if is_initialised {
+        connection
+            .transaction_sync(integrate_and_translate)
+            .map_err::<RepositoryError, _>(|e| e.to_inner_error())
+    } else {
+        integrate_and_translate(&connection)
+    }?;
 
     Ok(result)
 }

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -59,7 +59,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_records)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection).unwrap();
+    integrate_and_translate_sync_buffer(&connection, true).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 
@@ -105,7 +105,7 @@ async fn test_sync_pull_and_push() {
         .upsert_many(&sync_reords)
         .unwrap();
 
-    integrate_and_translate_sync_buffer(&connection).unwrap();
+    integrate_and_translate_sync_buffer(&connection, true).unwrap();
 
     check_test_records_against_database(&connection, test_records).await;
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -135,7 +135,7 @@ impl<'a> TranslationAndIntegration<'a> {
 
 impl IntegrationRecords {
     pub(crate) fn integrate(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
-        // Only start nested transaction is transaction is already ongoing. See integrate_and_translate_sync_buffer
+        // Only start nested transaction if transaction is already ongoing. See integrate_and_translate_sync_buffer
         let start_nested_transaction = { connection.transaction_level.get() > 0 };
 
         for upsert in self.upserts.iter() {

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -135,20 +135,31 @@ impl<'a> TranslationAndIntegration<'a> {
 
 impl IntegrationRecords {
     pub(crate) fn integrate(&self, connection: &StorageConnection) -> Result<(), RepositoryError> {
+        // Only start nested transaction is transaction is already ongoing. See integrate_and_translate_sync_buffer
+        let start_nested_transaction = { connection.transaction_level.get() > 0 };
+
         for upsert in self.upserts.iter() {
             // Integrate every record in a sub transaction. This is mainly for Postgres where the
             // whole transaction fails when there is a DB error (not a problem in sqlite).
-            connection
-                .transaction_sync_etc(|sub_tx| upsert.upsert(sub_tx), false)
-                .map_err(|e| e.to_inner_error())?;
+            if start_nested_transaction {
+                connection
+                    .transaction_sync_etc(|sub_tx| upsert.upsert(sub_tx), false)
+                    .map_err(|e| e.to_inner_error())?;
+            } else {
+                upsert.upsert(&connection)?;
+            }
         }
 
         for delete in self.deletes.iter() {
             // Integrate every record in a sub transaction. This is mainly for Postgres where the
             // whole transaction fails when there is a DB error (not a problem in sqlite).
-            connection
-                .transaction_sync_etc(|sub_tx| delete.delete(sub_tx), false)
-                .map_err(|e| e.to_inner_error())?;
+            if start_nested_transaction {
+                connection
+                    .transaction_sync_etc(|sub_tx| delete.delete(sub_tx), false)
+                    .map_err(|e| e.to_inner_error())?;
+            } else {
+                delete.delete(&connection)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
closes: #976 

Implementation as per issue description, remove transaction from initialisation integration

Easy way to test would be to run the following on your data file (will add lots of invalid records, causing inner transactions to be rolled back). Try initialisation on this branch (should take less then a minute to do `integration` step. Try initialisation on develop (it would take more then a minute, quite a lot more)

```
For (i; 1; 50000)
	$item:=ds.item.new()
	$item.ID:=UUID_generate
	$item.item_name:=UUID_generate
	$item.code:=UUID_generate
	$item.type_of:="general"
	$item.unit_ID:="invalid"
	$item.save()
End for 
```