### PR TITLE
#1285 Fix for unable to create new patient

### DIFF
--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -30,7 +30,7 @@
   "messages.no-patient-record": "Can't access detailed information for this patient.",
   "messages.patients-found_one": "1 patient found matching the supplied details",
   "messages.patients-found_other": "{{count}} patients found matching the supplied details",
-  "messages.patients-create": "Click [Create] to add a new patient with the details entered, or click an existing patient below to view their details.",
+  "messages.patients-create": "Click [OK & Next] to add a new patient with the details entered, or click an existing patient below to view their details.",
   "messages.regenerate-id-confirm": "This will create a new ID and cannot be undone.",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-last-name": "Search by last name",

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -95,6 +95,11 @@ const additionalRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: encounterProgramEventTester, renderer: EncounterProgramEvent },
 ];
 
+/**
+ * @param docName the document name (if the document already exist)
+ * @param createDoc the initial data of of the document if the the document doesn't exist yet
+ */
+
 export const useJsonForms = (
   docName: string | undefined,
   options: JsonFormOptions = {},
@@ -162,16 +167,14 @@ export const useJsonForms = (
     const dirty =
       isSaving ||
       isLoading ||
-      // not sure why isDirty should be set if nothing has changed.. do we allow saving when the initial createDoc is presented?
-      // I've disabled, as this means that refreshing a page after rendering with createDoc set will prompt the user even
-      // when the modal is cancelled
-      // !!createDoc ||
+      // document doesn't exist yet; always set the isDirty flag
+      !!createDoc ||
       !isEqualIgnoreUndefined(initialData, data);
     setIsDirty(dirty);
     if (data === undefined) {
       setData(initialData);
     }
-  }, [initialData, data, isSaving, isLoading]);
+  }, [initialData, data, isSaving, isLoading, createDoc]);
 
   useEffect(() => {
     setData(initialData);

--- a/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
@@ -128,7 +128,7 @@ export const CreatePatientModal: FC<CreatePatientModal> = ({ onClose }) => {
       okButton={
         currentTab === Tabs.SearchResults ? (
           <DialogButton
-            variant="create"
+            variant="next"
             disabled={!patient?.canCreate}
             onClick={onOk}
           />

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openmsupply-client/programs';
 import { PatientPanel } from './PatientPanel';
 import { createPatient, createPatientUI } from './DefaultCreatePatientJsonForm';
-import { isEqual } from 'lodash';
+import { ObjUtils } from '@common/utils';
 
 type Patient = {
   code?: string;
@@ -35,7 +35,7 @@ export const PatientFormTab: FC<PatientPanel> = ({ patient, value }) => {
     ) {
       // Prevents infinite re-render if data hasn't actually changed, but
       // instance of "patient" has
-      if (isEqual(patient, newData)) return;
+      if (ObjUtils.isEqual(patient, newData)) return;
 
       const patientData = newData as Patient;
       updatePatient({

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
@@ -8,6 +8,7 @@ import {
 } from '@openmsupply-client/programs';
 import { PatientPanel } from './PatientPanel';
 import { createPatient, createPatientUI } from './DefaultCreatePatientJsonForm';
+import { isEqual } from 'lodash';
 
 type Patient = {
   code?: string;
@@ -32,6 +33,10 @@ export const PatientFormTab: FC<PatientPanel> = ({ patient, value }) => {
       newData !== null &&
       !Array.isArray(newData)
     ) {
+      // Prevents infinite re-render if data hasn't actually changed, but
+      // instance of "patient" has
+      if (isEqual(patient, newData)) return;
+
       const patientData = newData as Patient;
       updatePatient({
         code: patientData?.code,

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -78,9 +78,11 @@ const PatientDetailView: FC = () => {
   const handleSave = useUpsertPatient();
   const { JsonForm, saveData, isSaving, isDirty, validationError } =
     useJsonForms(patient ? undefined : documentName, { handleSave }, createDoc);
+
   useEffect(() => {
     return () => setNewPatient(undefined);
   }, []);
+
   const save = useCallback(async () => {
     const documentName = await saveData();
     if (documentName) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1285 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

I think this should fix the immediately reported problem from #1285, but it was only happening intermittently for me, so not 100% sure. However, it does fix the other two problems I noted on that thread and so I think it takes care of the main problem too. 

I think it was all due to the infinite re-render caused by the `setPatient` method causing a change in `patient` even though no actual data had changed, which in turn caused `setPatient` to re-run when the component re-rendered, etc. 

This is a problem I've encountered before -- when a state object changes its instance (due to a new object being created with ` {...originalState, ...newState }`) but not actually having any new data. It can be fixed by doing a deep equality check (in this case with `lodash`), but I feel like there should be a nicer way to prevent this kind of thing, so suggestions welcome!

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Follow the steps reported in the original issue and check that the problem has gone away. Also, you can add `console.log("patient", patient)` in `CreatePatientModal.ts` to note that the infinite re-render has been fixed (compare it with base branch).