### PR TITLE
Tetum language support part II

### DIFF
--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -80,6 +80,7 @@
   "searching": "Searching...",
   "select-report": "Select Template",
   "select-store": "Select store",
+  "select-language": "Select language",
   "stock": "View Stock",
   "stocktakes": "Stocktakes",
   "store-details": "Store code: {{code}}",

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -5,6 +5,14 @@ import { LanguageType } from '../../types/schema';
 
 export { useTranslationNext };
 
+const languageOptions = [
+  { label: 'عربي', value: 'ar' },
+  { label: 'Français', value: 'fr' },
+  { label: 'English', value: 'en' },
+  { label: 'Española', value: 'es' },
+  { label: 'Tetum', value: 'tet' },
+];
+
 const locales = [
   'ar' as const,
   'en' as const,
@@ -53,6 +61,9 @@ export const IntlUtils = {
     }
     return 'en';
   },
+  languageOptions,
+  getLanguageName: (language: string) =>
+    languageOptions.find(option => option.value === language)?.label,
 };
 
 const parseLanguage = (language?: LanguageType) => {

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -71,6 +71,8 @@ const parseLanguage = (language?: LanguageType) => {
       return 'ru';
     case LanguageType.Spanish:
       return 'es';
+    case LanguageType.Tetum:
+      return 'tet';
     default:
       return undefined;
   }

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1464,7 +1464,8 @@ export enum LanguageType {
   Laos = 'LAOS',
   Portuguese = 'PORTUGUESE',
   Russian = 'RUSSIAN',
-  Spanish = 'SPANISH'
+  Spanish = 'SPANISH',
+  Tetum = 'TETUM'
 }
 
 export type LocationConnector = {

--- a/client/packages/host/src/components/Footer/Footer.tsx
+++ b/client/packages/host/src/components/Footer/Footer.tsx
@@ -2,18 +2,22 @@ import React from 'react';
 import {
   Box,
   HomeIcon,
+  IntlUtils,
   styled,
   Tooltip,
+  TranslateIcon,
   Typography,
   useAuthContext,
   UserIcon,
   useTranslation,
 } from '@openmsupply-client/common';
 import { StoreSelector } from './StoreSelector';
+import { LanguageSelector } from './LanguageSelector';
 
 export const Footer: React.FC = () => {
   const { user, store } = useAuthContext();
   const t = useTranslation('app');
+  const i18n = IntlUtils.useI18N();
   const PaddedCell = styled(Box)({ display: 'flex' });
   const iconStyles = { color: 'gray.main', height: '16px', width: '16px' };
   const textStyles = {
@@ -38,6 +42,16 @@ export const Footer: React.FC = () => {
           <Typography sx={textStyles}>{user.name}</Typography>
         </PaddedCell>
       ) : null}
+      <LanguageSelector>
+        <PaddedCell>
+          <TranslateIcon sx={iconStyles} />
+          <Tooltip title={t('select-language', { ...store })}>
+            <Typography sx={textStyles}>
+              {IntlUtils.getLanguageName(i18n.language)}
+            </Typography>
+          </Tooltip>
+        </PaddedCell>
+      </LanguageSelector>
     </Box>
   );
 };

--- a/client/packages/host/src/components/Footer/LanguageSelector.tsx
+++ b/client/packages/host/src/components/Footer/LanguageSelector.tsx
@@ -1,0 +1,61 @@
+import React, { FC } from 'react';
+import {
+  Box,
+  FlatButton,
+  PaperPopoverSection,
+  usePaperClickPopover,
+  useTranslation,
+  IntlUtils,
+  useNavigate,
+} from '@openmsupply-client/common';
+
+import { PropsWithChildrenOnly } from '@common/types';
+
+export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
+  const navigate = useNavigate();
+  const { hide, PaperClickPopover } = usePaperClickPopover();
+  const t = useTranslation('app');
+
+  const i18n = IntlUtils.useI18N();
+
+  const languageButtons = IntlUtils.languageOptions.map(l => (
+    <FlatButton
+      label={l.label}
+      disabled={l.value === i18n.language}
+      onClick={() => {
+        i18n.changeLanguage(l.value);
+        hide();
+        navigate(0);
+      }}
+      key={l.value}
+      sx={{
+        whiteSpace: 'nowrap',
+        overflowX: 'hidden',
+        overflowY: 'visible',
+        textOverflow: 'ellipsis',
+        display: 'block',
+        textAlign: 'left',
+      }}
+    />
+  ));
+  return (
+    <PaperClickPopover
+      placement="top"
+      width={300}
+      Content={
+        <PaperPopoverSection label={t('select-language')}>
+          <Box
+            style={{
+              overflowY: 'auto',
+              maxHeight: 300,
+            }}
+          >
+            {languageButtons}
+          </Box>
+        </PaperPopoverSection>
+      }
+    >
+      {children}
+    </PaperClickPopover>
+  );
+};

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -16,14 +16,6 @@ export const LanguageMenu: React.FC = () => {
     navigate(0);
   };
 
