### PR TITLE
Use astro-dnssd for discovery

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -463,25 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dnssd"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98efc05996cc8d660e88841fcffb75aa71be5339c9ae559a8c8016c048420b82"
-dependencies = [
- "bitflags",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-util",
- "libc",
- "log",
- "pin-utils",
- "pkg-config",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,7 +3856,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "astro-dnssd",
- "async-dnssd",
  "chrono",
  "clap",
  "config",

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -56,13 +56,10 @@ actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 httpmock = "0.6"
 
-[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
-async-dnssd = { version = "0.5.0" }
-
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(not(target_os = "android"))'.dependencies]
 astro-dnssd = { version = "0.3.2" }
 
 [features]

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -1,7 +1,4 @@
 use crate::certs::Protocol;
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-use async_dnssd::{RegisterData, TxtRecord};
-#[cfg(target_os = "windows")]
 use {astro_dnssd::DNSServiceBuilder, std::collections::HashMap};
 
 const SERVICE_NAME: &'static str = "_omsupply._tcp";
@@ -13,55 +10,26 @@ const CLIENT_VERSION: &'static str = "unspecified";
 
 pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String) {
     tokio::task::spawn(async move {
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
-        {
-            let mut txt: TxtRecord = TxtRecord::new();
-            txt.set_value(HARDWARE_ID_KEY.as_bytes(), hardware_id.as_bytes())
-                .unwrap();
-            txt.set_value(CLIENT_VERSION_KEY.as_bytes(), CLIENT_VERSION.as_bytes())
-                .unwrap();
-            txt.set_value(PROTOCOL_KEY.as_bytes(), protocol.to_string().as_bytes())
-                .unwrap();
-            let (_registration, _) = async_dnssd::register_extended(
-                SERVICE_NAME,
-                port,
-                RegisterData {
-                    txt: txt.rdata(),
-                    name: Some(NAME),
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-            .await
-            .unwrap();
-
-            // Without this discovery stops (even if result of register_extended is kept and passed to caller)
-            futures::future::pending::<()>().await;
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            let mut text_record = HashMap::<String, String>::new();
-            text_record.insert(HARDWARE_ID_KEY.to_string(), hardware_id.to_string());
-            text_record.insert(CLIENT_VERSION_KEY.to_string(), CLIENT_VERSION.to_string());
-            text_record.insert(PROTOCOL_KEY.to_string(), protocol.to_string());
-            // need to keep the thread running
-            // found that the discovery client in electron did not pick up the server at times
-            // and running register again was necessary for the server to be found
-            loop {
-                let service = DNSServiceBuilder::new(SERVICE_NAME, port)
-                    .with_txt_record(text_record.clone())
-                    .with_name(NAME)
-                    .register();
-                {
-                    match service {
-                        Ok(_service) => {
-                            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                        }
-                        Err(e) => {
-                            log::error!("Error registering discovery: {:?}", e);
-                            break;
-                        }
+        let mut text_record = HashMap::<String, String>::new();
+        text_record.insert(HARDWARE_ID_KEY.to_string(), hardware_id.to_string());
+        text_record.insert(CLIENT_VERSION_KEY.to_string(), CLIENT_VERSION.to_string());
+        text_record.insert(PROTOCOL_KEY.to_string(), protocol.to_string());
+        // need to keep the thread running
+        // found that the discovery client in electron did not pick up the server at times
+        // and running register again was necessary for the server to be found
+        loop {
+            let service = DNSServiceBuilder::new(SERVICE_NAME, port)
+                .with_txt_record(text_record.clone())
+                .with_name(NAME)
+                .register();
+            {
+                match service {
+                    Ok(_service) => {
+                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    }
+                    Err(e) => {
+                        log::error!("Error registering discovery: {:?}", e);
+                        break;
                     }
                 }
             }

--- a/server/server/src/discovery.rs
+++ b/server/server/src/discovery.rs
@@ -14,25 +14,15 @@ pub(crate) fn start_discovery(protocol: Protocol, port: u16, hardware_id: String
         text_record.insert(HARDWARE_ID_KEY.to_string(), hardware_id.to_string());
         text_record.insert(CLIENT_VERSION_KEY.to_string(), CLIENT_VERSION.to_string());
         text_record.insert(PROTOCOL_KEY.to_string(), protocol.to_string());
-        // need to keep the thread running
-        // found that the discovery client in electron did not pick up the server at times
-        // and running register again was necessary for the server to be found
-        loop {
-            let service = DNSServiceBuilder::new(SERVICE_NAME, port)
-                .with_txt_record(text_record.clone())
-                .with_name(NAME)
-                .register();
-            {
-                match service {
-                    Ok(_service) => {
-                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    }
-                    Err(e) => {
-                        log::error!("Error registering discovery: {:?}", e);
-                        break;
-                    }
-                }
-            }
+
+        let registration_result = DNSServiceBuilder::new(SERVICE_NAME, port)
+            .with_txt_record(text_record.clone())
+            .with_name(NAME)
+            .register();
+
+        match registration_result {
+            Ok(_service_handle) => futures::future::pending::<()>().await,
+            Err(e) => log::error!("Error registering discovery: {:?}", e),
         }
     });
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -40,7 +40,7 @@ pub mod static_files;
 pub use self::logging::*;
 
 // Only import discovery for non android features (otherwise build for android targets would fail due to local-ip-address)
-#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+#[cfg(not(target_os = "android"))]
 mod discovery;
 
 /// Starts the server
@@ -199,7 +199,7 @@ pub async fn start_server(
 
     // START DISCOVERY
     // Don't do discovery in android
-    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+    #[cfg(not(target_os = "android"))]
     {
         info!("Starting server DNS-SD discovery",);
         discovery::start_discovery(certificates.protocol(), settings.server.port, machine_uid);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1064 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
I've been hitting the seg fault a lot lately, and wanted to get a more permanent fix in place, so I tried the astro-dnssd implementation on macOS and it worked fine. 

So, just swapped out the `async-dnssd` for `astro-dnssd` 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Run the server a few times, and see if it crashes 🤷 
Check that discovery is working from a macOS machine. You can try a tablet, or the desktop app or `dns-sd -Q _omsupply._tcp.local ANY` from a terminal.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

