### PR TITLE
Add GitHub pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report for a bug or to help us improve
 title: A brief clear title explaining the bug
-labels: 'bug'
+labels: 'bug, needs triage'
 assignees: ''
 
 ---
@@ -25,6 +25,5 @@ Steps to reproduce the behaviour:
 
 ## Your environment 🌱
  - Version [e.g. 22]
- - Application Type [e.g. tablet, browser, single user]
- - Browser [e.g. chrome, safari]
+ - Platform [e.g. tablet, browser, single user]
  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 ## What went wrong? 😲
-
 <!-- Provide a clear and concise description of what the bug is. Screenshots are helpful! --> 
 
 ## Expected behaviour 🤔
@@ -24,6 +23,6 @@ Steps to reproduce the behaviour:
 4. See error
 
 ## Your environment 🌱
- - Version [e.g. 22]
- - Platform [e.g. tablet, browser, single user]
+ - Version [e.g. 1.2.3]
+ - Platform [e.g. tablet, browser, windows desktop, macOS desktop, server]
  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report for a bug or to help us improve
+title: A brief clear title explaining the bug
+labels: 'bug'
+assignees: ''
+
+---
+
+## What went wrong? 😲
+
+<!-- Provide a clear and concise description of what the bug is. Screenshots are helpful! --> 
+
+## Expected behaviour 🤔
+
+
+## How to Reproduce 🔨
+
+Steps to reproduce the behaviour:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Your environment 🌱
+ - Version [e.g. 22]
+ - Application Type [e.g. tablet, browser, single user]
+ - Browser [e.g. chrome, safari]
+ 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement, needs triage'
+assignees: ''
+
+---
+
+<!-- NOTE: before adding something to your issue name or description, check that there does not already exist a label for it! -->
+
+## Is your feature request related to a problem? Please describe 👀
+
+<!-- Provide a clear and concise description of the problem or desired functionality. E.g. "omSupply does not do X", "It's frustrating when omSupply does Y". -->
+
+## Describe the solution you'd like 🎁
+
+
+### Describe alternatives you've considered 💭
+
+
+### Additional context 💌
+
+<!-- Add any other context or screenshots about the feature request here. -->
+
+### Moneyworks Jobcode 🧰
+
+<!-- Add the moneyworks jobcode for this change if you know what it is. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- IMPORTANT!
+  - Every PR must reference an issue.
+  - PR titles should begin with "#issueNumber".
+  - PRs should be concise. Do not add information not contained in the issue, update the issue instead.
+ -->
+
+Fixes #X. 
+
+# 👩🏻‍💻 What does this PR do? 
+ <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
+
+# 🧪 How has this change been tested? 
+
+<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
+
+## 👀 Related areas to think about 
+<!-- If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here --> 
+
+# 💌 Any notes for the reviewer?
+<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,26 @@
 <!-- IMPORTANT!
-  - Every PR must reference an issue.
-  - PR titles should begin with "#issueNumber".
+  - Every PR must reference an issue; this helps to explain the intent of the PR
  -->
 
-Fixes #X. 
+Fixes #
 
 # 👩🏻‍💻 What does this PR do? 
  <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
 
 # 🧪 How has this change been tested? 
-
 <!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
 
 ## 👀 Related areas to think about 
 <!-- If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here --> 
 
-# 💌 Any notes for the reviewer?
+## 💌 Any notes for the reviewer?
 <!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? -->
+
+## 📃 Documentation
+<!-- Note down any areas which require documentation updates -->
+_No user facing changes_
+
+or
+
+- [ ] Functional change 1
+- [ ] Functional change 2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!-- IMPORTANT!
   - Every PR must reference an issue.
   - PR titles should begin with "#issueNumber".
-  - PRs should be concise. Do not add information not contained in the issue, update the issue instead.
  -->
 
 Fixes #X. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,14 +7,11 @@ Fixes #
 # 👩🏻‍💻 What does this PR do? 
  <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
 
-# 🧪 How has this change been tested? 
+# 🧪 How has/should this change been tested? 
 <!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
 
-## 👀 Related areas to think about 
-<!-- If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here --> 
-
 ## 💌 Any notes for the reviewer?
-<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? -->
+<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
 
 ## 📃 Documentation
 <!-- Note down any areas which require documentation updates -->


### PR DESCRIPTION
### Why add templates?

- To speed up dev processes:  
       - The person making the PR is the expert on their own code. They know a lot more about it than the person reviewing, and transferring that knowledge helps speed up the review process. 
       - Having a template means you don't have to think about what details you need to add - it's there for you to check. 
       - We're open source - having a template for outside contributors will help get the details we need without multiple back and forths. 

References: https://www.awesomecodereviews.com/pull-request-template/


### What was added?
* A PR template
* A new feature issue template 
* A bug issue template
