### PR TITLE
Enhanced material-ui and storybook integration

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -23,6 +23,26 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
   ],
+  typescript: {
+    check: false,
+    checkOptions: {},
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      // speeds up storybook build time
+      allowSyntheticDefaultImports: false,
+      // speeds up storybook build time
+      esModuleInterop: false,
+      // makes union prop types like variant and size appear as select controls
+      shouldExtractLiteralValuesFromEnum: true,
+      // makes string and boolean types that can be undefined appear as inputs and switches
+      shouldRemoveUndefinedFromOptional: true,
+      // Filter out third-party props from node_modules except @mui packages
+      propFilter: prop =>
+        prop.parent
+          ? !/node_modules\/(?!@mui)/.test(prop.parent.fileName)
+          : true,
+    },
+  },
   webpackFinal: async config => {
     return {
       ...config,

--- a/client/.storybook/manager-head.html
+++ b/client/.storybook/manager-head.html
@@ -1,0 +1,6 @@
+<style>
+  div#storybook-explorer-tree,
+  div#storybook-explorer-tree a {
+    color: white;
+  }
+</style>

--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -22,6 +22,7 @@ export const decorators = [
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
+    expanded: true, // Adds the description and default columns
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,

--- a/client/.storybook/theme.js
+++ b/client/.storybook/theme.js
@@ -1,8 +1,6 @@
 import { create } from '@storybook/theming/create';
 
 export default create({
-  base: 'light',
-
   colorPrimary: '#e95c30',
   colorSecondary: '#CDCDCD',
 
@@ -17,7 +15,7 @@ export default create({
   fontCode: 'monospace',
 
   // Text colors
-  textColor: 'white',
+  textColor: '#ed7d59',
   textInverseColor: 'rgba(255,255,255,0.9)',
 
   brandTitle: 'mSupply Foundation',

--- a/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.stories.tsx
+++ b/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.stories.tsx
@@ -9,7 +9,7 @@ const Template: ComponentStory<typeof FlatButton> = args => (
     <FlatButton
       {...args}
       startIcon={<BookIcon color={args.color} />}
-      label="Docs"
+      label={args.label ?? 'Docs'}
       onClick={() => console.info('clicked')}
     />
   </Box>
@@ -20,7 +20,7 @@ const StyledTemplate: ComponentStory<typeof FlatButton> = args => (
     <FlatButton
       {...args}
       endIcon={<FilterIcon fontSize="small" />}
-      label="View Filters"
+      label={args.label ?? 'View Filters'}
       onClick={() => console.info('clicked')}
       sx={{
         color: 'gray.main',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1206

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
- Adds support for material UI props if the component props are extending from a material interface
- Changes the text colour to something readable ( white looks better in the sidebar, but is unreadable in the menu and addons window )
- Adds select / radio button selection for enumerated props
- Adds description and default column for controls

As an example - this is the `FlatButton` control, which now has the colour options as radio buttons, the description and default columns shown and the boolean 'disabled' selectable.

<img width="1141" alt="Screenshot 2023-02-20 at 11 32 20 AM" src="https://user-images.githubusercontent.com/9192912/219979663-96ce51d1-5a1d-4f22-8462-1af22470e2eb.png">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Run `yarn storybook` from the `/client` folder


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

