### PR TITLE
1202 GBV report

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -844,8 +844,8 @@ export type EncounterConnector = {
 export type EncounterEventFilterInput = {
   /**
    * 	Only include events that are for the current encounter, i.e. have matching encounter type
-   * and matching encounter name of the current encounter. If not set all events for with
-   * matching encounter type are returned.
+   * and matching encounter name of the current encounter. If not set all events with matching
+   * encounter type are returned.
    */
   isCurrentEncounter?: InputMaybe<Scalars['Boolean']>;
   type?: InputMaybe<EqualFilterStringInput>;
@@ -872,9 +872,10 @@ export type EncounterFieldsResponse = EncounterFieldsConnector;
 export type EncounterFilterInput = {
   clinicianId?: InputMaybe<EqualFilterStringInput>;
   createdDatetime?: InputMaybe<DatetimeFilterInput>;
+  documentData?: InputMaybe<SimpleStringFilterInput>;
+  documentName?: InputMaybe<EqualFilterStringInput>;
   endDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  name?: InputMaybe<EqualFilterStringInput>;
   patientId?: InputMaybe<EqualFilterStringInput>;
   program?: InputMaybe<EqualFilterStringInput>;
   startDatetime?: InputMaybe<DatetimeFilterInput>;
@@ -2685,6 +2686,11 @@ export type PatientNode = {
   website?: Maybe<Scalars['String']>;
 };
 
+
+export type PatientNodeProgramEnrolmentsArgs = {
+  filter?: InputMaybe<ProgramEnrolmentFilterInput>;
+};
+
 export type PatientResponse = PatientConnector;
 
 export type PatientSearchConnector = {
@@ -2791,7 +2797,7 @@ export type ProgramEnrolmentNode = {
   /** The encounter document */
   document: DocumentNode;
   /** The program document */
-  encounters: Array<EncounterNode>;
+  encounters: EncounterConnector;
   enrolmentDatetime: Scalars['DateTime'];
   events: Array<ProgramEventNode>;
   /** The program document name */
@@ -2800,6 +2806,13 @@ export type ProgramEnrolmentNode = {
   /** The program type */
   program: Scalars['String'];
   programPatientId?: Maybe<Scalars['String']>;
+};
+
+
+export type ProgramEnrolmentNodeEncountersArgs = {
+  filter?: InputMaybe<EncounterFilterInput>;
+  page?: InputMaybe<PaginationInput>;
+  sort?: InputMaybe<EncounterSortInput>;
 };
 
 

--- a/server/graphql/programs/src/mutations/encounter/insert.rs
+++ b/server/graphql/programs/src/mutations/encounter/insert.rs
@@ -95,7 +95,7 @@ pub fn insert_encounter(
         .encounter_service
         .encounter(
             &service_context,
-            EncounterFilter::new().name(EqualFilter::equal_to(&document.name)),
+            EncounterFilter::new().document_name(EqualFilter::equal_to(&document.name)),
             allowed_docs.clone(),
         )?
         .ok_or(

--- a/server/graphql/programs/src/mutations/encounter/update.rs
+++ b/server/graphql/programs/src/mutations/encounter/update.rs
@@ -94,7 +94,7 @@ pub fn update_encounter(
         .encounter_service
         .encounter(
             &service_context,
-            EncounterFilter::new().name(EqualFilter::equal_to(&document.name)),
+            EncounterFilter::new().document_name(EqualFilter::equal_to(&document.name)),
             allowed_docs.clone(),
         )?
         .ok_or(

--- a/server/graphql/programs/src/queries/encounter.rs
+++ b/server/graphql/programs/src/queries/encounter.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{DatetimeFilterInput, EqualFilterStringInput},
+    generic_filters::{DatetimeFilterInput, EqualFilterStringInput, SimpleStringFilterInput},
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -8,7 +8,7 @@ use graphql_core::{
 };
 use repository::{
     DatetimeFilter, EncounterFilter, EncounterSort, EncounterSortField, EqualFilter,
-    PaginationOption,
+    PaginationOption, SimpleStringFilter,
 };
 use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
@@ -59,12 +59,13 @@ pub struct EncounterFilterInput {
     pub r#type: Option<EqualFilterStringInput>,
     pub patient_id: Option<EqualFilterStringInput>,
     pub program: Option<EqualFilterStringInput>,
-    pub name: Option<EqualFilterStringInput>,
+    pub document_name: Option<EqualFilterStringInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
     pub start_datetime: Option<DatetimeFilterInput>,
     pub end_datetime: Option<DatetimeFilterInput>,
     pub status: Option<EqualFilterEncounterStatusInput>,
     pub clinician_id: Option<EqualFilterStringInput>,
+    pub document_data: Option<SimpleStringFilterInput>,
 }
 
 impl EncounterFilterInput {
@@ -74,7 +75,7 @@ impl EncounterFilterInput {
             r#type: self.r#type.map(EqualFilter::from),
             patient_id: self.patient_id.map(EqualFilter::from),
             program: self.program.map(EqualFilter::from),
-            name: self.name.map(EqualFilter::from),
+            document_name: self.document_name.map(EqualFilter::from),
             created_datetime: self.created_datetime.map(DatetimeFilter::from),
             start_datetime: self.start_datetime.map(DatetimeFilter::from),
             status: self
@@ -82,6 +83,7 @@ impl EncounterFilterInput {
                 .map(|s| map_filter!(s, EncounterNodeStatus::to_domain)),
             end_datetime: self.end_datetime.map(DatetimeFilter::from),
             clinician_id: self.clinician_id.map(EqualFilter::from),
+            document_data: self.document_data.map(SimpleStringFilter::from),
         }
     }
 }

--- a/server/graphql/programs/src/types/encounter.rs
+++ b/server/graphql/programs/src/types/encounter.rs
@@ -154,7 +154,7 @@ impl EncounterNode {
     }
 
     pub async fn name(&self) -> &str {
-        &self.encounter_row.name
+        &self.encounter_row.document_name
     }
 
     pub async fn status(&self) -> Option<EncounterNodeStatus> {
@@ -185,7 +185,7 @@ impl EncounterNode {
         let result = loader
             .load_one(DocumentLoaderInput {
                 store_id: self.store_id.clone(),
-                document_name: self.encounter_row.name.clone(),
+                document_name: self.encounter_row.document_name.clone(),
             })
             .await?
             .map(|document| DocumentNode {
@@ -212,8 +212,8 @@ impl EncounterNode {
             .patient_id(EqualFilter::equal_to(&self.encounter_row.patient_id))
             .document_type(EqualFilter::equal_to(&self.encounter_row.r#type));
         if filter.and_then(|f| f.is_current_encounter).unwrap_or(false) {
-            program_filter =
-                program_filter.document_name(EqualFilter::equal_to(&self.encounter_row.name))
+            program_filter = program_filter
+                .document_name(EqualFilter::equal_to(&self.encounter_row.document_name))
         };
         let entries = ctx
             .service_provider()

--- a/server/graphql/programs/src/types/program_enrolment.rs
+++ b/server/graphql/programs/src/types/program_enrolment.rs
@@ -53,7 +53,7 @@ impl ProgramEnrolmentNode {
 
     /// The program document name
     pub async fn name(&self) -> &str {
-        &self.program_row.name
+        &self.program_row.document_name
     }
 
     pub async fn patient_id(&self) -> &str {
@@ -75,7 +75,7 @@ impl ProgramEnrolmentNode {
         let result = loader
             .load_one(DocumentLoaderInput {
                 store_id: self.store_id.clone(),
-                document_name: self.program_row.name.clone(),
+                document_name: self.program_row.document_name.clone(),
             })
             .await?
             .map(|document| DocumentNode {

--- a/server/repository/migrations/postgres/2022-06-07T16-00_create_program_enrolment_table/up.sql
+++ b/server/repository/migrations/postgres/2022-06-07T16-00_create_program_enrolment_table/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE program_enrolment (
     id TEXT NOT NULL PRIMARY KEY,
     program TEXT NOT NULL,
-    name TEXT NOT NULL,
+    document_name TEXT NOT NULL,
     patient_id TEXT NOT NULL,
     enrolment_datetime TIMESTAMP NOT NULL,
     program_patient_id TEXT

--- a/server/repository/migrations/postgres/2022-06-07T17-00_create_encounter_table/up.sql
+++ b/server/repository/migrations/postgres/2022-06-07T17-00_create_encounter_table/up.sql
@@ -7,7 +7,7 @@ CREATE TYPE encounter_status AS ENUM (
 CREATE TABLE encounter (
     id TEXT NOT NULL PRIMARY KEY,
     type TEXT NOT NULL,
-    name TEXT NOT NULL,
+    document_name TEXT NOT NULL,
     patient_id TEXT NOT NULL,
     program TEXT NOT NULL,
     created_datetime TIMESTAMP NOT NULL,

--- a/server/repository/migrations/sqlite/2022-06-07T16-00_create_program_enrolment_table/up.sql
+++ b/server/repository/migrations/sqlite/2022-06-07T16-00_create_program_enrolment_table/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE program_enrolment (
     id TEXT NOT NULL PRIMARY KEY,
     program TEXT NOT NULL,
-    name TEXT NOT NULL,
+    document_name TEXT NOT NULL,
     patient_id TEXT NOT NULL,
     enrolment_datetime TIMESTAMP NOT NULL,
     program_patient_id TEXT

--- a/server/repository/migrations/sqlite/2022-06-07T17-00_create_encounter_table/up.sql
+++ b/server/repository/migrations/sqlite/2022-06-07T17-00_create_encounter_table/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE encounter (
     id TEXT NOT NULL PRIMARY KEY,
     type TEXT NOT NULL,
-    name TEXT NOT NULL,
+    document_name TEXT NOT NULL,
     patient_id TEXT NOT NULL,
     program TEXT NOT NULL,
     created_datetime TIMESTAMP NOT NULL,

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -253,7 +253,9 @@ impl<'a> DocumentRepository<'a> {
 
         if let Some(sort) = sort {
             match sort.key {
-                DocumentSortField::Name => apply_sort!(query, sort, latest_document::dsl::name),
+                DocumentSortField::Name => {
+                    apply_sort!(query, sort, latest_document::dsl::name)
+                }
                 DocumentSortField::Type => {
                     apply_sort!(query, sort, latest_document::dsl::type_)
                 }

--- a/server/repository/src/db_diesel/encounter.rs
+++ b/server/repository/src/db_diesel/encounter.rs
@@ -1,12 +1,15 @@
 use super::{
+    document::{latest_document, latest_document::dsl as latest_document_dsl},
     encounter_row::encounter::{self, dsl as encounter_dsl},
     StorageConnection,
 };
 
 use crate::{
-    diesel_macros::{apply_date_time_filter, apply_equal_filter, apply_sort},
+    diesel_macros::{
+        apply_date_time_filter, apply_equal_filter, apply_simple_string_filter, apply_sort,
+    },
     DBType, DatetimeFilter, EncounterRow, EncounterStatus, EqualFilter, Pagination,
-    RepositoryError, Sort,
+    RepositoryError, SimpleStringFilter, Sort,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -17,12 +20,14 @@ pub struct EncounterFilter {
     pub r#type: Option<EqualFilter<String>>,
     pub patient_id: Option<EqualFilter<String>>,
     pub program: Option<EqualFilter<String>>,
-    pub name: Option<EqualFilter<String>>,
+    pub document_name: Option<EqualFilter<String>>,
     pub created_datetime: Option<DatetimeFilter>,
     pub start_datetime: Option<DatetimeFilter>,
     pub end_datetime: Option<DatetimeFilter>,
     pub status: Option<EqualFilter<EncounterStatus>>,
     pub clinician_id: Option<EqualFilter<String>>,
+    /// Filter by encounter data
+    pub document_data: Option<SimpleStringFilter>,
 }
 
 impl EncounterFilter {
@@ -50,8 +55,8 @@ impl EncounterFilter {
         self
     }
 
-    pub fn name(mut self, filter: EqualFilter<String>) -> Self {
-        self.name = Some(filter);
+    pub fn document_name(mut self, filter: EqualFilter<String>) -> Self {
+        self.document_name = Some(filter);
         self
     }
 
@@ -77,6 +82,11 @@ impl EncounterFilter {
 
     pub fn clinician_id(mut self, filter: EqualFilter<String>) -> Self {
         self.clinician_id = Some(filter);
+        self
+    }
+
+    pub fn document_data(mut self, filter: SimpleStringFilter) -> Self {
+        self.document_data = Some(filter);
         self
     }
 }
@@ -106,24 +116,33 @@ fn create_filtered_query<'a>(filter: Option<EncounterFilter>) -> BoxedProgramQue
             r#type,
             patient_id,
             program,
-            name,
+            document_name: name,
             created_datetime,
             start_datetime,
             end_datetime,
             status,
             clinician_id,
+            document_data,
         } = f;
 
         apply_equal_filter!(query, id, encounter_dsl::id);
         apply_equal_filter!(query, r#type, encounter_dsl::type_);
         apply_equal_filter!(query, patient_id, encounter_dsl::patient_id);
         apply_equal_filter!(query, program, encounter_dsl::program);
-        apply_equal_filter!(query, name, encounter_dsl::name);
+        apply_equal_filter!(query, name, encounter_dsl::document_name);
         apply_date_time_filter!(query, created_datetime, encounter_dsl::created_datetime);
         apply_date_time_filter!(query, start_datetime, encounter_dsl::start_datetime);
         apply_date_time_filter!(query, end_datetime, encounter_dsl::end_datetime);
         apply_equal_filter!(query, status, encounter_dsl::status);
         apply_equal_filter!(query, clinician_id, encounter_dsl::clinician_id);
+
+        if document_data.is_some() {
+            let mut sub_query = latest_document_dsl::latest_document
+                .select(latest_document_dsl::name)
+                .into_boxed();
+            apply_simple_string_filter!(sub_query, document_data, latest_document::data);
+            query = query.filter(encounter_dsl::document_name.eq_any(sub_query));
+        }
     }
     query
 }

--- a/server/repository/src/db_diesel/encounter_row.rs
+++ b/server/repository/src/db_diesel/encounter_row.rs
@@ -21,7 +21,7 @@ table! {
     encounter (id) {
         id -> Text,
         #[sql_name = "type"] type_ -> Text,
-        name -> Text,
+        document_name -> Text,
         patient_id -> Text,
         program -> Text,
         created_datetime -> Timestamp,
@@ -41,7 +41,7 @@ pub struct EncounterRow {
     #[column_name = "type_"]
     pub r#type: String,
     /// The encounter document name
-    pub name: String,
+    pub document_name: String,
     pub patient_id: String,
     pub program: String,
     pub created_datetime: NaiveDateTime,

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -732,7 +732,7 @@ mod tests {
         ProgramEnrolmentRowRepository::new(&connection)
             .upsert_one(&ProgramEnrolmentRow {
                 id: util::uuid::uuid(),
-                name: "doc_name".to_string(),
+                document_name: "doc_name".to_string(),
                 patient_id: mock_name_2().id,
                 program: "ProgramType".to_string(),
                 enrolment_datetime: Utc::now().naive_utc(),

--- a/server/repository/src/db_diesel/program_enrolment_row.rs
+++ b/server/repository/src/db_diesel/program_enrolment_row.rs
@@ -11,7 +11,7 @@ table! {
     program_enrolment (id) {
         id -> Text,
         program -> Text,
-        name -> Text,
+        document_name -> Text,
         patient_id -> Text,
         enrolment_datetime -> Timestamp,
         program_patient_id -> Nullable<Text>,
@@ -31,7 +31,7 @@ pub struct ProgramEnrolmentRow {
     /// The program the patient is enrolled in.
     pub program: String,
     /// The program document name
-    pub name: String,
+    pub document_name: String,
     /// The patient this program belongs to
     pub patient_id: String,
     /// Time when the patient has been enrolled to this program

--- a/server/service/src/programs/encounter/encounter_fields.rs
+++ b/server/service/src/programs/encounter/encounter_fields.rs
@@ -45,7 +45,7 @@ pub(crate) fn encounter_fields(
     let encounters = repository.query(pagination, Some(filter.clone()), sort)?;
     let doc_names = encounters
         .iter()
-        .map(|row| row.name.clone())
+        .map(|row| row.document_name.clone())
         .collect::<Vec<_>>();
     let documents = DocumentRepository::new(&ctx.connection).query(
         Pagination::all(),
@@ -59,7 +59,7 @@ pub(crate) fn encounter_fields(
     let rows = encounters
         .into_iter()
         .map(|row| {
-            let doc = match doc_map.remove(&row.name) {
+            let doc = match doc_map.remove(&row.document_name) {
                 Some(doc) => doc,
                 // should not happen:
                 None => return Err(RepositoryError::NotFound),

--- a/server/service/src/programs/encounter/encounter_updated.rs
+++ b/server/service/src/programs/encounter/encounter_updated.rs
@@ -34,7 +34,7 @@ pub(crate) fn update_encounter_row(
 
     let repo = EncounterRepository::new(con);
     let row = repo
-        .query_by_filter(EncounterFilter::new().name(EqualFilter::equal_to(&doc.name)))?
+        .query_by_filter(EncounterFilter::new().document_name(EqualFilter::equal_to(&doc.name)))?
         .pop();
     let id = match row {
         Some(row) => row.id,
@@ -43,7 +43,7 @@ pub(crate) fn update_encounter_row(
     let row = EncounterRow {
         id,
         r#type: doc.r#type.clone(),
-        name: doc.name.clone(),
+        document_name: doc.name.clone(),
         patient_id: patient_id.to_string(),
         program: program.to_string(),
         created_datetime: validated_encounter.created_datetime,

--- a/server/service/src/programs/encounter/insert.rs
+++ b/server/service/src/programs/encounter/insert.rs
@@ -383,7 +383,9 @@ mod test {
         assert_eq!(found.data, serde_json::to_value(encounter.clone()).unwrap());
         // check that encounter table has been updated
         let row = EncounterRepository::new(&ctx.connection)
-            .query_by_filter(EncounterFilter::new().name(EqualFilter::equal_to(&found.name)))
+            .query_by_filter(
+                EncounterFilter::new().document_name(EqualFilter::equal_to(&found.name)),
+            )
             .unwrap()
             .pop();
         assert!(row.is_some());

--- a/server/service/src/programs/encounter/update.rs
+++ b/server/service/src/programs/encounter/update.rs
@@ -141,7 +141,7 @@ fn validate_exiting_encounter(
     name: &str,
 ) -> Result<Option<Encounter>, RepositoryError> {
     let result = EncounterRepository::new(&ctx.connection)
-        .query_by_filter(EncounterFilter::new().name(EqualFilter::equal_to(name)))?
+        .query_by_filter(EncounterFilter::new().document_name(EqualFilter::equal_to(name)))?
         .pop();
     Ok(result)
 }
@@ -387,7 +387,9 @@ mod test {
         assert_eq!(found.data, serde_json::to_value(encounter.clone()).unwrap());
         // check that encounter table has been updated
         let row = EncounterRepository::new(&ctx.connection)
-            .query_by_filter(EncounterFilter::new().name(EqualFilter::equal_to(&found.name)))
+            .query_by_filter(
+                EncounterFilter::new().document_name(EqualFilter::equal_to(&found.name)),
+            )
             .unwrap()
             .pop()
             .unwrap();

--- a/server/service/src/programs/program_enrolment/program_enrolment_updated.rs
+++ b/server/service/src/programs/program_enrolment/program_enrolment_updated.rs
@@ -34,7 +34,7 @@ pub(crate) fn program_enrolment_updated(
     let program_row = ProgramEnrolmentRow {
         id,
         program: document.r#type.clone(),
-        name: document.name.clone(),
+        document_name: document.name.clone(),
         patient_id: patient_id.to_string(),
         enrolment_datetime,
         program_patient_id: program.enrolment_patient_id,

--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -187,6 +187,7 @@ const ENCOUNTERS_REPORT: &'static str =
 const VL_ELIGIBILITY_REPORT: &'static str =
     std::include_str!("./program_schemas/report_vl_eligibility.json");
 const LTFU_REPORT: &'static str = std::include_str!("./program_schemas/report_ltfu.json");
+const GBV_REPORT: &'static str = std::include_str!("./program_schemas/report_gbv.json");
 
 fn person_1() -> RelatedPerson {
     RelatedPerson {
@@ -1174,6 +1175,19 @@ pub fn init_program_data(
             name: "Lost to follow up".to_string(),
             r#type: repository::ReportType::OmSupply,
             template: LTFU_REPORT.to_string(),
+            context: ReportContext::Patient,
+            comment: None,
+            sub_context: Some("HIVCareProgram".to_string()),
+            argument_schema_id: None,
+        })
+        .unwrap();
+
+    report_repo
+        .upsert_one(&ReportRow {
+            id: uuid(),
+            name: "Gender-based Violence Summary".to_string(),
+            r#type: repository::ReportType::OmSupply,
+            template: GBV_REPORT.to_string(),
             context: ReportContext::Patient,
             comment: None,
             sub_context: Some("HIVCareProgram".to_string()),

--- a/server/service/src/sync/program_schemas/report_gbv.json
+++ b/server/service/src/sync/program_schemas/report_gbv.json
@@ -1,0 +1,28 @@
+{
+  "index": {
+    "template": "template.html",
+    "header": null,
+    "footer": null,
+    "query": "query.graphql"
+  },
+  "entries": {
+    "style.css": {
+      "type": "Resource",
+      "data": "table,\nth,\ntd {\n  border: 1px dotted #fc9208;\n  border-collapse: collapse;\n}\n\nbody {\n  margin: 10px 5% 10px 5%;\n  font-family: \"Segoe UI\", Tahoma, Geneva, Verdana, sans-serif;\n}\n"
+    },
+    "template.html": {
+      "type": "TeraTemplate",
+      "data": {
+        "output": "Html",
+        "template": "{% set_global timezone = \"Pacific/Port_Moresby\" %}\n\n<style>\n  {% include \"style.css\" %}\n</style>\n\n<body>\n  <h1>CT GBV Register For</h1>\n  <h2>{{data.store.storeName}}</h2>\n\n  <table>\n    <tr>\n      <td>Visit Date</td>\n      <td>Patient ID</td>\n      <td>Sex</td>\n      <td>Date Of Birth</td>\n      <td>GBV Screened</td>\n      <td>GBV Type</td>\n      <td>GBV Referred</td>\n      <td>IPV Case</td>\n      <td>Rape Case</td>\n      <td>GBV Services Provided</td>\n      <td>GBV Service Type</td>\n    </tr>\n    {% for patient in data.patients.nodes %}\n      {% if patient.programEnrolments | length > 0 %}\n        {% set enrolment = patient.programEnrolments.0 %}\n          {% if enrolment.encounters.nodes | length > 0 %}\n            {% set encounter = enrolment.encounters.nodes.0 %}\n            {% set gbv = encounter.document.data.genderBasedViolence %}\n            <tr>\n              <td>\n                {{encounter.startDatetime | date(format=\"%d/%m/%Y\",timezone=timezone)}}\n              </td>\n              <td>{{enrolment.programPatientId}}</td>\n              <td>\n                {% if patient.gender == \"FEMALE\" %}\n                  Female\n                {% elif patient.gender == \"MALE\" %}\n                  Male\n                {% elif patient.gender == \"TRANSGENDER\" %}\n                  Transgender\n                {% else %}\n                  {{patient.gender}}\n                {% endif %}\n              </td>\n              <td>\n                {{patient.dateOfBirth | date(format=\"%d/%m/%Y\",timezone=timezone)}}\n              </td>\n              <td>\n                {% if gbv.screened %}\n                  {{gbv.screened}}\n                {% endif %}\n              </td>\n              <td>\n                {% if gbv.type %}\n                  {{gbv.type}}\n                {% endif %}\n              </td>\n              <td>\n                {% if gbv.referredForExternalServices %}\n                  {{gbv.referredForExternalServices}}\n                {% endif %}\n              </td>\n              <td>\n                {% if gbv.intimatePartnerViolence %}\n                  {{gbv.intimatePartnerViolence}}\n                {% endif %}\n              </td>\n              <td>\n                {% if gbv.rape %}\n                  {{gbv.rape}}\n                {% endif %}\n              </td>             \n              <td>\n                {% if gbv.postServiceProvided %}\n                  {{gbv.postServiceProvided}}\n                {% endif %}\n              </td>\n              <td>\n                {% if gbv.receivedServiceType %}\n                  {{gbv.receivedServiceType}}\n                {% endif %}\n              </td>\n            </tr>\n          {% endif %}\n      {% endif %}\n    {% endfor %}\n  </table>\n</body>\n"
+      }
+    },
+    "query.graphql": {
+      "type": "GraphGLQuery",
+      "data": {
+        "query": "query GBVSummary($storeId: String, $now: String) {\n  store(id: $storeId) {\n    ... on StoreNode {\n      storeName\n    }\n  }\n\n  patients(storeId: $storeId) {\n    ... on PatientConnector {\n      nodes {\n        gender\n        dateOfBirth\n        programEnrolments(filter: { program: { equalTo: \"HIVCareProgram\" } }) {\n          programPatientId\n          encounters(\n            page: { first: 1, offset: 0 }\n            sort: { key: startDatetime, desc: true }\n            filter: {\n              program: { equalTo: \"HIVCareProgram\" }\n              startDatetime: { beforeOrEqualTo: $now }\n              documentData: { like: \"\\\"genderBasedViolence\\\":\" }\n            }\n          ) {\n            nodes {\n              startDatetime\n              document {\n                data\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n",
+        "variables": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1202 

Adds a GBV report and adds a filter for filtering encounter document data. This is done by doing a string search in the JSON data. However, I think this could be done using the building json functions in sqlite as well as postgres in a fairly DB agnostic way in the future....

For testing: fill some fields in the GBV section in the HIV care encounter. The values from the latest encounter should show up in the report.