### PR TITLE
1359 Programs: patient detailed view's header => remove "Health" from National Health ID

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -149,7 +149,7 @@
   "label.forecast-quantity": "Suggested Quantity",
   "label.hold": "Hold",
   "label.in-store": "In Store (packs)",
-  "label.patient-id": "National Health ID",
+  "label.patient-id": "National ID (NID)",
   "label.patient-nuic": "NUIC",
   "label.invoice-number": "Number",
   "label.issue": "Issue",

--- a/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientJsonForm.ts
+++ b/client/packages/system/src/Patient/CreatePatientModal/DefaultCreatePatientJsonForm.ts
@@ -57,7 +57,7 @@ export const createPatientUI = {
     {
       type: 'Control',
       scope: '#/properties/code',
-      label: 'National Health ID',
+      label: 'National ID (NID)',
       options: {
         pattern: '^[0-9]{10}$',
         examples: ['1234567890'],

--- a/server/service/src/sync/program_schemas/patient_creation_ui_schema.json
+++ b/server/service/src/sync/program_schemas/patient_creation_ui_schema.json
@@ -4,7 +4,7 @@
     {
       "type": "Control",
       "scope": "#/properties/code",
-      "label": "National Health ID",
+      "label": "National ID (NID)",
       "options": {
         "pattern": "^[0-9]{10}$",
         "examples": ["1234567890"]


### PR DESCRIPTION
Fixes #1359

# 👩🏻‍💻 What does this PR do? 
Rename all `National Health ID` to `National ID (NID)
