### PR TITLE
Remember android app state when switching apps

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -27,6 +27,7 @@ import javax.net.ssl.SSLHandshakeException;
 @CapacitorPlugin(name = "NativeApi")
 public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     public static final String OM_SUPPLY = "omSupply";
+    private static final String DEFAULT_URL = "https://localhost:8000/";
     DiscoveryConstants discoveryConstants;
     JSArray discoveredServers;
     Deque<NsdServiceInfo> serversToResolve;
@@ -83,6 +84,11 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     @Override
     protected void handleOnStart() {
         WebView webView = this.getBridge().getWebView();
+        // this method (handleOnStart) is called when resuming and switching to the app
+        // the webView url will be DEFAULT_URL only on the initial load
+        // so this test is a quick check to see if we should be redirecting to the /android loader or not
+        if (!webView.getUrl().matches(DEFAULT_URL)) return;
+        // Initial load, display splash screen and wait for the server to start
         webView.post(() -> webView.loadData(SplashPage.encodedHtml, "text/html", "base64"));
         // advertiseService();
         Thread thread = new Thread(new Runnable() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1188 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Started looking into registering for events / actions in order to save and restore the app state and URL. 
Then found that the `handleOnStart` method of plugins is called when resuming; simply checking the loaded URL tells us if this is the initial load or a resume.

So.. check the URL on start, and if we have the default url run through the current process of
- display the splash screen
- wait for the server to respond
- redirect to `/android`

and if we are resuming, don't bother with all that.

Have checked that closing the app does log you out; clearing app data gets you back to the initial splash screen process etc.

https://user-images.githubusercontent.com/9192912/222315385-562908e5-a1fa-4bdc-ad4f-50518f80e003.mp4


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Have played around to check behaviour:
- switched between apps to check that the state / url is retained
- closed the app, should ask you to login again
- clear app data and check that it requires set up again
- wait for the app to log you out and check that you are redirected to the login

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
