### PR TITLE
#1308 add is active to name store join

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be seperated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -45,8 +45,7 @@ pub struct NameFilterInput {
     pub is_store: Option<bool>,
     /// Code of the store if store is linked to name
     pub store_code: Option<SimpleStringFilterInput>,
-    /// Visibility in current store (based on store_id parameter and existence of name_store_join record)
-    pub is_visible: Option<bool>,
+    pub is_active: Option<bool>,
     /// Show system names (defaults to false)
     /// System names don't have name_store_join thus if queried with true filter, is_visible filter should also be true or null
     /// if is_visible is set to true and is_system_name is also true no system names will be returned
@@ -118,7 +117,7 @@ impl NameFilterInput {
             is_supplier,
             is_store,
             store_code,
-            is_visible,
+            is_active,
             is_system_name,
             r#type,
         } = self;
@@ -131,7 +130,7 @@ impl NameFilterInput {
             is_customer,
             is_supplier,
             is_store,
-            is_visible,
+            is_active,
             is_system_name: is_system_name.or(Some(false)),
             r#type: r#type.map(|t| map_filter!(t, NameNodeType::to_domain)),
         }

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -120,7 +120,7 @@ mod graphql {
             "storeCode": {
               "like": "store code like"
             },
-            "isVisible": false,
+            "isActive": false,
             "isSystemName": true,
             "type": { "equalTo": "STORE" },
           }
@@ -160,7 +160,7 @@ mod graphql {
                 is_supplier,
                 is_store,
                 store_code,
-                is_visible,
+                is_active,
                 is_system_name,
                 r#type,
             } = filter.unwrap();
@@ -175,7 +175,7 @@ mod graphql {
                 store_code,
                 Some(SimpleStringFilter::like("store code like"))
             );
-            assert_eq!(is_visible, Some(false));
+            assert_eq!(is_active, Some(false));
             assert_eq!(is_system_name, Some(true));
             assert_eq!(
                 r#type,

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -16,6 +16,7 @@ table! {
         store_id -> Text,
         name_is_customer -> Bool,
         name_is_supplier -> Bool,
+        is_active -> Bool,
     }
 }
 
@@ -27,6 +28,7 @@ pub struct NameStoreJoinRow {
     pub store_id: String,
     pub name_is_customer: bool,
     pub name_is_supplier: bool,
+    pub is_active: bool,
 }
 
 joinable!(name_store_join -> store (store_id));

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -3,6 +3,7 @@ mod v1_00_04;
 mod v1_01_01;
 mod v1_01_02;
 mod v1_01_03;
+mod v1_01_05;
 mod version;
 pub(crate) use self::types::*;
 use self::v1_00_04::V1_00_04;
@@ -60,6 +61,7 @@ pub fn migrate(
         Box::new(V1_01_01),
         Box::new(V1_01_02),
         Box::new(V1_01_03),
+        Box::new(v1_01_05::V1_01_05),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_01_05/mod.rs
+++ b/server/repository/src/migrations/v1_01_05/mod.rs
@@ -1,0 +1,40 @@
+use super::{version::Version, Migration};
+use crate::StorageConnection;
+
+pub(crate) struct V1_01_05;
+
+impl Migration for V1_01_05 {
+    fn version(&self) -> Version {
+        Version::from_str("1.1.5")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        use crate::migrations::sql;
+
+        sql!(
+            connection,
+            r#"ALTER TABLE name_store_join
+                ADD is_active BOOLEAN;"#
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_01_05() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_01_05.version();
+
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/mock/name_store_join.rs
+++ b/server/repository/src/mock/name_store_join.rs
@@ -7,6 +7,7 @@ pub fn mock_name_store_join_a() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: false,
+        is_active: true,
     }
 }
 
@@ -17,6 +18,7 @@ pub fn mock_name_store_join_b() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: false,
+        is_active: true,
     }
 }
 
@@ -27,6 +29,7 @@ pub fn mock_name_store_join_c() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -37,6 +40,7 @@ pub fn mock_name_store_join_d() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -47,6 +51,7 @@ pub fn mock_name_store_join_e() -> NameStoreJoinRow {
         store_id: String::from("store_c"),
         name_is_customer: false,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 

--- a/server/repository/src/mock/test_name_query.rs
+++ b/server/repository/src/mock/test_name_query.rs
@@ -52,6 +52,7 @@ pub fn mock_name_1_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_2().id,
         name_is_customer: false,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -70,6 +71,7 @@ pub fn mock_name_2_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -88,6 +90,7 @@ pub fn mock_name_3_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -98,6 +101,7 @@ pub fn mock_name_3_join2() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_2().id,
         name_is_customer: false,
         name_is_supplier: false,
+        is_active: true,
     }
 }
 
@@ -116,5 +120,6 @@ pub fn name_a_umlaut_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }

