### PR TITLE
update number display

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -2,17 +2,13 @@ import React, { useState } from 'react';
 import { ControlProps, rankWith, schemaTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
+  DetailInputWithLabelRow,
   NumericTextInput,
   NumericTextInputProps,
   PositiveNumberInput,
   useDebounceCallback,
 } from '@openmsupply-client/common';
-import {
-  FORM_INPUT_COLUMN_WIDTH,
-  FORM_LABEL_COLUMN_WIDTH,
-} from '../styleConstants';
-import { Box } from '@mui/system';
-import { FormLabel } from '@mui/material';
+import { FORM_LABEL_WIDTH } from '../styleConstants';
 
 export const numberTester = rankWith(3, schemaTypeIs('number'));
 
@@ -45,24 +41,25 @@ const UIComponent = (props: ControlProps) => {
     value: localData ?? '',
   };
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="space-around"
-      style={{ minWidth: 300 }}
-      sx={{ margin: 0.5, marginLeft: 0, gap: 2 }}
-    >
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
-      </Box>
-      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
-        {schema.minimum !== undefined ? (
+    <DetailInputWithLabelRow
+      sx={{
+        margin: 0.5,
+        marginLeft: 0,
+        gap: 2,
+        minWidth: '300px',
+        justifyContent: 'space-around',
+      }}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment="start"
+      Input={
+        schema.minimum !== undefined ? (
           <PositiveNumberInput {...inputProps} min={schema.minimum} />
         ) : (
           <NumericTextInput {...inputProps} />
-        )}
-      </Box>
-    </Box>
+        )
+      }
+    />
   );
 };
 

--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -6,7 +6,6 @@ import {
   defaultOptionMapper,
   getDefaultOptionRenderer,
   InventoryAdjustmentReasonNodeType,
-  Typography,
 } from '@openmsupply-client/common';
 import {
   useInventoryAdjustmentReason,
@@ -76,23 +75,13 @@ export const InventoryAdjustmentReasonSearchInput: FC<
             }}
             sx={{ width }}
             error={isError && isRequired}
+            required={isRequired}
           />
         )}
         options={defaultOptionMapper(reasons, 'reason')}
         renderOption={getDefaultOptionRenderer('reason')}
         isOptionEqualToValue={(option, value) => option?.id === value?.id}
       />
-      {isRequired && (
-        <Typography
-          sx={{
-            color: 'primary.light',
-            paddingLeft: 0.5,
-            fontSize: '17px',
-          }}
-        >
-          *
-        </Typography>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1205

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Following on from #1241 - this PR is to left-align the `Number` JSONForms component. 
Also brought through the change from [Roxy's comment](https://github.com/openmsupply/open-msupply/pull/1241/files#r1118146638)

- Inbound shipment should show required indicator as it does before the PR
- Look at patient details: the `Birth Order` should align left, not right

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Manual testing, this one is alignment / UI

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
