### PR TITLE
#1110 add empty contact details to init persons

### DIFF
--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -192,13 +192,30 @@ const VL_ELIGIBILITY_REPORT: &'static str =
 const LTFU_REPORT: &'static str = std::include_str!("./program_schemas/report_ltfu.json");
 const GBV_REPORT: &'static str = std::include_str!("./program_schemas/report_gbv.json");
 
+const EMPTY_CONTACT_DETAILS: ContactDetails = {
+    ContactDetails {
+        description: None,
+        address_1: None,
+        address_2: None,
+        city: None,
+        country: None,
+        district: None,
+        region: None,
+        zip_code: None,
+        mobile: None,
+        phone: None,
+        email: None,
+        website: None,
+    }
+};
+
 fn person_1() -> RelatedPerson {
     RelatedPerson {
         id: Some("person1".to_string()),
         code: Some("id34568".to_string()),
         first_name: Some("Tom".to_string()),
         last_name: Some("Smith".to_string()),
-        contact_details: vec![],
+        contact_details: vec![EMPTY_CONTACT_DETAILS.clone()],
         date_of_birth: None,
         date_of_birth_is_estimated: None,
         birth_place: None,
@@ -220,7 +237,7 @@ fn person_2() -> RelatedPerson {
         code: Some("id41325".to_string()),
         first_name: Some("Eli".to_string()),
         last_name: Some("Bond".to_string()),
-        contact_details: vec![],
+        contact_details: vec![EMPTY_CONTACT_DETAILS.clone()],
         date_of_birth: None,
         date_of_birth_is_estimated: None,
         birth_place: None,
@@ -242,7 +259,7 @@ fn person_3() -> RelatedPerson {
         code: Some("id12245".to_string()),
         first_name: Some("Heidi".to_string()),
         last_name: Some("Tomalla".to_string()),
-        contact_details: vec![],
+        contact_details: vec![EMPTY_CONTACT_DETAILS.clone()],
         date_of_birth: None,
         date_of_birth_is_estimated: None,
         birth_place: None,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1110

## 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

As discussed in [this comment](https://github.com/openmsupply/open-msupply/issues/1110#issuecomment-1421841322), this PR just adds some empty info to the contact details for the related people, which prevents the warning in the original issue .

## 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Delete database, re-start server, then go to "Patients". The default patients "Tina Ling" and "Andy Cook" should be able to be viewed and switched away from (change tab) without any edit change warning.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

There's probably a better way to do this. It would be acceptable to have the array initialised with an empty object `[ { } ]` rather than adding "None" to every field, but couldn't figure out how to do that in Rust.