### PR TITLE
Remove absolute positioning of version info

### DIFF
--- a/client/packages/host/src/Admin/Settings.tsx
+++ b/client/packages/host/src/Admin/Settings.tsx
@@ -180,39 +180,38 @@ export const Settings: React.FC = () => {
     ) : null;
 
   return (
-    <Grid
-      container
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={{ padding: 15, width: 500 }}
-      flexWrap="nowrap"
-    >
-      <Typography variant="h5" color="primary" style={{ paddingBottom: 25 }}>
-        {t('heading.settings-display')}
-      </Typography>
-      <Setting
-        component={<LanguageMenu />}
-        title={t('button.language')}
-        icon={<TranslateIcon />}
-      />
-      <SettingTextArea
-        defaultValue={customThemeValue}
-        onSave={saveTheme}
-        onToggle={onToggleCustomTheme}
-        title={t('heading.custom-theme')}
-      />
-      <SettingTextArea
-        defaultValue={customLogoValue}
-        onSave={saveLogo}
-        onToggle={onToggleCustomLogo}
-        title={t('heading.custom-logo')}
-      />
-      <SyncSettings />
-      <AndroidSettings />
-      <AppVersion
-        style={{ bottom: 30, right: 15 }}
-        SiteInfo={<SiteInfo siteName={initStatus?.siteName} />}
-      />
+    <Grid display="flex" flexDirection="column" flex={1}>
+      <Grid
+        container
+        flexDirection="column"
+        justifyContent="flex-start"
+        style={{ padding: 15, width: 500 }}
+        flexWrap="nowrap"
+      >
+        <Typography variant="h5" color="primary" style={{ paddingBottom: 25 }}>
+          {t('heading.settings-display')}
+        </Typography>
+        <Setting
+          component={<LanguageMenu />}
+          title={t('button.language')}
+          icon={<TranslateIcon />}
+        />
+        <SettingTextArea
+          defaultValue={customThemeValue}
+          onSave={saveTheme}
+          onToggle={onToggleCustomTheme}
+          title={t('heading.custom-theme')}
+        />
+        <SettingTextArea
+          defaultValue={customLogoValue}
+          onSave={saveLogo}
+          onToggle={onToggleCustomLogo}
+          title={t('heading.custom-logo')}
+        />
+        <SyncSettings />
+        <AndroidSettings />
+      </Grid>
+      <AppVersion SiteInfo={<SiteInfo siteName={initStatus?.siteName} />} />
     </Grid>
   );
 };

--- a/client/packages/host/src/components/AppVersion.tsx
+++ b/client/packages/host/src/components/AppVersion.tsx
@@ -13,14 +13,14 @@ export const AppVersion: FC<AppVersionProps> = ({ SiteInfo, style }) => {
   return (
     <Grid
       style={{
-        position: 'absolute',
-        right: 30,
-        bottom: 15,
+        flexGrow: 0,
+        alignSelf: 'flex-end',
         alignContent: 'flex-end',
         display: 'flex',
         flexDirection: 'column',
         ...style,
       }}
+      padding={1}
     >
       <Grid padding={1} paddingBottom={0}>
         <Grid item display="flex" flex={1} gap={1} justifyContent="flex-end">

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -96,7 +96,7 @@ export const Initialise = () => {
             !isInitialising /* isValid would be false if isInitialising since password is emptied out */
           }
         >
-          {/* Retry will only be shown when not loading and is initialised (when sync error occured) */}
+          {/* Retry will only be shown when not loading and is initialised (when sync error occurred) */}
           {isInitialising ? t('button.retry') : t('button.initialise')}
         </LoadingButton>
       }

--- a/client/packages/host/src/components/Initialise/InitialiseLayout.tsx
+++ b/client/packages/host/src/components/Initialise/InitialiseLayout.tsx
@@ -93,34 +93,42 @@ export const InitialiseLayout = ({
         flex="1 0 50%"
         sx={{
           backgroundColor: 'background.login',
-          alignItems: 'center',
-          justifyContent: 'center',
           overflowY: 'scroll',
         }}
         display="flex"
         flexDirection="column"
       >
-        <Box style={{ width: 285 }}>
-          <form onSubmit={onInitialise} onKeyDown={handleKeyDown}>
-            <Stack spacing={5}>
-              <Box display="flex" justifyContent="center">
-                <LoginIcon small />
-              </Box>
-              {UrlInput}
-              {UsernameInput}
-              {PasswordInput}
-              {ErrorMessage}
-              <Box display="flex" justifyContent="flex-end">
-                {Button}
-              </Box>
-            </Stack>
-          </form>
+        <Box
+          sx={{
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          display="flex"
+          flexDirection="column"
+          flex={1}
+        >
+          <Box style={{ width: 285 }}>
+            <form onSubmit={onInitialise} onKeyDown={handleKeyDown}>
+              <Stack spacing={5}>
+                <Box display="flex" justifyContent="center">
+                  <LoginIcon small />
+                </Box>
+                {UrlInput}
+                {UsernameInput}
+                {PasswordInput}
+                {ErrorMessage}
+                <Box display="flex" justifyContent="flex-end">
+                  {Button}
+                </Box>
+              </Stack>
+            </form>
+          </Box>
+          <Box paddingTop={2} width="100%">
+            {SyncProgress}
+          </Box>
         </Box>
-        <Box paddingTop={2} width="100%">
-          {SyncProgress}
-        </Box>
+        <AppVersion style={{ opacity: 0.4 }} SiteInfo={SiteInfo} />
       </Box>
-      <AppVersion style={{ opacity: 0.4 }} SiteInfo={SiteInfo} />
     </Box>
   );
 };

--- a/client/packages/host/src/components/Login/LoginLayout.tsx
+++ b/client/packages/host/src/components/Login/LoginLayout.tsx
@@ -117,8 +117,8 @@ export const LoginLayout = ({
             </form>
           </Box>
         </Box>
+        <AppVersion style={{ opacity: 0.4 }} SiteInfo={SiteInfo} />
       </Box>
-      <AppVersion style={{ opacity: 0.4 }} SiteInfo={SiteInfo} />
     </Box>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1297 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The version info was using absolute positioning to get it to stick to the bottom right of the screen. Have refactored the layout to use flex.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Checked on android and in a browser with various screen sizes. Examples below are android screenshots:

**Login**
<img width="1290" alt="Screenshot 2023-03-09 at 11 52 34 AM" src="https://user-images.githubusercontent.com/9192912/223875226-f5f218e3-a4c7-4dce-88eb-13d4210a4163.png">

<img width="1291" alt="Screenshot 2023-03-09 at 11 52 20 AM" src="https://user-images.githubusercontent.com/9192912/223875235-c03281a2-71bc-4a01-b0db-3ba8a08d11ae.png">

**Initialise**
<img width="1295" alt="Screenshot 2023-03-09 at 12 19 48 PM" src="https://user-images.githubusercontent.com/9192912/223875327-99f6c051-3424-4e74-af47-8b75fa3125d3.png">

<img width="1295" alt="Screenshot 2023-03-09 at 12 20 00 PM" src="https://user-images.githubusercontent.com/9192912/223875349-e845f019-0fd9-4d6f-8f5f-1816a4c9f48d.png">

**Settings**
<img width="1300" alt="Screenshot 2023-03-09 at 12 06 57 PM" src="https://user-images.githubusercontent.com/9192912/223875380-922ffa0e-1e90-4816-92fd-af6e6e1c34f3.png">


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
