### PR TITLE
1298 android url handling

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
@@ -4,12 +4,14 @@ import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.net.http.SslCertificate;
 import android.net.http.SslError;
 import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
 import android.webkit.SslErrorHandler;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
@@ -146,8 +148,7 @@ class CertWebViewClient extends ExtendedWebViewClient {
 
     @SuppressLint("WebViewClientOnReceivedSslError")
     @Override
-    public void onReceivedSslError(WebView view, SslErrorHandler handler,
-            SslError error) {
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
 
         // We are only handling self signed certificate errors (untrusted)
         if (error.getPrimaryError() != SslError.SSL_UNTRUSTED) {
@@ -190,5 +191,19 @@ class CertWebViewClient extends ExtendedWebViewClient {
 
             super.onReceivedSslError(view, handler, error);
         }
+    }
+
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+        // reloading a page ( javascript: navigate(0) or window.location.reload() )
+        // will not only reload, but will open the URL in a browser tab
+        // for local URLs we don't want this to happen!
+        Uri url = request.getUrl();
+        if(url.toString().startsWith(this.nativeApi.getServerUrl())) {
+            return false;
+        }
+
+        return bridge.launchIntent(url);
     }
 }

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -43,6 +43,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     boolean isDebug;
     boolean isAdvertising;
     String localUrl;
+    String serverUrl;
     boolean isDiscovering;
     boolean isResolvingServer;
     boolean shouldRestartDiscovery;
@@ -78,6 +79,9 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
     public String getLocalUrl() {
         return localUrl;
+    }
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     private void sleep(int delay) {
@@ -254,6 +258,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
         Bridge bridge = this.getBridge();
         WebView webView = bridge.getWebView();
+        this.serverUrl = url;
         // .post to run on UI thread
         webView.post(() -> webView.loadUrl(url));
     }

--- a/client/packages/common/src/ui/icons/MSupplyGuy.tsx
+++ b/client/packages/common/src/ui/icons/MSupplyGuy.tsx
@@ -73,9 +73,7 @@ export const AnimatedMSupplyGuy = styled(SvgGuy)(({ theme, size }) => {
     }),
     '&:hover': {
       animation:
-        size === 'large'
-          ? `${spin} 1s infinite ease`
-          : `${otherSpin} 1s infinite ease`,
+        size === 'large' ? `${spin} 1s  ease` : `${otherSpin} 1s 1 ease`,
     },
   };
 

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -33,6 +33,7 @@ pub mod android {
                     &Record::builder()
                         .args(format_args!("{}", record.args))
                         .target("omSupply")
+                        .module_path(Some("omSupply"))
                         .level(record.level)
                         .build(),
                 )
@@ -49,8 +50,6 @@ pub mod android {
         cache_dir: JString,
         android_id: JString,
     ) {
-        log_panics::init();
-
         let (off_switch, off_switch_receiver) = mpsc::channel(1);
         let files_dir: String = env.get_string(files_dir).unwrap().into();
         let files_dir = PathBuf::from(&files_dir);
@@ -84,11 +83,12 @@ pub mod android {
             ),
         };
 
-        // logging_init_with_appender(settings.logging.clone(), &AndroidLogger {});
         logging_init(
             settings.logging.clone(),
             Some(Box::new(|config| config.custom(AndroidLogger {}))),
         );
+        log_panics::init();
+        log::info!("omSupply server starting...");
 
         // run server in background thread
         let thread = thread::spawn(move || {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1298 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The issue is a strange behaviour in the webView - refreshing a page ( either with `window.location.reload()` or `navigate(0)` ) will reload *and* open the URL in a browser.

The change here is to overload the URL handling in the webView and if the URL is local, do not open in a browser.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
You'll need an android build.
Try the two actions in the issue, as well as a baseline external URL handling one:

- Change language (either the footer, or the admin > language selection)
- Create an outbound shipment from a customer requisition
- Open the docs: this should open in a browser

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