--- a/server/repository/src/mock/test_name_store_id.rs
+++ b/server/repository/src/mock/test_name_store_id.rs
@@ -55,6 +55,7 @@ pub fn mock_name_linked_to_store_join() -> NameStoreJoinRow {
         store_id: "store_a".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -83,6 +84,7 @@ pub fn mock_name_linked_to_store_join_a() -> NameStoreJoinRow {
         store_id: "store_c".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -103,6 +105,7 @@ pub fn mock_name_not_linked_to_store_join() -> NameStoreJoinRow {
         store_id: "store_a".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -123,5 +126,6 @@ pub fn mock_name_not_linked_to_store_join_a() -> NameStoreJoinRow {
         store_id: "store_c".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -65,8 +65,6 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncPullReco
     test_records.append(&mut report::test_pull_delete_records());
     test_records.append(&mut store::test_pull_delete_records());
     test_records.append(&mut unit::test_pull_delete_records());
-    // Central but site specific
-    test_records.append(&mut name_store_join::test_pull_delete_records());
     test_records
 }
 

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -1,6 +1,6 @@
 use crate::sync::{
     test::TestSyncPullRecord,
-    translations::{LegacyTableName, PullDeleteRecordTable, PullUpsertRecord},
+    translations::{LegacyTableName, PullUpsertRecord},
 };
 use repository::NameStoreJoinRow;
 
@@ -27,6 +27,7 @@ fn name_store_join_1_pull_record() -> TestSyncPullRecord {
             name_id: "name_store_c".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
+            is_active: true,
         }),
     )
 }
@@ -43,10 +44,10 @@ const NAME_STORE_JOIN_2: (&'static str, &'static str) = (
       "store_ID": "store_b"
   }"#,
 );
-const NAME_STORE_JOIN_INACTIVE_2: (&'static str, &'static str) = (
-    "BE65A4A05E4D47E88303D6105A7872CC",
+const NAME_STORE_JOIN_INACTIVE: (&'static str, &'static str) = (
+    "some_inactive",
     r#"{
-      "ID": "BE65A4A05E4D47E88303D6105A7872CC",
+      "ID": "some_inactive",
       "inactive": true,
       "name_ID": "name_store_a",
       "spare_Category_ID": 0,
@@ -65,21 +66,24 @@ fn name_store_join_2_pull_record() -> TestSyncPullRecord {
             name_id: "name_store_a".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
+            is_active: true,
         }),
     )
 }
-fn name_store_join_2_delete_record() -> TestSyncPullRecord {
-    TestSyncPullRecord::new_pull_delete(
-        LegacyTableName::NAME_STORE_JOIN,
-        NAME_STORE_JOIN_2.0,
-        PullDeleteRecordTable::NameStoreJoin,
-    )
-}
 
-fn name_store_join_2_inactive_pull_record() -> TestSyncPullRecord {
-    let mut record = name_store_join_2_delete_record();
-    record.sync_buffer_row.data = NAME_STORE_JOIN_INACTIVE_2.1.to_string();
-    record
+fn name_store_inactive_join_pull_record() -> TestSyncPullRecord {
+    TestSyncPullRecord::new_pull_upsert(
+        LegacyTableName::NAME_STORE_JOIN,
+        NAME_STORE_JOIN_INACTIVE,
+        PullUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+            id: NAME_STORE_JOIN_INACTIVE.0.to_string(),
+            store_id: "store_b".to_string(),
+            name_id: "name_store_a".to_string(),
+            name_is_customer: false,
+            name_is_supplier: true,
+            is_active: false,
+        }),
+    )
 }
 
 // same as NAME_STORE_JOIN_2 but with new om fields
@@ -116,14 +120,6 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
     vec![
         name_store_join_1_pull_record(),
         name_store_join_2_pull_record(),
-        // name_store_join_3_pull_record(),
+        name_store_inactive_join_pull_record(), // name_store_join_3_pull_record(),
     ]
-}
-
-pub(crate) fn test_pull_delete_records() -> Vec<TestSyncPullRecord> {
-    vec![name_store_join_2_delete_record()]
-}
-
-pub(crate) fn test_pull_upsert_inactive_records() -> Vec<TestSyncPullRecord> {
-    vec![name_store_join_2_inactive_pull_record()]
 }

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -129,6 +129,7 @@ pub fn name_store_join1() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: false,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 
@@ -139,6 +140,7 @@ pub fn name_store_join2() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: false,
         name_is_supplier: false,
+        is_active: true,
     }
 }
 
@@ -149,6 +151,7 @@ pub fn name_store_join3() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: true,
         name_is_supplier: true,
+        is_active: true,
     }
 }
 


### PR DESCRIPTION
Fixes #1308 

# 👩🏻‍💻 What does this PR do? 
- Adds an is_active to name store join table
- Change is_visible filter to is_active

# 🧪 How has/should this change been tested? 
- Run tests

## 💌 Any notes for the reviewer?
- Programs will need to be updated from develop after this is merged and `patient_updated` will need updating

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2