### PR TITLE
Use same margins and gaps for JsonForms components

### DIFF
--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -4,10 +4,13 @@ import {
   Box,
   FormLabelProps,
   StandardTextFieldProps,
+  SxProps,
+  Theme,
 } from '@mui/material';
 import { BasicTextInput } from '@common/components';
 
 interface InputWithLabelRowProps {
+  sx?: SxProps<Theme>;
   Input?: ReactNode;
   DisabledInput?: ReactNode;
   label: string;
@@ -19,6 +22,7 @@ interface InputWithLabelRowProps {
 }
 
 export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
+  sx,
   label,
   labelWidthPercentage = 40,
   inputAlignment,
@@ -27,15 +31,15 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
   DisabledInput = <BasicTextInput {...inputProps} />,
   labelProps,
 }) => {
-  const { sx, ...labelPropsRest } = labelProps || {};
+  const { sx: labelSx, ...labelPropsRest } = labelProps || {};
   const isDisabled = inputProps?.disabled;
   const labelFlexBasis = `${labelWidthPercentage}%`;
   const inputFlexBasis = `${100 - labelWidthPercentage}%`;
 
   return (
-    <Box display="flex" alignItems="center" gap={1}>
+    <Box display="flex" alignItems="center" gap={1} sx={{ ...sx }}>
       <Box style={{ textAlign: 'end' }} flexBasis={labelFlexBasis}>
-        <FormLabel sx={{ fontWeight: 'bold', ...sx }} {...labelPropsRest}>
+        <FormLabel sx={{ fontWeight: 'bold', ...labelSx }} {...labelPropsRest}>
           {label}:
         </FormLabel>
       </Box>

--- a/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
@@ -20,10 +20,9 @@ const UIComponent = (props: ControlProps) => {
     <Box
       display="flex"
       alignItems="center"
-      gap={2}
       justifyContent="space-around"
       style={{ minWidth: 300 }}
-      marginTop={1}
+      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>

--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -48,10 +48,9 @@ const UIComponent = (props: ControlProps) => {
     <Box
       display="flex"
       alignItems="center"
-      gap={2}
       justifyContent="space-around"
       style={{ minWidth: 300 }}
-      marginTop={1}
+      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -123,10 +123,11 @@ const UIComponent = (props: ControlProps) => {
 
   return (
     <DetailInputWithLabelRow
+      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
       label={label}
       inputProps={{
         value: text ?? '',
-        sx: { margin: 0.5, width },
+        sx: { width },
         onChange: e => onChange(e.target.value || ''),
         disabled: !props.enabled,
         error,

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -68,10 +68,9 @@ const UIComponent = (props: ControlProps) => {
     <Box
       display="flex"
       alignItems="center"
-      gap={2}
       justifyContent="space-around"
       style={{ minWidth: 300 }}
-      marginTop={1}
+      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
@@ -80,7 +79,6 @@ const UIComponent = (props: ControlProps) => {
         flexBasis={FORM_INPUT_COLUMN_WIDTH}
         display="flex"
         alignItems="center"
-        gap={2}
       >
         <BaseDatePickerInput
           // undefined is displayed as "now" and null as unset

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -371,10 +371,9 @@ const UIComponent = (props: ControlProps) => {
     <Box
       display="flex"
       alignItems="center"
-      gap={2}
       justifyContent="space-around"
       style={{ minWidth: 300 }}
-      marginTop={1}
+      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
@@ -383,7 +382,6 @@ const UIComponent = (props: ControlProps) => {
         flexBasis={FORM_INPUT_COLUMN_WIDTH}
         display="flex"
         alignItems="center"
-        gap={2}
       >
         <BasicTextInput
           disabled={!props.enabled || !options?.allowManualEntry}


### PR DESCRIPTION
Couldn't stand the misalignment anymore so at least fixed some issues...

@mark-prins could you please check my change to the common InputWithLabelRow?