### PR TITLE
976 2 integration tests

### DIFF
--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -208,7 +208,6 @@ impl ShipmentTransferTester {
             r.pack_size = 10;
             r.total_number_of_packs = 200.0;
             r.available_number_of_packs = 200.0;
-            r.supplier_id = Some(String::from("name_store_b"));
         });
 
         let outbound_shipment_line1 = inline_init(|r: &mut InvoiceLineRow| {
@@ -238,7 +237,6 @@ impl ShipmentTransferTester {
             r.total_number_of_packs = 200.0;
             r.available_number_of_packs = 200.0;
             r.expiry_date = Some(NaiveDate::from_ymd(2023, 1, 5));
-            r.supplier_id = Some(String::from("name_store_b"));
         });
 
         let outbound_shipment_line2 = inline_init(|r: &mut InvoiceLineRow| {

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -8,6 +8,7 @@ use util::inline_edit;
 
 // Ordered by referencial constraints
 const TRANSLATION_AND_INTEGRATION_ORDER: &[&str] = &[
+    LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
     LegacyTableName::NAME,
     LegacyTableName::UNIT,
     LegacyTableName::ITEM,
@@ -26,7 +27,6 @@ const TRANSLATION_AND_INTEGRATION_ORDER: &[&str] = &[
     LegacyTableName::REQUISITION_LINE,
     LegacyTableName::NAME_STORE_JOIN,
     LegacyTableName::OM_ACTIVITY_LOG,
-    LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
 ];
 
 pub(crate) struct SyncBuffer<'a> {

--- a/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/test/integration/central/inventory_adjustment_reason.rs
@@ -1,0 +1,82 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::{IntegrationRecords, PullUpsertRecord},
+};
+use repository::{InventoryAdjustmentReasonRow, InventoryAdjustmentReasonType};
+
+use serde_json::json;
+use util::uuid::uuid;
+
+pub(crate) struct InventoryAdjustmentReasonTester;
+
+impl SyncRecordTester for InventoryAdjustmentReasonTester {
+    fn test_step_data(&self, _: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let pos_1 = InventoryAdjustmentReasonRow {
+            id: uuid(),
+            r#type: InventoryAdjustmentReasonType::Positive,
+            is_active: true,
+            reason: "POS 1".to_string(),
+        };
+
+        let pos_2 = InventoryAdjustmentReasonRow {
+            id: uuid(),
+            r#type: InventoryAdjustmentReasonType::Positive,
+            is_active: false,
+            reason: "POS 2".to_string(),
+        };
+
+        let neg_1 = InventoryAdjustmentReasonRow {
+            id: uuid(),
+            r#type: InventoryAdjustmentReasonType::Negative,
+            is_active: false,
+            reason: "NEG 1".to_string(),
+        };
+
+        let neg_2 = InventoryAdjustmentReasonRow {
+            id: uuid(),
+            r#type: InventoryAdjustmentReasonType::Negative,
+            is_active: true,
+            reason: "NEG 2".to_string(),
+        };
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "options": [{
+                    "ID": pos_1.id,
+                    "isActive": true,
+                    "title": "POS 1",
+                    "type": "positiveInventoryAdjustment"
+                  }, {
+                    "ID": pos_2.id,
+                    "isActive": false,
+                    "title": "POS 2",
+                    "type": "positiveInventoryAdjustment"
+                  }, {
+                    "ID": neg_1.id,
+                    "isActive": false,
+                    "title": "NEG 1",
+                    "type": "negativeInventoryAdjustment"
+                  }, {
+                    "ID": neg_2.id,
+                    "isActive": true,
+                    "title": "NEG 2",
+                    "type": "negativeInventoryAdjustment"
+                  }],
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::InventoryAdjustmentReason(pos_1),
+                PullUpsertRecord::InventoryAdjustmentReason(pos_2),
+                PullUpsertRecord::InventoryAdjustmentReason(neg_1),
+                PullUpsertRecord::InventoryAdjustmentReason(neg_2),
+            ]),
+        });
+        // STEP 2 - deletes
+        // TODO should be soft deleted
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/central/mod.rs
+++ b/server/service/src/sync/test/integration/central/mod.rs
@@ -1,3 +1,4 @@
+mod inventory_adjustment_reason;
 mod master_list;
 mod name_and_store_and_name_store_join;
 mod report;

--- a/server/service/src/sync/test/integration/central/test.rs
+++ b/server/service/src/sync/test/integration/central/test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::sync::test::integration::central::{
+        inventory_adjustment_reason::InventoryAdjustmentReasonTester,
         master_list::MasterListTester,
         name_and_store_and_name_store_join::NameAndStoreAndNameStoreJoinTester,
         report::ReportTester, test_central_sync_record, unit_and_item::UnitAndItemTester,
@@ -24,5 +25,14 @@ mod tests {
     #[actix_rt::test]
     async fn integration_sync_central_report() {
         test_central_sync_record("report", &ReportTester).await;
+    }
+
+    #[actix_rt::test]
+    async fn integration_sync_central_inventory_adjustment_reason() {
+        test_central_sync_record(
+            "inventory_adjustment_reason",
+            &InventoryAdjustmentReasonTester,
+        )
+        .await;
     }
 }

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -1,8 +1,13 @@
-use crate::sync::{
-    test::integration::{
-        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+use crate::{
+    inventory_adjustment_reason,
+    sync::{
+        test::integration::{
+            central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+        },
+        translations::{
+            IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord,
+        },
     },
-    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
 };
 use chrono::NaiveDate;
 use repository::mock::mock_request_draft_requisition;
@@ -24,6 +29,8 @@ impl SyncRecordTester for InvoiceRecordTester {
             on_hold: false,
             store_id: store_id.to_string(),
         };
+        // test option (inventory adjustment reason)
+        let inventory_adjustment_reason_id = uuid();
         let base_invoice_row = InvoiceRow {
             id: uuid(),
             name_id: uuid(),
@@ -68,6 +75,7 @@ impl SyncRecordTester for InvoiceRecordTester {
             tax: Some(10.0),
             number_of_packs: 10.129,
             note: None,
+            inventory_adjustment_reason_id: Some(inventory_adjustment_reason_id.clone()),
         };
         let invoice_row_1 = base_invoice_row.clone();
         let invoice_line_row_1 = base_invoice_line_row.clone();
@@ -100,6 +108,7 @@ impl SyncRecordTester for InvoiceRecordTester {
             d.id = uuid();
             d.invoice_id = invoice_row_2.id.clone();
             d.r#type = InvoiceLineRowType::StockOut;
+            d.inventory_adjustment_reason_id = None;
             d
         });
         let invoice_row_3 = inline_edit(&base_invoice_row, |mut d| {
@@ -145,6 +154,12 @@ impl SyncRecordTester for InvoiceRecordTester {
                     "ID": base_invoice_row.name_store_id.as_ref().unwrap(),
                     "name_ID": base_invoice_row.name_id,
                     "store_mode": "store"
+                }],
+                "options": [{
+                    "ID": inventory_adjustment_reason_id,
+                    "isActive": true,
+                    "title": "POS 1",
+                    "type": "positiveInventoryAdjustment"
                 }]
             }),
             central_delete: json!({}),
@@ -172,7 +187,6 @@ impl SyncRecordTester for InvoiceRecordTester {
             r.pack_size = 20;
             r.cost_price_per_pack = 0.5;
             r.sell_price_per_pack = 0.2;
-            r.name_id = String::from("name_store_b");
         });
         // create requisition and linked invoice
         let requisition_row = inline_edit(&mock_request_draft_requisition(), |mut r| {
@@ -219,6 +233,7 @@ impl SyncRecordTester for InvoiceRecordTester {
             d.tax = Some(0.0);
             d.number_of_packs = 15.120;
             d.note = Some("invoice line note".to_string());
+            d.inventory_adjustment_reason_id = None;
             d
         });
 

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -1,13 +1,8 @@
-use crate::{
-    inventory_adjustment_reason,
-    sync::{
-        test::integration::{
-            central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
-        },
-        translations::{
-            IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord,
-        },
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
     },
+    translations::{IntegrationRecords, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord},
 };
 use chrono::NaiveDate;
 use repository::mock::mock_request_draft_requisition;

--- a/server/service/src/sync/test/integration/remote/stock_line.rs
+++ b/server/service/src/sync/test/integration/remote/stock_line.rs
@@ -37,7 +37,7 @@ impl SyncRecordTester for StockLineRecordTester {
             expiry_date: Some(NaiveDate::from_ymd(2021, 03, 21)),
             on_hold: true,
             note: Some("some remote sync test note".to_string()),
-            name_id: String::from("name_store_b"),
+            supplier_id: Some(new_site_properties.name_id.clone()),
         };
 
         result.push(TestStepData {
@@ -64,6 +64,7 @@ impl SyncRecordTester for StockLineRecordTester {
             d.expiry_date = Some(NaiveDate::from_ymd(2021, 03, 22));
             d.on_hold = false;
             d.note = Some("some remote sync test note 2".to_string());
+            d.supplier_id = None;
             d
         });
         result.push(TestStepData {

--- a/server/service/src/sync/test/integration/remote/stocktake.rs
+++ b/server/service/src/sync/test/integration/remote/stocktake.rs
@@ -57,6 +57,7 @@ impl SyncRecordTester for StocktakeRecordTester {
             cost_price_per_pack: Some(0.0),
             sell_price_per_pack: Some(0.0),
             note: None,
+            inventory_adjustment_reason_id: None,
         };
         result.push(TestStepData {
             central_upsert: json!({"item": [{
@@ -76,13 +77,13 @@ impl SyncRecordTester for StocktakeRecordTester {
             r.name_id = new_site_properties.name_id.clone();
             r.store_id = store_id.clone();
             r.name_store_id = Some(store_id.clone());
+            r.tax = Some(0.0);
         });
 
         let stock_line_row = inline_init(|r: &mut StockLineRow| {
             r.id = uuid();
             r.item_id = uuid();
             r.store_id = store_id.clone();
-            r.name_id = String::from("name_store_b");
         });
 
         let stocktake_row = inline_edit(&stocktake_row, |mut d| {

--- a/server/service/src/sync/test/integration/remote/test.rs
+++ b/server/service/src/sync/test/integration/remote/test.rs
@@ -2,8 +2,8 @@
 mod tests {
     use crate::sync::test::integration::remote::{
         activity_log::ActivityLogRecordTester, invoice::InvoiceRecordTester,
-        location::LocationRecordTester,
-        requisition::RequisitionRecordTester, stock_line::StockLineRecordTester,
+        location::LocationRecordTester, requisition::RequisitionRecordTester,
+        stock_line::StockLineRecordTester, stocktake::StocktakeRecordTester,
         test_remote_sync_record,
     };
 
@@ -19,7 +19,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn integration_sync_remote_stocktake() {
-        test_remote_sync_record("stocktake", &StockLineRecordTester).await;
+        test_remote_sync_record("stocktake", &StocktakeRecordTester).await;
     }
 
     #[actix_rt::test]

--- a/server/service/src/sync/test/test_data/stock_line.rs
+++ b/server/service/src/sync/test/test_data/stock_line.rs
@@ -114,7 +114,7 @@ const ITEM_LINE_2: (&'static str, &'static str) = (
       "kit_data": null,
       "location_ID": "",
       "manufacturer_ID": "",
-      "name_ID": "name_store_b",
+      "name_ID": "",
       "note": "",
       "pack_inners_per_outer": 0,
       "pack_quan_per_inner": 0,
@@ -158,7 +158,7 @@ fn item_line_2_pull_record() -> TestSyncPullRecord {
             expiry_date: None,
             on_hold: false,
             note: None,
-            supplier_id: Some("name_store_b".to_string()),
+            supplier_id: None,
         }),
     )
 }
@@ -180,7 +180,7 @@ fn item_line_2_push_record() -> TestSyncPushRecord {
             cost_price: 0.0,
             sell_price: 0.0,
             note: None,
-            supplier_id: Some("name_store_b".to_string()),
+            supplier_id: None,
         }),
     }
 }

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -42,6 +42,7 @@ pub struct LegacyStockLineRow {
     #[serde(deserialize_with = "empty_str_as_option_string")]
     pub note: Option<String>,
     #[serde(rename = "name_ID")]
+    #[serde(deserialize_with = "empty_str_as_option_string")]
     pub supplier_id: Option<String>,
 }
 


### PR DESCRIPTION
closes: #976 

Further work to fix integration tests, was just going to fix compilation errors, but saw quite a few places where sync could break:

* If stockline name_id is empty 
* Any invoice lines with optionID (since we were integration inventory adjustment reason after invoice line

Also found that stocktake tests were not being run and found.

Added database name to console log, needed this to connect to correct test database (to debug test failure issue)