### PR TITLE
#1078 Can try to create an outbound shipment from a customer requisition when finalised (+ UI is a little confusing) 

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -115,5 +115,6 @@
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.shipment-saved": "Shipment saved 🥳",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
-  "warning.nothing-to-supply": "Nothing left to supply!"
+  "warning.nothing-to-supply": "Nothing left to supply!",
+  "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."
 }

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/CreateShipmentButton.tsx
@@ -15,6 +15,8 @@ export const CreateShipmentButtonComponent = () => {
   ]);
   const t = useTranslation('distribution');
   const { mutate: createOutbound } = useResponse.utils.createOutbound();
+  const isDisabled = useResponse.utils.isDisabled();
+
   const getConfirmation = useConfirmationModal({
     onConfirm: createOutbound,
     message: t('messages.create-outbound-from-requisition'),
@@ -42,6 +44,7 @@ export const CreateShipmentButtonComponent = () => {
       Icon={<PlusCircleIcon />}
       label={t('button.create-shipment')}
       onClick={onCreateShipment}
+      disabled={isDisabled}
     />
   );
 };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -10,6 +10,7 @@ import {
   DeleteIcon,
   useTranslation,
   SearchBar,
+  InfoPanel,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 
@@ -19,12 +20,14 @@ export const Toolbar: FC = () => {
   const t = useTranslation(['distribution', 'common']);
   const isDisabled = useResponse.utils.isDisabled();
   const { itemFilter, setItemFilter } = useResponse.line.list();
-  const { otherParty, theirReference, update } = useResponse.document.fields([
+  const { otherParty, theirReference, shipments, update } = useResponse.document.fields([
     'lines',
     'otherParty',
     'theirReference',
+    'shipments'
   ]);
   const { onDelete } = useResponse.line.delete();
+  const linkedToShipment = shipments?.totalCount > 0;
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -65,6 +68,11 @@ export const Toolbar: FC = () => {
                   />
                 }
               />
+              { !linkedToShipment && (
+                <InfoPanel
+                  message={t('info.no-shipment')}
+                />
+              )}
             </Box>
           </Box>
         </Grid>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -20,14 +20,16 @@ export const Toolbar: FC = () => {
   const t = useTranslation(['distribution', 'common']);
   const isDisabled = useResponse.utils.isDisabled();
   const { itemFilter, setItemFilter } = useResponse.line.list();
-  const { otherParty, theirReference, shipments, update } = useResponse.document.fields([
-    'lines',
-    'otherParty',
-    'theirReference',
-    'shipments'
-  ]);
+  const { otherParty, theirReference, shipments, update } =
+    useResponse.document.fields([
+      'lines',
+      'otherParty',
+      'theirReference',
+      'shipments',
+    ]);
   const { onDelete } = useResponse.line.delete();
-  const linkedToShipment = shipments?.totalCount > 0;
+  const noLinkedShipments = (shipments?.totalCount ?? 0) === 0;
+  const showInfo = noLinkedShipments && !isDisabled;
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -68,10 +70,8 @@ export const Toolbar: FC = () => {
                   />
                 }
               />
-              { !linkedToShipment && (
-                <InfoPanel
-                  message={t('info.no-shipment')}
-                />
+              {showInfo && (
+                <InfoPanel message={t('info.no-shipment')} />
               )}
             </Box>
           </Box>


### PR DESCRIPTION
Closes #1078 
 
- Disabled `Create Shipment` button on Requisitions if requisition is finalised.
- Added warning message if no outbound shipment has been created for requisition

#### Related areas
Users can create multiple shipments from one requisition so should the warning message always be on...? 🤔 