### PR TITLE
Android prints report as text, not HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-msupply",
-  "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be seperated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
+  "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
   "version": "1.1.4",
   "private": true,
   "scripts": {

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -161,30 +161,30 @@ fn print_html_report_to_html(
 /// Puts the document content, header and footer into a <html> template.
 /// This assumes that the document contains the html body.
 fn format_html_document(document: GeneratedReport) -> String {
+    // ensure that <html> is at the start of the text
+    // if not, the cordova printer plugin renders as text not HTML!
     format!(
-        "
-<html>
+        "<html>
     <body>
         <table class=\"paging\">
-        <thead>
-            <tr>
-            <td>{}</td>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-            <td>{}</td>
-            </tr>
-        </tbody>
-        <tfoot>
-            <tr>
-            <td>{}</td>
-            </tr>
-        </tfoot>
+            <thead>
+                <tr>
+                <td>{}</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                <td>{}</td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                <td>{}</td>
+                </tr>
+            </tfoot>
         </table>
     </body>
-</html>
-",
+</html>",
         document.header.unwrap_or("".to_string()),
         document.document,
         document.footer.unwrap_or("".to_string())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1316 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The cordova printing plugin was not interpreting the supplied text as HTML because of a leading space. The change in #1235 tidied up the HTML template, and introduced a newline before the `<html>` tag. That's enough to throw the plugin

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Deploy the `open-msupply-1.1.5-debug-with-printing-and-logout.apk` or `open-msupply-1.1.5-release-with-printing-and-logout.apk` builds to a tablet; add an oms report to mSupply, sync, and then try to print it.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
