### PR TITLE
#1240 Inbound shipment service charge tax pen icon glitch with calculating Service price total on fly

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
@@ -10,7 +10,8 @@ export const NonNegativeDecimalCell = <T extends RecordWithId>({
   column,
   isError,
   isDisabled = false,
-}: CellProps<T>): React.ReactElement<CellProps<T>> => {
+  max,
+}: CellProps<T> & { max?: number }): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData }) || ''
   );
@@ -20,6 +21,7 @@ export const NonNegativeDecimalCell = <T extends RecordWithId>({
   return (
     <NonNegativeNumberInput
       disabled={isDisabled}
+      max={max}
       InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}
       type="number"
       error={isError}

--- a/client/packages/common/src/utils/numbers/NumUtils.ts
+++ b/client/packages/common/src/utils/numbers/NumUtils.ts
@@ -12,4 +12,8 @@ export const NumUtils = {
 
     return constrain(parsed, min, max);
   },
+  round: (value: number, dp = 0): number => {
+    const multiplier = 10 ** dp;
+    return Math.round(value * multiplier) / multiplier;
+  },
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -29,6 +29,7 @@ export const PricingSectionComponent = () => {
   ]);
   const { data: stockLines } = useInbound.lines.list();
   const { mutateAsync: updateTax } = useInbound.document.updateTax();
+  const isInboundDisabled = useInbound.utils.isDisabled();
 
   const tax = PricingUtils.effectiveTax(
     pricing?.serviceTotalBeforeTax,
@@ -65,7 +66,7 @@ export const PricingSectionComponent = () => {
           )}`}</PanelLabel>
           <PanelField>
             <TaxEdit
-              disabled={!stockLines?.length}
+              disabled={!stockLines?.length || isInboundDisabled}
               tax={taxPercentage ?? 0}
               onChange={taxPercentage => {
                 update({ taxPercentage });
@@ -87,6 +88,7 @@ export const PricingSectionComponent = () => {
               icon={<EditIcon style={{ fontSize: 16, fill: 'none' }} />}
               label={t('label.edit')}
               onClick={serviceLineModal.toggleOn}
+              disabled={!stockLines?.length || isInboundDisabled}
             />
           </PanelField>
         </PanelRow>
@@ -98,8 +100,8 @@ export const PricingSectionComponent = () => {
           <PanelLabel>{`${t('heading.tax')} ${Formatter.tax(tax)}`}</PanelLabel>
           <PanelField>
             <TaxEdit
-              disabled={!stockLines?.length}
-              tax={tax}
+              disabled={!stockLines?.length || isInboundDisabled} 
+              tax={tax} 
               onChange={taxPercentage => {
                 updateTax({
                   lines: lines.nodes,

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -98,7 +98,7 @@ export const PricingSectionComponent = () => {
           <PanelLabel>{`${t('heading.tax')} ${Formatter.tax(tax)}`}</PanelLabel>
           <PanelField>
             <TaxEdit
-              disabled={true}
+              disabled={!stockLines?.length}
               tax={tax}
               onChange={taxPercentage => {
                 updateTax({

--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -98,7 +98,7 @@ export const PricingSectionComponent = () => {
           <PanelLabel>{`${t('heading.tax')} ${Formatter.tax(tax)}`}</PanelLabel>
           <PanelField>
             <TaxEdit
-              disabled={false}
+              disabled={true}
               tax={tax}
               onChange={taxPercentage => {
                 updateTax({

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/useDraftServiceLines.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/useDraftServiceLines.ts
@@ -46,7 +46,12 @@ export const useDraftServiceLines = () => {
   const update = (patch: RecordPatch<DraftInboundLine>) => {
     setDraftLines(currLines => {
       const newLines = currLines.map(line => {
-        if (line.id === patch.id) return { ...line, ...patch, isUpdated: true };
+        const taxAmount =
+          (patch.totalBeforeTax ?? 0) * ((patch.taxPercentage ?? 0) / 100);
+        const totalAfterTax = (patch.totalBeforeTax ?? 0) + taxAmount;
+        const newPatch = { ...patch, totalAfterTax };
+        if (line.id === patch.id)
+          return { ...line, ...newPatch, isUpdated: true };
         return line;
       });
       return newLines;

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/useServiceLineColumns.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/useServiceLineColumns.tsx
@@ -10,12 +10,17 @@ import {
   ColumnAlign,
   NonNegativeDecimalCell,
   useFormatCurrency,
+  CellProps,
 } from '@openmsupply-client/common';
 import {
   ServiceItemSearchInput,
   toItemWithPackSize,
 } from '@openmsupply-client/system';
 import { DraftInboundLine } from './../../../../types';
+
+const TaxPercentageCell = (props: CellProps<DraftInboundLine>) => (
+  <NonNegativeDecimalCell max={100} {...props} />
+);
 
 export const useServiceLineColumns = (
   setter: (patch: RecordPatch<DraftInboundLine>) => void
@@ -62,7 +67,7 @@ export const useServiceLineColumns = (
       label: 'label.tax',
       width: 75,
       setter,
-      Cell: NonNegativeDecimalCell,
+      Cell: TaxPercentageCell,
     },
     {
       key: 'totalAfterTax',

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/TaxEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/TaxEdit.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   EditIcon,
   useToggle,
+  NumUtils,
 } from '@openmsupply-client/common';
 
 interface TaxEditProps {
@@ -31,8 +32,8 @@ export const TaxEdit = ({ disabled = false, tax, onChange }: TaxEditProps) => {
           max={100}
           isOpen={modalController.isOn}
           onClose={modalController.toggleOff}
-          onChange={onChange}
-          initialValue={tax}
+          onChange={value => onChange(NumUtils.round(value, 2))}
+          initialValue={NumUtils.round(tax, 2)}
           title={t('heading.edit-tax-rate')}
         />
       )}

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -443,6 +443,7 @@ export const InvoiceCountsDocument = gql`
 export const UpsertInboundShipmentDocument = gql`
     mutation upsertInboundShipment($storeId: String!, $input: BatchInboundShipmentInput!) {
   batchInboundShipment(storeId: $storeId, input: $input) {
+    __typename
     updateInboundShipments {
       id
       response {

--- a/client/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -368,6 +368,7 @@ mutation upsertInboundShipment(
   $input: BatchInboundShipmentInput!
 ) {
   batchInboundShipment(storeId: $storeId, input: $input) {
+    __typename
     updateInboundShipments {
       id
       response {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useDraftServiceLines.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useDraftServiceLines.ts
@@ -71,13 +71,18 @@ export const useDraftServiceLines = () => {
   const update = (patch: RecordPatch<DraftOutboundLine>) => {
     setDraftLines(currLines => {
       const newLines = currLines.map(line => {
-        if (line.id === patch.id) return { ...line, ...patch, isUpdated: true };
+        const taxAmount =
+          (patch.totalBeforeTax ?? 0) * ((patch.taxPercentage ?? 0) / 100);
+        const totalAfterTax = (patch.totalBeforeTax ?? 0) + taxAmount;
+        const newPatch = { ...patch, totalAfterTax };
+        if (line.id === patch.id)
+          return { ...line, ...newPatch, isUpdated: true };
         return line;
       });
       return newLines;
     });
   };
-
+  
   const add = () => {
     setDraftLines(currLines => {
       if (defaultServiceItem) {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
@@ -10,9 +10,14 @@ import {
   NonNegativeDecimalCell,
   TextInputCell,
   useFormatCurrency,
+  CellProps,
 } from '@openmsupply-client/common';
 import { ServiceItemSearchInput } from '@openmsupply-client/system';
 import { DraftOutboundLine } from './../../../types';
+
+const TaxPercentageCell = (props: CellProps<DraftOutboundLine>) => (
+  <NonNegativeDecimalCell max={100} {...props} />
+);
 
 export const useServiceLineColumns = (
   setter: (patch: RecordPatch<DraftOutboundLine>) => void
@@ -57,7 +62,7 @@ export const useServiceLineColumns = (
       label: 'label.tax',
       width: 75,
       setter,
-      Cell: NonNegativeDecimalCell,
+      Cell: TaxPercentageCell,
     },
     {
       key: 'totalAfterTax',

--- a/client/packages/invoices/src/OutboundShipment/DetailView/modals/TaxEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/modals/TaxEdit.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   EditIcon,
   useToggle,
+  NumUtils,
 } from '@openmsupply-client/common';
 
 interface TaxEditProps {
@@ -31,8 +32,8 @@ export const TaxEdit = ({ disabled = false, tax, update }: TaxEditProps) => {
           max={100}
           isOpen={modalController.isOn}
           onClose={modalController.toggleOff}
-          onChange={newValue => update(newValue)}
-          initialValue={tax}
+          onChange={value => update(NumUtils.round(value, 2))}
+          initialValue={NumUtils.round(tax, 2)}
           title={t('heading.edit-tax-rate')}
         />
       )}


### PR DESCRIPTION
Fixes #1240 

# 👩🏻‍💻 What does this PR do? 
This will disable the Tax pen icon disable for the Service charges section

![Screen Shot 2023-03-09 at 2 03 10 PM](https://user-images.githubusercontent.com/13144882/223963092-3c2659c6-4bdf-41bc-8afd-4633d4f648c8.png)

## 💌 Any notes for the reviewer?

~Considering the workflow of Outbound > Service charges section, This does not get enabled at all so considering that, thinking is, The service charges are yet to get applied.~
~So, Have disabled the Tax pen icon on Inbound shipment as well.~

~Also, It seems, Service charge is per line, Does not make sense though, and there is no handler in Backend to the best of my understanding.~

The issue is the GraphQl Typename.