### PR TITLE
1147 negative available number of packs 

### DIFF
--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -8,6 +8,7 @@
   "error.no-stocktake-items": "No items have been added to this stocktake.",
   "error.stocktake-not-found": "Stocktake not found",
   "error.provide-reason": "A reason must be provided for any rows which have a difference in the counted number of packs.",
+  "error.reduced-below-zero": "Stock line has existing outbound shipments. The quantity cannot be reduced below zero.",
   "label.add-batch": "Add batch",
   "label.add-new-line": "Add a new line",
   "label.cost-price": "Cost price",

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -78,6 +78,8 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
       const msg =
         `${e}`.indexOf('AdjustmentReasonNotProvided') !== -1
           ? t('error.provide-reason')
+          : `${e}`.indexOf('StockLineReducedBelowZero') !== -1
+          ? t('error.reduced-below-zero')
           : t('error.cant-save');
       error(msg)();
     }

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -16,6 +16,7 @@ import {
   createQueryParamsStore,
   QueryParamsProvider,
   useRowStyle,
+  LocaleKey,
 } from '@openmsupply-client/common';
 import { StocktakeLineEditForm } from './StocktakeLineEditForm';
 import { useStocktakeLineEdit } from './hooks';
@@ -63,6 +64,16 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
     return true;
   };
 
+  const parseError = (error: string): LocaleKey => {
+    switch (true) {
+      case error.indexOf('AdjustmentReasonNotProvided') !== -1:
+        return 'error.provide-reason';
+      case error.indexOf('StockLineReducedBelowZero') !== -1:
+        return 'error.reduced-below-zero';
+    }
+    return 'error.cant-save';
+  };
+
   const onOk = async () => {
     try {
       await save(draftLines);
@@ -75,12 +86,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
       }
       onClose();
     } catch (e) {
-      const msg =
-        `${e}`.indexOf('AdjustmentReasonNotProvided') !== -1
-          ? t('error.provide-reason')
-          : `${e}`.indexOf('StockLineReducedBelowZero') !== -1
-          ? t('error.reduced-below-zero')
-          : t('error.cant-save');
+      const msg = t(parseError(`${e}`));
       error(msg)();
     }
   };

--- a/server/graphql/stocktake_line/src/mutations/insert.rs
+++ b/server/graphql/stocktake_line/src/mutations/insert.rs
@@ -110,6 +110,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         ServiceError::AdjustmentReasonNotValid => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::InternalError(err) => InternalError(err),
+        ServiceError::StockLineReducedBelowZero(_) => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/graphql/stocktake_line/src/mutations/update.rs
+++ b/server/graphql/stocktake_line/src/mutations/update.rs
@@ -134,6 +134,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::AdjustmentReasonNotValid => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::InternalError(err) => InternalError(err),
+        ServiceError::StockLineReducedBelowZero(_) => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -63,6 +63,7 @@ pub struct InvoiceLineFilter {
     pub number_of_packs: Option<EqualFilter<f64>>,
     pub invoice_type: Option<EqualFilter<InvoiceRowType>>,
     pub invoice_status: Option<EqualFilter<InvoiceRowStatus>>,
+    pub stock_line_id: Option<EqualFilter<String>>,
 }
 
 impl InvoiceLineFilter {
@@ -78,6 +79,7 @@ impl InvoiceLineFilter {
             number_of_packs: None,
             invoice_type: None,
             invoice_status: None,
+            stock_line_id: None,
         }
     }
 
@@ -128,6 +130,11 @@ impl InvoiceLineFilter {
 
     pub fn invoice_status(mut self, filter: EqualFilter<InvoiceRowStatus>) -> Self {
         self.invoice_status = Some(filter);
+        self
+    }
+
+    pub fn stock_line_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.stock_line_id = Some(filter);
         self
     }
 }
@@ -222,6 +229,7 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
             number_of_packs,
             invoice_type,
             invoice_status,
+            stock_line_id,
         } = f;
 
         apply_equal_filter!(query, id, invoice_line_dsl::id);
@@ -234,6 +242,7 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
         apply_equal_filter!(query, number_of_packs, invoice_line_dsl::number_of_packs);
         apply_equal_filter!(query, invoice_type, invoice_dsl::type_);
         apply_equal_filter!(query, invoice_status, invoice_dsl::status);
+        apply_equal_filter!(query, stock_line_id, stock_line_dsl::id);
     }
 
     query

