### PR TITLE
Delete inactive name store joins

### DIFF
--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -43,6 +43,18 @@ const NAME_STORE_JOIN_2: (&'static str, &'static str) = (
       "store_ID": "store_b"
   }"#,
 );
+const NAME_STORE_JOIN_INACTIVE_2: (&'static str, &'static str) = (
+    "BE65A4A05E4D47E88303D6105A7872CC",
+    r#"{
+      "ID": "BE65A4A05E4D47E88303D6105A7872CC",
+      "inactive": true,
+      "name_ID": "name_store_a",
+      "spare_Category_ID": 0,
+      "spare_Category_optional2_id": 0,
+      "spare_Category_optional_id": 0,
+      "store_ID": "store_b"
+  }"#,
+);
 fn name_store_join_2_pull_record() -> TestSyncPullRecord {
     TestSyncPullRecord::new_pull_upsert(
         LegacyTableName::NAME_STORE_JOIN,
@@ -55,6 +67,19 @@ fn name_store_join_2_pull_record() -> TestSyncPullRecord {
             name_is_supplier: true,
         }),
     )
+}
+fn name_store_join_2_delete_record() -> TestSyncPullRecord {
+    TestSyncPullRecord::new_pull_delete(
+        LegacyTableName::NAME_STORE_JOIN,
+        NAME_STORE_JOIN_2.0,
+        PullDeleteRecordTable::NameStoreJoin,
+    )
+}
+
+fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
+    let mut record = name_store_join_2_delete_record();
+    record.sync_buffer_row.data = NAME_STORE_JOIN_INACTIVE_2.1.to_string();
+    record
 }
 
 // same as NAME_STORE_JOIN_2 but with new om fields
@@ -96,9 +121,9 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
 }
 
 pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::NAME_STORE_JOIN,
-        NAME_STORE_JOIN_2.0,
-        PullDeleteRecordTable::NameStoreJoin,
-    )]
+    vec![name_store_join_2_delete_record()]
+}
+
+pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestSyncPullRecord> {
+    vec![name_store_join_2_inactive_pull_record()]
 }

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -14,6 +14,7 @@ pub struct LegacyNameStoreJoinRow {
     pub ID: String,
     pub store_ID: String,
     pub name_ID: String,
+    pub inactive: Option<bool>,
     #[serde(rename = "om_name_is_customer")]
     pub name_is_customer: Option<bool>,
     #[serde(rename = "om_name_is_supplier")]
@@ -34,6 +35,14 @@ impl SyncTranslation for NameStoreJoinTranslation {
             return Ok(None);
         }
         let data = serde_json::from_str::<LegacyNameStoreJoinRow>(&sync_record.data)?;
+
+        // in mSupply the inactive flag is used for soft-deletes.
+        // given that we don't handle soft deletes, translate to a hard-delete
+        if let Some(inactive) = data.inactive {
+            if inactive {
+                return self.try_translate_pull_delete(connection, sync_record);
+            }
+        }
 
         let name = match NameRowRepository::new(connection).find_one_by_id(&data.name_ID)? {
             Some(name) => name,
@@ -80,7 +89,8 @@ impl SyncTranslation for NameStoreJoinTranslation {
         _: &StorageConnection,
         sync_record: &SyncBufferRow,
     ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        // TODO is it possible for name store join to be set inactive ? Rather then being deleted ?
+        // it is possible for name store join to be set inactive
+        // this is handled in the upsert translation
         let result = match_pull_table(sync_record).then(|| {
             IntegrationRecords::from_delete(
                 &sync_record.record_id,
@@ -109,6 +119,14 @@ mod tests {
         .await;
 
         for record in test_data::test_pull_upsert_records() {
+            let translation_result = translator
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_upsert_inactive_records() {
             let translation_result = translator
                 .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
                 .unwrap();


### PR DESCRIPTION
Fixes #1085 

Pretty much does what it says on the tin.

## Tests
### Setup
- [ ] Create a supplier in mSupply and make it visible in the store that you are using in omSupply

### Tests
- [ ] Observe that the supplier shows in omSupply ( supplier list, when creating an inbound shipment )
- [ ] Uncheck the 'visible in store' option in the 'Store visibility' tab of the name in mSupply. Sync omSupply. Observe that the supplier is no longer visible