### PR TITLE
Handle dashboard errors

### DIFF
--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -20,7 +20,12 @@ import { RequestInit } from 'graphql-request/dist/types.dom';
 
 export type SkipRequest = (documentNode: DocumentNode) => boolean;
 
-const permissionExceptions = ['reports', 'stockCounts', 'invoiceCounts'];
+const permissionExceptions = [
+  'reports',
+  'stockCounts',
+  'invoiceCounts',
+  'itemCounts',
+];
 interface ResponseError {
   message?: string;
   path?: string[];

--- a/client/packages/common/src/api/GqlContext.tsx
+++ b/client/packages/common/src/api/GqlContext.tsx
@@ -46,10 +46,10 @@ const handleResponseError = (errors: ResponseError[]) => {
     return;
   }
 
-  if (
-    hasError(errors, AuthError.PermissionDenied) &&
-    !hasPermissionException(errors)
-  ) {
+  if (hasError(errors, AuthError.PermissionDenied)) {
+    if (hasPermissionException(errors)) {
+      throw errors[0];
+    }
     LocalStorage.setItem('/auth/error', AuthError.PermissionDenied);
     return;
   }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -44,6 +44,7 @@
   "error.no-data": "No data available",
   "error.no-items": "No items",
   "error.no-items-filter-on": "No items to display. Try changing the filter criteria.",
+  "error.no-permission": "No permission to view this data",
   "error.no-report-permission": "No permission to view reports",
   "error.no-reports-available": "No reports available",
   "error.no-results": "Nothing here",

--- a/client/packages/common/src/intl/locales/en/dashboard.json
+++ b/client/packages/common/src/intl/locales/en/dashboard.json
@@ -5,6 +5,7 @@
   "heading.shipments-to-be-picked": "Shipments to be picked",
   "heading-stock": "Stock",
   "heading.stock-levels": "Stock levels",
+  "error.failed-to-create-requisition": "Failed to create requisition! {{message}}",
   "label.expired_one": "Expired batch",
   "label.expired_other": "Expired batches",
   "label.expiring-soon_one": "Batch close to expiry",

--- a/client/packages/common/src/types/exceptions.ts
+++ b/client/packages/common/src/types/exceptions.ts
@@ -1,0 +1,20 @@
+import { AuthError } from '../authentication';
+
+interface Extensions {
+  details: string;
+}
+
+interface Location {
+  column: number;
+  line: number;
+}
+
+interface ApiException {
+  extensions: Extensions;
+  locations: Location[];
+  message: string;
+  path: string[];
+}
+
+export const isPermissionDeniedException = (e?: any) =>
+  !!e && (e as ApiException).message === AuthError.PermissionDenied;

--- a/client/packages/common/src/types/exceptions.ts
+++ b/client/packages/common/src/types/exceptions.ts
@@ -9,12 +9,14 @@ interface Location {
   line: number;
 }
 
-interface ApiException {
+export interface ApiException {
   extensions: Extensions;
   locations: Location[];
   message: string;
   path: string[];
 }
 
-export const isPermissionDeniedException = (e?: any) =>
-  !!e && (e as ApiException).message === AuthError.PermissionDenied;
+export const isPermissionDeniedException = (e?: ApiException) =>
+  !!e &&
+  'message' in e &&
+  (e as ApiException).message === AuthError.PermissionDenied;

--- a/client/packages/common/src/types/exceptions.ts
+++ b/client/packages/common/src/types/exceptions.ts
@@ -17,6 +17,4 @@ export interface ApiException {
 }
 
 export const isPermissionDeniedException = (e?: ApiException) =>
-  !!e &&
-  'message' in e &&
-  (e as ApiException).message === AuthError.PermissionDenied;
+  !!e && 'message' in e && e.message === AuthError.PermissionDenied;

--- a/client/packages/common/src/types/index.ts
+++ b/client/packages/common/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './exceptions';
 export * from './utility';
 export * from './schema';
 export { UserStoreNodeFragment } from '../authentication/api/operations.generated';

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -2,14 +2,14 @@ import React, { FC } from 'react';
 import { Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { InlineSpinner, StockIcon } from '../../../';
 import { useTranslation } from '@common/intl';
-import { isPermissionDeniedException } from '@common/types';
+import { ApiException, isPermissionDeniedException } from '@common/types';
 
 export type Stat = {
   label: string;
   value?: string;
 };
 export interface StatsPanelProps {
-  error?: any;
+  error?: ApiException;
   isError?: boolean;
   isLoading: boolean;
   stats: Stat[];
@@ -64,7 +64,7 @@ const Content = ({
   isLoading,
   stats,
 }: {
-  error: any;
+  error?: ApiException;
   isError: boolean;
   isLoading: boolean;
   stats: Stat[];

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -2,12 +2,14 @@ import React, { FC } from 'react';
 import { Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { InlineSpinner, StockIcon } from '../../../';
 import { useTranslation } from '@common/intl';
+import { isPermissionDeniedException } from '@common/types';
 
 export type Stat = {
   label: string;
   value?: string;
 };
 export interface StatsPanelProps {
+  error?: any;
   isError?: boolean;
   isLoading: boolean;
   stats: Stat[];
@@ -57,20 +59,24 @@ const Statistic: FC<Stat> = ({ label, value }) => {
 };
 
 const Content = ({
+  error,
   isError,
   isLoading,
   stats,
 }: {
+  error: any;
   isError: boolean;
   isLoading: boolean;
   stats: Stat[];
 }) => {
   const t = useTranslation();
+  const isPermissionDenied = isPermissionDeniedException(error);
+
   switch (true) {
     case isError:
       return (
         <Typography sx={{ color: 'gray.main', fontSize: 12, marginLeft: 3.2 }}>
-          {t('error.no-data')}
+          {t(isPermissionDenied ? 'error.no-permission' : 'error.no-data')}
         </Typography>
       );
     case isLoading:
@@ -87,6 +93,7 @@ const Content = ({
 };
 
 export const StatsPanel: FC<StatsPanelProps> = ({
+  error,
   isError = false,
   isLoading,
   stats,
@@ -125,7 +132,12 @@ export const StatsPanel: FC<StatsPanelProps> = ({
         </Grid>
       </Grid>
       <Grid container justifyContent="space-between" alignItems="flex-end">
-        <Content isError={isError} isLoading={isLoading} stats={stats} />
+        <Content
+          isError={isError}
+          isLoading={isLoading}
+          stats={stats}
+          error={error}
+        />
       </Grid>
     </Grid>
   </Paper>

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -8,20 +8,16 @@ export type Stat = {
   value?: string;
 };
 export interface StatsPanelProps {
+  isError?: boolean;
   isLoading: boolean;
   stats: Stat[];
   title: string;
   width?: number;
 }
 
-export const StatsPanel: FC<StatsPanelProps> = ({
-  isLoading,
-  stats,
-  title,
-  width,
-}) => {
+const Statistic: FC<Stat> = ({ label, value }) => {
   const t = useTranslation();
-  const Statistic: FC<Stat> = ({ label, value }) => (
+  return (
     <Grid container alignItems="center" style={{ height: 30 }}>
       <Grid item>
         {value ? (
@@ -58,51 +54,79 @@ export const StatsPanel: FC<StatsPanelProps> = ({
       </Grid>
     </Grid>
   );
+};
 
-  return (
-    <Paper
-      sx={{
-        borderRadius: '16px',
-        marginTop: '14px',
-        marginBottom: '21px',
-        boxShadow: theme => theme.shadows[1],
-        padding: '14px 24px',
-        width: width ? `${width}px` : undefined,
-      }}
-    >
-      <Grid container>
-        <Grid alignItems="center" display="flex">
-          <Grid item style={{ marginInlineEnd: 8 }}>
-            <StockIcon
-              color="secondary"
-              style={{
-                height: 16,
-                width: 16,
-                fill: '#3568d4',
-              }}
-            />
-          </Grid>
-          <Grid item>
-            <Typography
-              color="secondary"
-              style={{ fontSize: 12, fontWeight: 500 }}
-            >
-              {title}
-            </Typography>
-          </Grid>
+const Content = ({
+  isError,
+  isLoading,
+  stats,
+}: {
+  isError: boolean;
+  isLoading: boolean;
+  stats: Stat[];
+}) => {
+  const t = useTranslation();
+  switch (true) {
+    case isError:
+      return (
+        <Typography sx={{ color: 'gray.main', fontSize: 12, marginLeft: 3.2 }}>
+          {t('error.no-data')}
+        </Typography>
+      );
+    case isLoading:
+      return <InlineSpinner color="secondary" />;
+    default:
+      return (
+        <Grid item>
+          {stats.map(stat => (
+            <Statistic key={stat.label} {...stat} />
+          ))}
         </Grid>
-        <Grid container justifyContent="space-between" alignItems="flex-end">
-          {isLoading ? (
-            <InlineSpinner color="secondary" />
-          ) : (
-            <Grid item>
-              {stats.map(stat => (
-                <Statistic key={stat.label} {...stat} />
-              ))}
-            </Grid>
-          )}
+      );
+  }
+};
+
+export const StatsPanel: FC<StatsPanelProps> = ({
+  isError = false,
+  isLoading,
+  stats,
+  title,
+  width,
+}) => (
+  <Paper
+    sx={{
+      borderRadius: '16px',
+      marginTop: '14px',
+      marginBottom: '21px',
+      boxShadow: theme => theme.shadows[1],
+      padding: '14px 24px',
+      width: width ? `${width}px` : undefined,
+    }}
+  >
+    <Grid container>
+      <Grid alignItems="center" display="flex">
+        <Grid item style={{ marginInlineEnd: 8 }}>
+          <StockIcon
+            color="secondary"
+            style={{
+              height: 16,
+              width: 16,
+              fill: '#3568d4',
+            }}
+          />
+        </Grid>
+        <Grid item>
+          <Typography
+            color="secondary"
+            style={{ fontSize: 12, fontWeight: 500 }}
+          >
+            {title}
+          </Typography>
         </Grid>
       </Grid>
-    </Paper>
-  );
-};
+      <Grid container justifyContent="space-between" alignItems="flex-end">
+        <Content isError={isError} isLoading={isLoading} stats={stats} />
+      </Grid>
+    </Grid>
+  </Paper>
+);

--- a/client/packages/dashboard/src/api/api.ts
+++ b/client/packages/dashboard/src/api/api.ts
@@ -1,8 +1,5 @@
 import { getSdk } from './operations.generated';
 
-export type DashboardApi = ReturnType<typeof getDashboardQueries> & {
-  storeId: string;
-};
 export type DashboardQueries = ReturnType<typeof getSdk>;
 
 export const getDashboardQueries = (

--- a/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
@@ -6,6 +6,9 @@ export const useItemCounts = (lowStockThreshold: number) => {
   return useQuery(
     api.keys.items(),
     () => api.get.itemCounts(lowStockThreshold),
-    { retry: false, onError: () => {} }
+    {
+      retry: false,
+      onError: () => {},
+    }
   );
 };

--- a/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/statistics/useItemCounts.ts
@@ -1,10 +1,11 @@
-import { useAuthContext, useQuery } from '@openmsupply-client/common';
+import { useQuery } from '@openmsupply-client/common';
 import { useDashboardApi } from './../utils/useDashboardApi';
 
 export const useItemCounts = (lowStockThreshold: number) => {
   const api = useDashboardApi();
-  const { storeId } = useAuthContext();
-  return useQuery(['dashboard', 'item-counts', storeId], () =>
-    api.get.itemCounts(lowStockThreshold)
+  return useQuery(
+    api.keys.items(),
+    () => api.get.itemCounts(lowStockThreshold),
+    { retry: false, onError: () => {} }
   );
 };

--- a/client/packages/dashboard/src/api/hooks/statistics/useStockCounts.ts
+++ b/client/packages/dashboard/src/api/hooks/statistics/useStockCounts.ts
@@ -1,10 +1,11 @@
-import { useAuthContext, useQuery } from '@openmsupply-client/common';
+import { useQuery } from '@openmsupply-client/common';
 import { useDashboardApi } from './../utils/useDashboardApi';
 
 export const useStockCounts = () => {
   const api = useDashboardApi();
-  const { storeId } = useAuthContext();
-  return useQuery(['dashboard', 'stock-counts', storeId], () =>
-    api.get.stockCounts()
-  );
+
+  return useQuery(api.keys.stock(), api.get.stockCounts, {
+    retry: false,
+    onError: () => {},
+  });
 };

--- a/client/packages/dashboard/src/api/hooks/utils/useDashboardApi.ts
+++ b/client/packages/dashboard/src/api/hooks/utils/useDashboardApi.ts
@@ -1,10 +1,18 @@
 import { useAuthContext, useGql } from '@openmsupply-client/common';
-import { DashboardApi, getDashboardQueries } from '../../api';
+import { getDashboardQueries } from '../../api';
 import { getSdk } from '../../operations.generated';
 
-export const useDashboardApi = (): DashboardApi => {
+export const useDashboardApi = () => {
+  const keys = {
+    base: () => ['dashboard'] as const,
+    count: () => [...keys.base(), 'count', storeId] as const,
+    items: () => [...keys.count(), 'items'] as const,
+    stock: () => [...keys.count(), 'stock'] as const,
+  };
+
   const { client } = useGql();
   const { storeId } = useAuthContext();
   const queries = getDashboardQueries(getSdk(client), storeId);
-  return { ...queries, storeId: storeId };
+
+  return { ...queries, storeId, keys };
 };

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -22,23 +22,16 @@ export const StockWidget: React.FC = () => {
   const { error } = useNotification();
   const t = useTranslation('dashboard');
   const formatNumber = useFormatNumber();
-  const { data: expiryData, isLoading: isExpiryLoading } =
-    useDashboard.statistics.stock();
-  const { data: itemCountsData, isLoading: isItemStatsLoading } =
-    useDashboard.statistics.item(LOW_MOS_THRESHOLD);
-  const [hasExpiryError, setHasExpiryError] = React.useState(false);
-  const [hasItemStatsError, setHasItemStatsError] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!isExpiryLoading && expiryData === undefined) setHasExpiryError(true);
-    return () => setHasExpiryError(false);
-  }, [expiryData, isExpiryLoading]);
-
-  React.useEffect(() => {
-    if (!isItemStatsLoading && itemCountsData === undefined)
-      setHasItemStatsError(true);
-    return () => setHasItemStatsError(false);
-  }, [itemCountsData, isItemStatsLoading]);
+  const {
+    data: expiryData,
+    isLoading: isExpiryLoading,
+    isError: hasExpiryError,
+  } = useDashboard.statistics.stock();
+  const {
+    data: itemCountsData,
+    isLoading: isItemStatsLoading,
+    isError: hasItemStatsError,
+  } = useDashboard.statistics.item(LOW_MOS_THRESHOLD);
 
   const { mutateAsync: onCreate } = useRequest.document.insert();
   const onError = (e: unknown) => {
@@ -73,52 +66,50 @@ export const StockWidget: React.FC = () => {
           flexDirection="column"
         >
           <Grid item>
-            {!hasExpiryError && (
-              <StatsPanel
-                isLoading={isExpiryLoading}
-                title={t('heading.expiring-stock')}
-                stats={[
-                  {
-                    label: t('label.expired', {
-                      count: Math.round(expiryData?.expired || 0),
-                    }),
-                    value: formatNumber.round(expiryData?.expired),
-                  },
-                  {
-                    label: t('label.expiring-soon', {
-                      count: Math.round(expiryData?.expiringSoon || 0),
-                    }),
-                    value: formatNumber.round(expiryData?.expiringSoon),
-                  },
-                ]}
-              />
-            )}
-            {!hasItemStatsError && (
-              <StatsPanel
-                isLoading={isItemStatsLoading}
-                title={t('heading.stock-levels')}
-                stats={[
-                  {
-                    label: t('label.total-items', {
-                      count: Math.round(itemCountsData?.total || 0),
-                    }),
-                    value: formatNumber.round(itemCountsData?.total || 0),
-                  },
-                  {
-                    label: t('label.items-no-stock', {
-                      count: Math.round(itemCountsData?.noStock || 0),
-                    }),
-                    value: formatNumber.round(itemCountsData?.noStock || 0),
-                  },
-                  {
-                    label: t('label.low-stock-items', {
-                      count: Math.round(itemCountsData?.lowStock || 0),
-                    }),
-                    value: formatNumber.round(itemCountsData?.lowStock || 0),
-                  },
-                ]}
-              />
-            )}
+            <StatsPanel
+              isError={hasExpiryError}
+              isLoading={isExpiryLoading}
+              title={t('heading.expiring-stock')}
+              stats={[
+                {
+                  label: t('label.expired', {
+                    count: Math.round(expiryData?.expired || 0),
+                  }),
+                  value: formatNumber.round(expiryData?.expired),
+                },
+                {
+                  label: t('label.expiring-soon', {
+                    count: Math.round(expiryData?.expiringSoon || 0),
+                  }),
+                  value: formatNumber.round(expiryData?.expiringSoon),
+                },
+              ]}
+            />
+            <StatsPanel
+              isError={hasItemStatsError}
+              isLoading={isItemStatsLoading}
+              title={t('heading.stock-levels')}
+              stats={[
+                {
+                  label: t('label.total-items', {
+                    count: Math.round(itemCountsData?.total || 0),
+                  }),
+                  value: formatNumber.round(itemCountsData?.total || 0),
+                },
+                {
+                  label: t('label.items-no-stock', {
+                    count: Math.round(itemCountsData?.noStock || 0),
+                  }),
+                  value: formatNumber.round(itemCountsData?.noStock || 0),
+                },
+                {
+                  label: t('label.low-stock-items', {
+                    count: Math.round(itemCountsData?.lowStock || 0),
+                  }),
+                  value: formatNumber.round(itemCountsData?.lowStock || 0),
+                },
+              ]}
+            />
           </Grid>
           <Grid
             item

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -19,16 +19,18 @@ const LOW_MOS_THRESHOLD = 3;
 
 export const StockWidget: React.FC = () => {
   const modalControl = useToggle(false);
-  const { error } = useNotification();
+  const { error: errorNotification } = useNotification();
   const t = useTranslation('dashboard');
   const formatNumber = useFormatNumber();
   const {
     data: expiryData,
+    error: expiryError,
     isLoading: isExpiryLoading,
     isError: hasExpiryError,
   } = useDashboard.statistics.stock();
   const {
     data: itemCountsData,
+    error: itemCountsError,
     isLoading: isItemStatsLoading,
     isError: hasItemStatsError,
   } = useDashboard.statistics.item(LOW_MOS_THRESHOLD);
@@ -36,7 +38,9 @@ export const StockWidget: React.FC = () => {
   const { mutateAsync: onCreate } = useRequest.document.insert();
   const onError = (e: unknown) => {
     const message = (e as Error).message ?? '';
-    const errorSnack = error(`Failed to create requisition! ${message}`);
+    const errorSnack = errorNotification(
+      `Failed to create requisition! ${message}`
+    );
     errorSnack();
   };
 
@@ -67,6 +71,7 @@ export const StockWidget: React.FC = () => {
         >
           <Grid item>
             <StatsPanel
+              error={expiryError}
               isError={hasExpiryError}
               isLoading={isExpiryLoading}
               title={t('heading.expiring-stock')}
@@ -86,6 +91,7 @@ export const StockWidget: React.FC = () => {
               ]}
             />
             <StatsPanel
+              error={itemCountsError}
               isError={hasItemStatsError}
               isLoading={isItemStatsLoading}
               title={t('heading.stock-levels')}

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  ApiException,
   ButtonWithIcon,
   FnUtils,
   Grid,
@@ -39,7 +40,7 @@ export const StockWidget: React.FC = () => {
   const onError = (e: unknown) => {
     const message = (e as Error).message ?? '';
     const errorSnack = errorNotification(
-      `Failed to create requisition! ${message}`
+      t('error.failed-to-create-requisition', { message })
     );
     errorSnack();
   };
@@ -71,7 +72,7 @@ export const StockWidget: React.FC = () => {
         >
           <Grid item>
             <StatsPanel
-              error={expiryError}
+              error={expiryError as ApiException}
               isError={hasExpiryError}
               isLoading={isExpiryLoading}
               title={t('heading.expiring-stock')}
@@ -91,7 +92,7 @@ export const StockWidget: React.FC = () => {
               ]}
             />
             <StatsPanel
-              error={itemCountsError}
+              error={itemCountsError as ApiException}
               isError={hasItemStatsError}
               isLoading={isItemStatsLoading}
               title={t('heading.stock-levels')}

--- a/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
@@ -6,7 +6,6 @@ import {
   PlusCircleIcon,
   StatsPanel,
   useNotification,
-  useQuery,
   useToggle,
   Widget,
 } from '@openmsupply-client/common';
@@ -18,18 +17,9 @@ import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   const modalControl = useToggle(false);
   const { error } = useNotification();
-  const api = useInbound.utils.api();
   const t = useTranslation(['app', 'dashboard']);
-  const [hasError, setHasError] = React.useState(false);
   const formatNumber = useFormatNumber();
-  const { data, isLoading } = useQuery(
-    ['inbound-shipment', 'count'],
-    api.dashboard.shipmentCount,
-    {
-      retry: false,
-      onError: () => setHasError(true),
-    }
-  );
+  const { data, isLoading, isError } = useInbound.utils.counts();
 
   const { mutateAsync: onCreate } = useInbound.document.insert();
   const onError = (e: unknown) => {
@@ -64,22 +54,21 @@ export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
           flexDirection="column"
         >
           <Grid item>
-            {!hasError && (
-              <StatsPanel
-                isLoading={isLoading}
-                title={t('inbound-shipments')}
-                stats={[
-                  {
-                    label: t('label.today', { ns: 'dashboard' }),
-                    value: formatNumber.round(data?.today),
-                  },
-                  {
-                    label: t('label.this-week', { ns: 'dashboard' }),
-                    value: formatNumber.round(data?.thisWeek),
-                  },
-                ]}
-              />
-            )}
+            <StatsPanel
+              isError={isError}
+              isLoading={isLoading}
+              title={t('inbound-shipments')}
+              stats={[
+                {
+                  label: t('label.today', { ns: 'dashboard' }),
+                  value: formatNumber.round(data?.today),
+                },
+                {
+                  label: t('label.this-week', { ns: 'dashboard' }),
+                  value: formatNumber.round(data?.thisWeek),
+                },
+              ]}
+            />
           </Grid>
           <Grid
             item

--- a/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
@@ -16,15 +16,17 @@ import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 
 export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   const modalControl = useToggle(false);
-  const { error } = useNotification();
+  const { error: errorNotification } = useNotification();
   const t = useTranslation(['app', 'dashboard']);
   const formatNumber = useFormatNumber();
-  const { data, isLoading, isError } = useInbound.utils.counts();
+  const { data, isLoading, isError, error } = useInbound.utils.counts();
 
   const { mutateAsync: onCreate } = useInbound.document.insert();
   const onError = (e: unknown) => {
     const message = (e as Error).message ?? '';
-    const errorSnack = error(`Failed to create requisition! ${message}`);
+    const errorSnack = errorNotification(
+      `Failed to create requisition! ${message}`
+    );
     errorSnack();
   };
 
@@ -55,6 +57,7 @@ export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
         >
           <Grid item>
             <StatsPanel
+              error={error}
               isError={isError}
               isLoading={isLoading}
               title={t('inbound-shipments')}

--- a/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/InboundShipment/Dashboard/Widget.tsx
@@ -10,7 +10,7 @@ import {
   Widget,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
-import { PropsWithChildrenOnly } from '@common/types';
+import { ApiException, PropsWithChildrenOnly } from '@common/types';
 import { useInbound } from '../api';
 import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 
@@ -25,7 +25,7 @@ export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   const onError = (e: unknown) => {
     const message = (e as Error).message ?? '';
     const errorSnack = errorNotification(
-      `Failed to create requisition! ${message}`
+      t('error.failed-to-create-requisition', { message })
     );
     errorSnack();
   };
@@ -57,7 +57,7 @@ export const InboundShipmentWidget: React.FC<PropsWithChildrenOnly> = () => {
         >
           <Grid item>
             <StatsPanel
-              error={error}
+              error={error as ApiException}
               isError={isError}
               isLoading={isLoading}
               title={t('inbound-shipments')}

--- a/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/index.ts
@@ -29,6 +29,7 @@ export const useInbound = {
   utils: {
     addFromMasterList: Utils.useAddFromMasterList,
     api: Utils.useInboundApi,
+    counts: Utils.useInboundCounts,
     isDisabled: Utils.useIsInboundDisabled,
     isStatusChangeDisabled: Utils.useIsStatusChangeDisabled,
   },

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/index.ts
@@ -2,10 +2,12 @@ import { useInboundApi } from './useInboundApi';
 import { useIsInboundDisabled } from './useIsInboundDisabled';
 import { useIsStatusChangeDisabled } from './useIsStatusChangeDisabled';
 import { useAddFromMasterList } from './useAddFromMasterList';
+import { useInboundCounts } from './useInboundCounts';
 
 export const Utils = {
   useInboundApi,
   useIsInboundDisabled,
   useIsStatusChangeDisabled,
   useAddFromMasterList,
+  useInboundCounts,
 };

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useInboundApi.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useInboundApi.ts
@@ -6,6 +6,7 @@ export const useInboundApi = () => {
   const { storeId } = useAuthContext();
   const keys = {
     base: () => ['inbound'] as const,
+    count: () => [...keys.base(), 'count'] as const,
     detail: (id: string) => [...keys.base(), storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useInboundCounts.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useInboundCounts.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@openmsupply-client/common';
+import { useInboundApi } from '../utils/useInboundApi';
+
+export const useInboundCounts = () => {
+  const api = useInboundApi();
+
+  return useQuery(api.keys.count(), api.dashboard.shipmentCount, {
+    retry: false,
+    onError: () => {},
+  });
+};

--- a/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
@@ -9,6 +9,7 @@ import {
   Widget,
   FnUtils,
   useToggle,
+  ApiException,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useOutbound } from '../api';
@@ -56,7 +57,7 @@ export const OutboundShipmentWidget: React.FC = () => {
         >
           <Grid item>
             <StatsPanel
-              error={error}
+              error={error as ApiException}
               isError={isError}
               isLoading={isLoading}
               title={t('heading.shipments-to-be-picked')}

--- a/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
@@ -5,12 +5,10 @@ import {
   Grid,
   PlusCircleIcon,
   useNotification,
-  useQuery,
   StatsPanel,
   Widget,
   FnUtils,
   useToggle,
-  useAuthContext,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useOutbound } from '../api';
@@ -20,15 +18,7 @@ export const OutboundShipmentWidget: React.FC = () => {
   const { error } = useNotification();
   const t = useTranslation(['app', 'dashboard']);
   const formatNumber = useFormatNumber();
-  const [hasError, setHasError] = React.useState(false);
-  const { store } = useAuthContext();
-
-  const api = useOutbound.utils.api();
-  const { data, isLoading } = useQuery(
-    ['outbound-shipment', 'count', store?.id],
-    api.dashboard.shipmentCount,
-    { retry: false, onError: () => setHasError(true) }
-  );
+  const { data, isLoading, isError } = useOutbound.utils.count();
 
   const { mutateAsync: onCreate } = useOutbound.document.insert();
   const onError = (e: unknown) => {
@@ -63,18 +53,17 @@ export const OutboundShipmentWidget: React.FC = () => {
           flexDirection="column"
         >
           <Grid item>
-            {!hasError && (
-              <StatsPanel
-                isLoading={isLoading}
-                title={t('heading.shipments-to-be-picked')}
-                stats={[
-                  {
-                    label: t('label.today', { ns: 'dashboard' }),
-                    value: formatNumber.round(data?.toBePicked),
-                  },
-                ]}
-              />
-            )}
+            <StatsPanel
+              isError={isError}
+              isLoading={isLoading}
+              title={t('heading.shipments-to-be-picked')}
+              stats={[
+                {
+                  label: t('label.today', { ns: 'dashboard' }),
+                  value: formatNumber.round(data?.toBePicked),
+                },
+              ]}
+            />
           </Grid>
           <Grid
             item

--- a/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
+++ b/client/packages/invoices/src/OutboundShipment/Dashboard/Widget.tsx
@@ -15,15 +15,17 @@ import { useOutbound } from '../api';
 
 export const OutboundShipmentWidget: React.FC = () => {
   const modalControl = useToggle(false);
-  const { error } = useNotification();
+  const { error: errorNotification } = useNotification();
   const t = useTranslation(['app', 'dashboard']);
   const formatNumber = useFormatNumber();
-  const { data, isLoading, isError } = useOutbound.utils.count();
+  const { data, isLoading, isError, error } = useOutbound.utils.count();
 
   const { mutateAsync: onCreate } = useOutbound.document.insert();
   const onError = (e: unknown) => {
     const message = (e as Error).message ?? '';
-    const errorSnack = error(`Failed to create invoice! ${message}`);
+    const errorSnack = errorNotification(
+      `Failed to create invoice! ${message}`
+    );
     errorSnack();
   };
 
@@ -54,6 +56,7 @@ export const OutboundShipmentWidget: React.FC = () => {
         >
           <Grid item>
             <StatsPanel
+              error={error}
               isError={isError}
               isLoading={isLoading}
               title={t('heading.shipments-to-be-picked')}

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
@@ -4,10 +4,11 @@ import { Document } from './document';
 
 export const useOutbound = {
   utils: {
+    addFromMasterList: Utils.useAddFromMasterList,
+    api: Utils.useOutboundApi,
+    count: Utils.useOutboundCounts,
     isDisabled: Utils.useOutboundIsDisabled,
     number: Utils.useOutboundNumber,
-    api: Utils.useOutboundApi,
-    addFromMasterList: Utils.useAddFromMasterList,
   },
 
   document: {

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/index.ts
@@ -1,6 +1,7 @@
 import { useOutboundNumber } from './useOutboundNumber';
 import { useOutboundIsDisabled } from './useOutboundIsDisabled';
 import { useOutboundApi } from './useOutboundApi';
+import { useOutboundCounts } from './useOutboundCounts';
 import { useAddFromMasterList } from './useAddFromMasterList';
 
 export const Utils = {
@@ -8,4 +9,5 @@ export const Utils = {
   useOutboundNumber,
   useOutboundIsDisabled,
   useOutboundApi,
+  useOutboundCounts,
 };

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundApi.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundApi.ts
@@ -17,6 +17,7 @@ export type ListParams = {
 export const useOutboundApi = () => {
   const keys = {
     base: () => ['outbound'] as const,
+    count: () => [...keys.base(), 'count', storeId] as const,
     detail: (id: string) => [...keys.base(), storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundCounts.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundCounts.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@openmsupply-client/common';
+import { useOutboundApi } from '../utils/useOutboundApi';
+
+export const useOutboundCounts = () => {
+  const api = useOutboundApi();
+
+  return useQuery(api.keys.count(), api.dashboard.shipmentCount, {
+    retry: false,
+    onError: () => {},
+  });
+};


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1224 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
There's a few file changes, but don't be put off! 
Essentially this is picking up on existing work, fixing an incorrect implementation in it and extending to a newer query that missed out on the change.

The process is:
- the `GqlContext` has a list of api calls which might throw a permission error but should not show an alert if they do ( the `itemCounts` dashboard query needed to be added to this list )
- the api calls should provide an `onError` which swallows the error ( note that errors are still logged to console, as an fyi )
- the `isError` prop is set on the `useQuery` response and this can be used to modify the UI response

As an extension to the current process, I've added a message when you don't have permission to view the stats. Simply hiding the panels ( previous behaviour ) results in a big blank page, with no indication that anything should be there. 

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/9192912/223573819-06ebbcd0-e935-4f2c-b1df-ef1c7ba0adda.png">

If there is a problem fetching, other than permission, you get a more generic notification:

<img width="1298" alt="Screenshot 2023-03-08 at 10 44 56 AM" src="https://user-images.githubusercontent.com/9192912/223566379-636e5a38-4554-4c5e-9be8-8dd2bacdcb67.png">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
1. Create a new user in mSupply
2. Grant them rights to login to one of the stores in the site which syncs to omSupply
3. Make that store default, and then do not assign any permissions in that store
4. login to omSupply as that user

You should see permission denied for the stats panels.

Extra for experts: grant permission for some of the requested permission and see what happens..

- InboundShipmentQuery (View supplier invoices )
- OutboundShipmentQuery (View customer invoices)
- StockLineQuery (View stock)

Unfortunately, the way the invoice counts query works, you need both inbound and outbound permission to see either widget 🙄 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Useful to add a note in the setup or dashboard sections about this with screenshot