### PR TITLE
Retain locally saved language option

### DIFF
--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -113,7 +113,10 @@ export const useLogin = (
       },
     };
 
-    changeLanguage(userDetails?.language);
+    const localLanguage = LocalStorage.getItem('/localisation/locale');
+    if (localLanguage === null) {
+      changeLanguage(userDetails?.language);
+    }
     setMRUCredentials({ username, store });
     setAuthCookie(authCookie);
     setCookie(authCookie);

--- a/client/packages/host/src/components/Footer/LanguageSelector.tsx
+++ b/client/packages/host/src/components/Footer/LanguageSelector.tsx
@@ -5,9 +5,10 @@ import {
   PaperPopoverSection,
   usePaperClickPopover,
   useTranslation,
-  IntlUtils,
   useNavigate,
+  LocalStorage,
 } from '@openmsupply-client/common';
+import { IntlUtils, SupportedLocales } from '@common/intl';
 
 import { PropsWithChildrenOnly } from '@common/types';
 
@@ -24,6 +25,10 @@ export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
       disabled={l.value === i18n.language}
       onClick={() => {
         i18n.changeLanguage(l.value);
+        LocalStorage.setItem(
+          '/localisation/locale',
+          l.value as SupportedLocales
+        );
         hide();
         navigate(0);
       }}

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {
-  IntlUtils,
   useNavigate,
   Select,
   MenuItem,
   Option,
+  LocalStorage,
 } from '@openmsupply-client/common';
+import { IntlUtils, SupportedLocales } from '@common/intl';
 
 export const LanguageMenu: React.FC = () => {
   const navigate = useNavigate();
@@ -13,6 +14,7 @@ export const LanguageMenu: React.FC = () => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     i18n.changeLanguage(value);
+    LocalStorage.setItem('/localisation/locale', value as SupportedLocales);
     navigate(0);
   };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1332 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
When the language is manually selected in the app, this option is saved.
On login, this language is used for the app. ( note that retention of the language option is handled by i18next )

If the user has not selected a language, then the current behaviour remains: the language configured for the user in mSupply is applied.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Login as a user - check that their language from mSupply is used.
Logout and login: confirm that the language is the mSupply configured language
Manually change the language: logout and login: confirm that the manually applied language is retained

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
