### PR TITLE
#1368 Leading 0 in filter fix

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -5,7 +5,7 @@ import { useHideOverStocked } from '../index';
 import { useRequestFields } from '../document/useRequestFields';
 
 const useItemFilter = () => {
-  const { urlQuery, updateQuery } = useUrlQuery();
+  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['itemName'] });
   return {
     itemFilter: urlQuery.itemName ?? '',
     setItemFilter: (itemFilter: string) =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1368

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Fixes the leading 0 problem as described in [the issue](#1368). 

Also -- since @alainsussol was attempting to filter by digits, it would suggest he was trying to search for a code, so I've expanded the filter to match **code** as well as item **name**. This also makes it consistent with the item filter on the Catagloue -> Items page.

# 🧪 How has/should this change been tested? 

Create a new Internal Order as per issue steps. You should be able to filter added items by name or code, and starting the filter string with a `0` shouldn't make any difference.