### PR TITLE
User incorrectly redirected to login screen 

### DIFF
--- a/client/packages/common/src/ui/components/modals/AlertModal/useAlertModal.ts
+++ b/client/packages/common/src/ui/components/modals/AlertModal/useAlertModal.ts
@@ -3,7 +3,7 @@ import { PartialBy } from '@common/types';
 import { AlertModalContext, AlertModalState } from './AlertModalContext';
 
 export const useAlertModal = ({
-  onOk,
+  onOk = () => {},
   message,
   title,
 }: PartialBy<AlertModalState, 'open'>) => {

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -23,14 +23,14 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
   mode,
   onChangeItem,
 }) => {
-  const t = useTranslation(['common', 'inventory']);
+  const t = useTranslation('inventory');
   const { items } = useStocktake.line.rows();
   const disabled = mode === ModalMode.Update;
 
   return (
     <>
       <ModalRow>
-        <ModalLabel label={t('label.item')} />
+        <ModalLabel label={t('label.item', { count: 1 })} />
         <Grid item flex={1} padding={1}>
           <StockItemSearchInput
             autoFocus={!item}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -153,7 +153,6 @@ const useStatusChangePlaceholderCheck = () => {
   const alert = useAlertModal({
     title: t('heading.cannot-do-that'),
     message: t('messages.must-allocate-all-lines'),
-    onOk: () => {},
   });
 
   const hasPlaceholder = useMemo(

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -153,6 +153,7 @@ const useStatusChangePlaceholderCheck = () => {
   const alert = useAlertModal({
     title: t('heading.cannot-do-that'),
     message: t('messages.must-allocate-all-lines'),
+    onOk: () => {},
   });
 
   const hasPlaceholder = useMemo(

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -77,7 +77,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
   return (
     <Grid container gap="4px">
       <ModalRow>
-        <ModalLabel label={t('label.item')} />
+        <ModalLabel label={t('label.item', { count: 1 })} />
         <Grid item flex={1}>
           <StockItemSearchInput
             autoFocus={!item}

--- a/server/report_builder/README.md
+++ b/server/report_builder/README.md
@@ -62,17 +62,17 @@ There are two sub commands:
 
 ```bash
 # Build a report definition template
-> report_build build
+> report_builder build
 # Print a report definition template
-> report_build print
+> report_builder print
 ```
 
 To see a full list of command line argument options use the `--help` flag:
 
 ```bash
-> report_build build --help
+> report_builder build --help
 # Print a report definition template
-> report_build print --help
+> report_builder print --help
 ```
 
 ### Build a report template definition
@@ -80,13 +80,13 @@ To see a full list of command line argument options use the `--help` flag:
 For example, to build the example template including header and footer using the default stocktake query:
 
 ```bash
-> report_build build --dir path/to/project --template template.html --header header.html --footer footer.html --query-default stocktake
+> report_builder build --dir path/to/project --template template.html --header header.html --footer footer.html --query-default stocktake
 ```
 
 To use a custom query instead, do:
 
 ```bash
-> report_build build --dir path/to/project --template template.html --header header.html --footer footer.html --query-gql query.graphql
+> report_builder build --dir path/to/project --template template.html --header header.html --footer footer.html --query-gql query.graphql
 ```
 
 On default this will create an `output.json` template definition file which can be uploaded to the central server.
@@ -95,7 +95,7 @@ On default this will create an `output.json` template definition file which can 
 ### Print a report template definition
 
 To print a report definition template a running remote-server is required.
-Moreover, report_build requires config details for how to access the remote-server.
+Moreover, report_builder requires config details for how to access the remote-server.
 To provide this information create a config file, e.g. `config.yaml`:
 
 ```yaml
@@ -110,7 +110,7 @@ The remote-server needs a store id and a data id to print the report.
 For example, to print a report for a stocktake with id "d734fd45-064e-4ddd-9886-ea71a2797640" from store "80004C94067A4CE5A34FC343EB1B4306":
 
 ```bash
-> report_build print --report output.json --config config.yaml --store-id 80004C94067A4CE5A34FC343EB1B4306 --data-id d734fd45-064e-4ddd-9886-ea71a2797640 --output report_pdf_name.pdf
+> report_builder print --report output.json --config config.yaml --store-id 80004C94067A4CE5A34FC343EB1B4306 --data-id d734fd45-064e-4ddd-9886-ea71a2797640 --output report_pdf_name.pdf
 ```
 
 ## References to other template definitions


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1137 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The `OK` button event on the OS status change alert modal was not being set and therefore retained the previous action, of a redirect to login, if the button is clicked after the user has been logged out due to inactivity.

🎩 tip to @andreievg for spotting the full scenario!

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Easiest way to repro 
- Login to the site
- Open dev tools, Application, Cookies and click on localhost ( if running locally )
- Delete the Auth cookie
- Wait a minute
- Click ok on the prompt, login again
- Go to Outbounds > click on an outbound
- Allocate some quantity to a placeholder
- Click on `Confirm Allocated`

![Screenshot 2023-02-27 at 5 37 17 PM](https://user-images.githubusercontent.com/9192912/221476137-b71c4e18-4069-4d64-a830-33a1a5ae7a62.png)

then wait for this

<img width="759" alt="Screenshot 2023-02-27 at 5 31 59 PM" src="https://user-images.githubusercontent.com/9192912/221476165-92540f76-2525-4cc9-8b2d-d9b2cf2ddbb6.png">


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
I spotted some offroads, as noted.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
