### PR TITLE
#1205 BasicTextInput and left aligned JSONForm number input 

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -2,11 +2,15 @@ import React, { FC } from 'react';
 import {
   Box,
   StandardTextFieldProps,
+  SxProps,
   TextField,
+  Theme,
   Typography,
 } from '@mui/material';
 
-export type BasicTextInputProps = StandardTextFieldProps;
+export interface BasicTextInputProps extends StandardTextFieldProps {
+  boxSx?: SxProps<Theme>;
+}
 
 /**
  * Very basic TextInput component with some simple styling applied where you can
@@ -14,8 +18,8 @@ export type BasicTextInputProps = StandardTextFieldProps;
  */
 
 export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
-  ({ sx, InputProps, error, required, ...props }, ref) => (
-    <Box display="flex" justifyContent="flex-end" alignItems="center">
+  ({ sx, InputProps, error, required, boxSx, ...props }, ref) => (
+    <Box sx={{ ...boxSx }}>
       <TextField
         ref={ref}
         color="secondary"

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
@@ -1,17 +1,20 @@
 import React, { ForwardedRef } from 'react';
 import { NumUtils } from '@common/utils';
 import { NumericTextInputProps, NumericTextInput } from './NumericTextInput';
+import { SxProps, Theme } from '@mui/material';
 
 interface NonNegativeNumberProps
   extends Omit<NumericTextInputProps, 'onChange'> {
   max?: number;
   onChange: (newValue: number) => void;
+  boxSx?: SxProps<Theme>;
 }
 
 // where NonNegative is n >=0
 export const NonNegativeNumberInput = React.forwardRef(
   (
     {
+      boxSx,
       sx,
       disabled = false,
       value,
@@ -22,6 +25,7 @@ export const NonNegativeNumberInput = React.forwardRef(
     ref: ForwardedRef<HTMLDivElement>
   ) => (
     <NumericTextInput
+      boxSx={boxSx}
       ref={ref}
       type="number"
       InputProps={{

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
@@ -1,15 +1,17 @@
 import React, { FC } from 'react';
-import { StandardTextFieldProps } from '@mui/material';
+import { StandardTextFieldProps, SxProps, Theme } from '@mui/material';
 import { BasicTextInput } from '../BasicTextInput';
 export interface NumericTextInputProps
   extends Omit<StandardTextFieldProps, 'onChange'> {
   onChange?: (value: number) => void;
   width?: number;
+  boxSx?: SxProps<Theme>;
 }
 
 export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
-  ({ sx, InputProps, width = 75, onChange, ...props }, ref) => (
+  ({ sx, InputProps, boxSx, width = 75, onChange, ...props }, ref) => (
     <BasicTextInput
+      boxSx={boxSx}
       ref={ref}
       sx={{
         '& .MuiInput-input': { textAlign: 'right', width: `${width}px` },

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeIntegerCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeIntegerCell.tsx
@@ -3,6 +3,7 @@ import { CellProps } from '../../../columns';
 import { NonNegativeNumberInput } from '@common/components';
 import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
+import { SxProps, Theme } from '@mui/material';
 
 // where NonNegative is n >=0
 export const NonNegativeIntegerCell = <T extends RecordWithId>({
@@ -11,13 +12,17 @@ export const NonNegativeIntegerCell = <T extends RecordWithId>({
   max,
   isDisabled = false,
   isRequired = false,
-}: CellProps<T> & { max?: number }): React.ReactElement<CellProps<T>> => {
+  boxSx,
+}: CellProps<T> & { max?: number; boxSx?: SxProps<Theme> }): React.ReactElement<
+  CellProps<T>
+> => {
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
 
   const updater = useDebounceCallback(column.setter, [column.setter], 250);
 
   return (
     <NonNegativeNumberInput
+      boxSx={boxSx}
       disabled={isDisabled}
       required={isRequired}
       InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -65,6 +65,11 @@ const NumberOfPacksCell: React.FC<CellProps<DraftInboundLine>> = ({
     {...props}
     isRequired={rowData.numberOfPacks === 0}
     rowData={rowData}
+    boxSx={{
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+    }}
   />
 );
 

--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -6,7 +6,6 @@ import {
   defaultOptionMapper,
   getDefaultOptionRenderer,
   InventoryAdjustmentReasonNodeType,
-  Typography,
 } from '@openmsupply-client/common';
 import {
   useInventoryAdjustmentReason,
@@ -76,23 +75,18 @@ export const InventoryAdjustmentReasonSearchInput: FC<
             }}
             sx={{ width }}
             error={isError && isRequired}
+            required={isRequired}
+            boxSx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+            }}
           />
         )}
         options={defaultOptionMapper(reasons, 'reason')}
         renderOption={getDefaultOptionRenderer('reason')}
         isOptionEqualToValue={(option, value) => option?.id === value?.id}
       />
-      {isRequired && (
-        <Typography
-          sx={{
-            color: 'primary.light',
-            paddingLeft: 0.5,
-            fontSize: '17px',
-          }}
-        >
-          *
-        </Typography>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
Fixes #1205 

# 👩🏻‍💻 What does this PR do? 
Have the basic text input box sx passed through props so that it doesn't mess with other components.

# 🧪 How has/should this change been tested? 
- Go an inbound shipment and see that the required field still looks the same...
- Number input components should no longer be left aligned

## 💌 Any notes for the reviewer?
This was a programs issue, but did it in develop since seemed relevant to other components too
