### PR TITLE
973 pack to one preference

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -137,7 +137,7 @@ export const PricingTableComponent: FC<TableProps> = ({
         'lineTotal',
         {
           accessor: ({ rowData }) =>
-            rowData.numberOfPacks * rowData.packSize * rowData.costPricePerPack,
+            rowData.numberOfPacks * rowData.costPricePerPack,
         },
       ],
     ],

--- a/server/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -13,6 +13,16 @@ pub fn convert_stock_line_to_single_pack(stock_line: StockLineRow) -> StockLineR
     }
 }
 
+pub fn convert_invoice_line_to_single_pack(invoice_line: InvoiceLineRow) -> InvoiceLineRow {
+    InvoiceLineRow {
+        number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
+        sell_price_per_pack: invoice_line.sell_price_per_pack / invoice_line.pack_size as f64,
+        cost_price_per_pack: invoice_line.cost_price_per_pack / invoice_line.pack_size as f64,
+        pack_size: 1,
+        ..invoice_line
+    }
+}
+
 pub fn generate_batch(
     store_id: &str,
     InvoiceLineRow {

--- a/server/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -1,17 +1,18 @@
-use repository::{InvoiceLineRow, StockLineRow};
+use repository::{InvoiceLineRow, StockLineRow, StorePreferenceRow};
 use util::uuid::uuid;
 
 pub fn generate_batch(
+    store_preferences: Option<StorePreferenceRow>,
     store_id: &str,
     InvoiceLineRow {
         stock_line_id,
         item_id,
-        pack_size,
+        mut pack_size,
         batch,
         expiry_date,
-        sell_price_per_pack,
-        cost_price_per_pack,
-        number_of_packs,
+        mut sell_price_per_pack,
+        mut cost_price_per_pack,
+        mut number_of_packs,
         location_id,
         note,
         ..
@@ -24,6 +25,13 @@ pub fn generate_batch(
         (Some(stock_line_id), true) => stock_line_id,
         _ => uuid(),
     };
+
+    if store_preferences.unwrap_or_default().pack_to_one {
+        number_of_packs = number_of_packs * pack_size as f64;
+        sell_price_per_pack = sell_price_per_pack / pack_size as f64;
+        cost_price_per_pack = cost_price_per_pack / pack_size as f64;
+        pack_size = 1;
+    }
 
     StockLineRow {
         id: stock_line_id,

--- a/server/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -1,15 +1,13 @@
 use repository::{InvoiceLineRow, StockLineRow};
 use util::uuid::uuid;
 
-pub fn convert_stock_line_to_single_pack(
-    stock_line: StockLineRow,
-    invoice_line: &InvoiceLineRow,
-) -> StockLineRow {
+pub fn convert_stock_line_to_single_pack(stock_line: StockLineRow) -> StockLineRow {
     StockLineRow {
-        total_number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
-        available_number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
-        cost_price_per_pack: invoice_line.cost_price_per_pack / invoice_line.pack_size as f64,
-        sell_price_per_pack: invoice_line.sell_price_per_pack / invoice_line.pack_size as f64,
+        total_number_of_packs: stock_line.total_number_of_packs * stock_line.pack_size as f64,
+        available_number_of_packs: stock_line.available_number_of_packs
+            * stock_line.pack_size as f64,
+        cost_price_per_pack: stock_line.cost_price_per_pack / stock_line.pack_size as f64,
+        sell_price_per_pack: stock_line.sell_price_per_pack / stock_line.pack_size as f64,
         pack_size: 1,
         ..stock_line
     }

--- a/server/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -1,18 +1,31 @@
-use repository::{InvoiceLineRow, StockLineRow, StorePreferenceRow};
+use repository::{InvoiceLineRow, StockLineRow};
 use util::uuid::uuid;
 
+pub fn convert_stock_line_to_single_pack(
+    stock_line: StockLineRow,
+    invoice_line: &InvoiceLineRow,
+) -> StockLineRow {
+    StockLineRow {
+        total_number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
+        available_number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
+        cost_price_per_pack: invoice_line.cost_price_per_pack / invoice_line.pack_size as f64,
+        sell_price_per_pack: invoice_line.sell_price_per_pack / invoice_line.pack_size as f64,
+        pack_size: 1,
+        ..stock_line
+    }
+}
+
 pub fn generate_batch(
-    store_preferences: Option<StorePreferenceRow>,
     store_id: &str,
     InvoiceLineRow {
         stock_line_id,
         item_id,
-        mut pack_size,
+        pack_size,
         batch,
         expiry_date,
-        mut sell_price_per_pack,
-        mut cost_price_per_pack,
-        mut number_of_packs,
+        sell_price_per_pack,
+        cost_price_per_pack,
+        number_of_packs,
         location_id,
         note,
         ..
@@ -25,13 +38,6 @@ pub fn generate_batch(
         (Some(stock_line_id), true) => stock_line_id,
         _ => uuid(),
     };
-
-    if store_preferences.unwrap_or_default().pack_to_one {
-        number_of_packs = number_of_packs * pack_size as f64;
-        sell_price_per_pack = sell_price_per_pack / pack_size as f64;
-        cost_price_per_pack = cost_price_per_pack / pack_size as f64;
-        pack_size = 1;
-    }
 
     StockLineRow {
         id: stock_line_id,

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
@@ -39,7 +39,7 @@ pub fn generate(
         new_line.stock_line_id = Some(new_batch.id.clone());
 
         let new_batch = match store_preferences.pack_to_one {
-            true => convert_stock_line_to_single_pack(new_batch, &new_line),
+            true => convert_stock_line_to_single_pack(new_batch),
             false => new_batch,
         };
 

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
@@ -1,7 +1,10 @@
 use crate::{
     invoice::common::{calculate_total_after_tax, generate_invoice_user_id_update},
     invoice_line::{
-        generate_batch, inbound_shipment_line::generate::convert_stock_line_to_single_pack,
+        generate_batch,
+        inbound_shipment_line::generate::{
+            convert_invoice_line_to_single_pack, convert_stock_line_to_single_pack,
+        },
     },
     store_preference::get_store_preferences,
     u32_to_i32,
@@ -100,15 +103,5 @@ fn generate_line(
         tax,
         note: None,
         inventory_adjustment_reason_id: None,
-    }
-}
-
-fn convert_invoice_line_to_single_pack(invoice_line: InvoiceLineRow) -> InvoiceLineRow {
-    InvoiceLineRow {
-        number_of_packs: invoice_line.number_of_packs * invoice_line.pack_size as f64,
-        sell_price_per_pack: invoice_line.sell_price_per_pack / invoice_line.pack_size as f64,
-        cost_price_per_pack: invoice_line.cost_price_per_pack / invoice_line.pack_size as f64,
-        pack_size: 1,
-        ..invoice_line
     }
 }

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
@@ -38,7 +38,7 @@ pub fn insert_inbound_shipment_line(
         .transaction_sync(|connection| {
             let (item, invoice) = validate(&input, &ctx.store_id, &connection)?;
             let (invoice_row_option, new_line, new_batch_option) =
-                generate(&ctx.user_id, input, item, invoice);
+                generate(&connection, &ctx.user_id, input, item, invoice)?;
 
             if let Some(new_batch) = new_batch_option {
                 StockLineRowRepository::new(&connection).upsert_one(&new_batch)?;

--- a/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
@@ -99,7 +99,8 @@ mod test {
             mock_store_a, mock_store_b, mock_user_account_a, MockDataInserts,
         },
         test_db::setup_all,
-        InvoiceLineRowRepository,
+        InvoiceLineRowRepository, StorePreferenceRow, StorePreferenceRowRepository,
+        StorePreferenceType,
     };
     use util::{inline_edit, inline_init};
 
@@ -296,6 +297,48 @@ mod test {
                 u.item_id = mock_item_a().id.clone();
                 u.pack_size = 1;
                 u.number_of_packs = 1.0;
+                u
+            })
+        );
+
+        // pack to one preference is set
+        let pack_to_one = StorePreferenceRow {
+            id: mock_store_a().id.clone(),
+            r#type: StorePreferenceType::StorePreferences,
+            pack_to_one: true,
+        };
+        StorePreferenceRowRepository::new(&connection)
+            .upsert_one(&pack_to_one)
+            .unwrap();
+
+        service
+            .insert_inbound_shipment_line(
+                &context,
+                inline_init(|r: &mut InsertInboundShipmentLine| {
+                    r.id = "new invoice line pack to one".to_string();
+                    r.invoice_id = mock_inbound_shipment_c_invoice_lines()[0]
+                        .invoice_id
+                        .clone();
+                    r.item_id = mock_item_a().id.clone();
+                    r.pack_size = 10;
+                    r.number_of_packs = 20.0;
+                    r.sell_price_per_pack = 100.0;
+                }),
+            )
+            .unwrap();
+
+        let inbound_line = InvoiceLineRowRepository::new(&connection)
+            .find_one_by_id("new invoice line pack to one")
+            .unwrap();
+
+        assert_eq!(
+            inbound_line,
+            inline_edit(&inbound_line, |mut u| {
+                u.id = "new invoice line pack to one".to_string();
+                u.item_id = mock_item_a().id.clone();
+                u.pack_size = 1;
+                u.number_of_packs = 200.0;
+                u.sell_price_per_pack = 10.0;
                 u
             })
         );

--- a/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
@@ -25,6 +25,7 @@ pub fn generate(
 
     let upsert_batch_option = if existing_invoice_row.status != InvoiceRowStatus::New {
         let new_batch = generate_batch(
+            None,
             &existing_invoice_row.store_id,
             update_line.clone(),
             batch_to_delete_id.is_none(),

--- a/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_line/update/generate.rs
@@ -25,7 +25,6 @@ pub fn generate(
 
     let upsert_batch_option = if existing_invoice_row.status != InvoiceRowStatus::New {
         let new_batch = generate_batch(
-            None,
             &existing_invoice_row.store_id,
             update_line.clone(),
             batch_to_delete_id.is_none(),

--- a/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
@@ -6,11 +6,14 @@ use repository::{
 };
 use util::uuid::uuid;
 
-use crate::{activity_log::system_activity_log_entry, number::next_number};
+use crate::{
+    activity_log::system_activity_log_entry, number::next_number,
+    store_preference::get_store_preferences,
+};
 
 use super::{
-    common::generate_inbound_shipment_lines, Operation, ShipmentTransferProcessor,
-    ShipmentTransferProcessorRecord,
+    common::{convert_invoice_line_to_single_pack, generate_inbound_shipment_lines},
+    Operation, ShipmentTransferProcessor, ShipmentTransferProcessorRecord,
 };
 
 const DESCRIPTION: &'static str = "Create inbound shipment from outbound shipment";
@@ -74,9 +77,14 @@ impl ShipmentTransferProcessor for CreateInboundShipmentProcessor {
         let new_inbound_lines = generate_inbound_shipment_lines(
             connection,
             &new_inbound_shipment.id,
-            &new_inbound_shipment.store_id,
             &outbound_shipment,
         )?;
+        let store_preferences = get_store_preferences(connection, &new_inbound_shipment.store_id)?;
+
+        let new_inbound_lines = match store_preferences.pack_to_one {
+            true => convert_invoice_line_to_single_pack(new_inbound_lines),
+            false => new_inbound_lines,
+        };
 
         InvoiceRowRepository::new(connection).upsert_one(&new_inbound_shipment)?;
 

--- a/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/create_inbound_shipment.rs
@@ -74,6 +74,7 @@ impl ShipmentTransferProcessor for CreateInboundShipmentProcessor {
         let new_inbound_lines = generate_inbound_shipment_lines(
             connection,
             &new_inbound_shipment.id,
+            &new_inbound_shipment.store_id,
             &outbound_shipment,
         )?;
 

--- a/server/service/src/processors/transfer/shipment/update_inbound_shipment.rs
+++ b/server/service/src/processors/transfer/shipment/update_inbound_shipment.rs
@@ -69,6 +69,7 @@ impl ShipmentTransferProcessor for UpdateInboundShipmentProcessor {
         let new_inbound_lines = generate_inbound_shipment_lines(
             connection,
             &inbound_shipment.invoice_row.id,
+            &inbound_shipment.invoice_row.store_id,
             &outbound_shipment,
         )?;
 


### PR DESCRIPTION
Closes #973

- Inbound shipment lines will recalculate relevant fields to be in packs of one 
- Relevant fields will also be recalculated when an outbound shipment is sent to a store with pack to one preference turned on.

### Inbound shipment manual testing
- [ ] Turn on pack to one preference on central server for store
- [ ] Go to store with pack to one preference and create an inbound shipment
- [ ] Add line with pack size > 1 
- [ ] Click OK - see changes in line

### Outbound shipment manual testing
- [ ] Follow steps 1-3 above
- [ ] Change status to picked or shipped
- [ ] Go to destination store 
- [ ] See recalculated invoice