--- a/server/service/src/stocktake_line/update.rs
+++ b/server/service/src/stocktake_line/update.rs
@@ -193,14 +193,17 @@ impl From<RepositoryError> for UpdateStocktakeLineError {
 
 #[cfg(test)]
 mod stocktake_line_test {
+    use chrono::NaiveDate;
     use repository::{
         mock::{
-            mock_locations, mock_locked_stocktake_line, mock_stocktake_line_a,
-            mock_stocktake_line_finalised, mock_store_a, MockData, MockDataInserts,
+            mock_item_a, mock_locations, mock_locked_stocktake_line, mock_stock_line_b,
+            mock_stocktake_line_a, mock_stocktake_line_finalised, mock_store_a, MockData,
+            MockDataInserts,
         },
         test_db::setup_all_with_data,
         InventoryAdjustmentReasonRow, InventoryAdjustmentReasonRowRepository,
-        InventoryAdjustmentReasonType, StocktakeLineRow,
+        InventoryAdjustmentReasonType, InvoiceLineRow, InvoiceRow, InvoiceRowStatus,
+        InvoiceRowType, StocktakeLineRow,
     };
     use util::inline_init;
 
@@ -238,12 +241,46 @@ mod stocktake_line_test {
             })
         }
 
+        fn outbound_shipment() -> InvoiceRow {
+            inline_init(|r: &mut InvoiceRow| {
+                r.id = "reduced_stock_outbound_shipment".to_string();
+                r.name_id = "name_store_b".to_string();
+                r.store_id = "store_a".to_string();
+                r.invoice_number = 15;
+                r.r#type = InvoiceRowType::OutboundShipment;
+                r.status = InvoiceRowStatus::New;
+                r.created_datetime = NaiveDate::from_ymd(1970, 1, 3).and_hms_milli(20, 30, 0, 0);
+            })
+        }
+
+        fn outbound_shipment_line() -> InvoiceLineRow {
+            inline_init(|r: &mut InvoiceLineRow| {
+                r.id = "outbound_shipment_line".to_string();
+                r.invoice_id = outbound_shipment().id;
+                r.item_id = mock_item_a().id;
+                r.stock_line_id = Some(mock_stock_line_b().id);
+                r.number_of_packs = 29.0;
+            })
+        }
+
+        fn mock_reduced_stock() -> StocktakeLineRow {
+            inline_init(|r: &mut StocktakeLineRow| {
+                r.id = "mock_reduced_stock".to_string();
+                r.stocktake_id = "stocktake_a".to_string();
+                r.snapshot_number_of_packs = 10.0;
+                r.item_id = "item_a".to_string();
+                r.stock_line_id = Some(mock_stock_line_b().id);
+            })
+        }
+
         let (_, _, connection_manager, _) = setup_all_with_data(
             "update_stocktake_line",
             MockDataInserts::all(),
             inline_init(|r: &mut MockData| {
+                r.invoices = vec![outbound_shipment()];
+                r.invoice_lines = vec![outbound_shipment_line()];
                 r.inventory_adjustment_reasons = vec![positive_reason(), negative_reason()];
-                r.stocktake_lines = vec![mock_stocktake_line()];
+                r.stocktake_lines = vec![mock_stocktake_line(), mock_reduced_stock()];
             }),
         )
         .await;
@@ -368,6 +405,23 @@ mod stocktake_line_test {
             .unwrap_err();
         assert_eq!(error, UpdateStocktakeLineError::CannotEditFinalised);
 
+        // error: StockLineReducedBelowZero
+        let error = service
+            .update_stocktake_line(
+                &context,
+                inline_init(|r: &mut UpdateStocktakeLine| {
+                    r.id = mock_reduced_stock().id;
+                    r.counted_number_of_packs = Some(5.0);
+                }),
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            UpdateStocktakeLineError::StockLineReducedBelowZero(format!(
+                "Stock line {} has been issued in new outbound shipments",
+                mock_stock_line_b().id
+            ))
+        );
         // success: no update
         let stocktake_line_a = mock_stocktake_line_a();
         let result = service


### PR DESCRIPTION
Closes #1147

- Throw error for stock line if counted number of packs is less than number of packs in new outbound shipments 
- Return simple error message in UI

#### Test 
- Create an outbound shipment, and issue stock (leaving only 1). Can follow https://github.com/openmsupply/open-msupply/issues/1147 until step two. 
- Do a stocktake. counted number of packs > available stock on hand
- See error