### PR TITLE
#1138 Can still click 'Use Suggested Quantities' button after an Internal Order has been sent

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/UseSuggestedQuantityButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/UseSuggestedQuantityButton.tsx
@@ -11,6 +11,8 @@ export const UseSuggestedQuantityButtonComponent = () => {
   const t = useTranslation('replenishment');
   const { mutate: setRequestedToSuggested } =
     useRequest.utils.suggestedQuantity();
+  const isDisabled = useRequest.utils.isDisabled();
+
   const getConfirmation = useConfirmationModal({
     onConfirm: setRequestedToSuggested,
     message: t('messages.requested-to-suggested'),
@@ -22,6 +24,7 @@ export const UseSuggestedQuantityButtonComponent = () => {
       Icon={<ZapIcon />}
       label={t('button.requested-to-suggested')}
       onClick={() => getConfirmation()}
+      disabled={isDisabled}
     />
   );
 };


### PR DESCRIPTION
Closes #1138 

Disable `Use Suggested Quantities` button if status is sent