-  const options = [
-    { label: 'عربي', value: 'ar' },
-    { label: 'Français', value: 'fr' },
-    { label: 'English', value: 'en' },
-    { label: 'Española', value: 'es' },
-    { label: 'Tetum', value: 'tet' },
-  ];
-
   const renderOption = (option: Option) => (
     <MenuItem
       key={option.value}
@@ -37,7 +29,7 @@ export const LanguageMenu: React.FC = () => {
   return (
     <Select
       onChange={handleChange}
-      options={options}
+      options={IntlUtils.languageOptions}
       value={i18n.language}
       renderOption={renderOption}
     />

--- a/server/graphql/types/src/types/user.rs
+++ b/server/graphql/types/src/types/user.rs
@@ -50,6 +50,7 @@ pub enum LanguageType {
     Khmer,
     Portuguese,
     Russian,
+    Tetum,
 }
 
 #[derive(SimpleObject)]
@@ -133,6 +134,7 @@ impl LanguageType {
             Language::Khmer => Self::Khmer,
             Language::Portuguese => Self::Portuguese,
             Language::Russian => Self::Russian,
+            Language::Tetum => Self::Tetum,
         }
     }
 }

--- a/server/repository/migrations/postgres/2022-10-27T09-15_v103/up.sql
+++ b/server/repository/migrations/postgres/2022-10-27T09-15_v103/up.sql
@@ -1,11 +1,13 @@
-CREATE TYPE language_type AS ENUM (
+CREATE TYPE language_type AS ENUM
+(
     'ENGLISH',
     'FRENCH',
     'SPANISH',
     'LAOS',
     'KHMER',
     'PORTUGUESE',
-    'RUSSIAN'
+    'RUSSIAN',
+    'TETUM'
 );
 
 ALTER TABLE user_account

--- a/server/repository/src/db_diesel/user_row.rs
+++ b/server/repository/src/db_diesel/user_row.rs
@@ -26,6 +26,7 @@ pub enum Language {
     Khmer,
     Portuguese,
     Russian,
+    Tetum,
 }
 
 impl Default for Language {

--- a/server/repository/src/migrations/v1_01_03/mod.rs
+++ b/server/repository/src/migrations/v1_01_03/mod.rs
@@ -36,6 +36,12 @@ impl Migration for V1_01_03 {
         );"#
         )?;
 
+        #[cfg(feature = "postgres")]
+        sql!(
+            connection,
+            r#"ALTER TYPE language_type ADD VALUE IF NOT EXISTS 'TETUM';"#
+        )?;
+
         Ok(())
     }
 }

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -237,6 +237,7 @@ impl LoginService {
                 4 => Language::Khmer,
                 5 => Language::Portuguese,
                 6 => Language::Russian,
+                7 => Language::Tetum,
                 _ => Language::English,
             },
         };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1164 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds the link between central server and the site - if a user has Tetum as their language in mSupply and they login to omSupply, the site now sets the language correctly.

An additional task, which Chris requested in the comments, was to easily select language; and to select language when you are not a site administrator.

To that end.. there's now a language icon and name shown beside the username:

<img width="526" alt="Screenshot 2023-02-16 at 4 04 41 PM" src="https://user-images.githubusercontent.com/9192912/219259244-15889fe0-09d6-4b15-8aaf-846eb215ee95.png">

The tooltip shows what you can do:

<img width="364" alt="Screenshot 2023-02-16 at 4 04 48 PM" src="https://user-images.githubusercontent.com/9192912/219259315-a0ba450d-7880-4b10-a3ad-2b521a81e4e8.png">

Which is this:

<img width="353" alt="Screenshot 2023-02-16 at 4 04 54 PM" src="https://user-images.githubusercontent.com/9192912/219259380-bce9e6cd-e066-4e83-a5f5-b4a743888ed6.png">




# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

You will need to use the [#12353-Add-Tetum-language](https://github.com/sussol/msupply/tree/%2312353-Add-Tetum-language) branch in order to test the mSupply integration

Once that is configured, change a user to be Tetum and login as that user.
The omSupply site will show in Tetum and the language shown in the footer should also show Tetum.


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
- [ ] Language selection
- [ ] New footer screenshots