### PR TITLE
1340 adherence score graph

### DIFF
--- a/client/packages/programs/src/api/hooks/document/useEncounterPrevious.ts
+++ b/client/packages/programs/src/api/hooks/document/useEncounterPrevious.ts
@@ -3,7 +3,8 @@ import { useEncounterApi } from '../utils/useEncounterApi';
 
 export const useEncounterPrevious = (
   patientId: string | undefined,
-  currentEncounter: Date
+  currentEncounter: Date,
+  enabled?: boolean
 ) => {
   const api = useEncounterApi();
 
@@ -11,7 +12,7 @@ export const useEncounterPrevious = (
     ...useQuery(
       api.keys.previous(patientId ?? '', currentEncounter.getTime()),
       () => api.previousEncounters(patientId ?? '', currentEncounter),
-      { enabled: !!patientId }
+      { enabled: enabled !== false && !!patientId }
     ),
   };
 };

--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -475,7 +475,7 @@ fn encounter_hiv_care_2(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.arv_medication = Some(inline_init(
             |e: &mut hiv_care_encounter::HivcareEncounterArvMedication| {
                 e.remaining_pill_count = Some(2.0);
-                e.quantity_prescribed = Some(8.0);
+                e.quantity_prescribed = Some(10.0);
                 e.adherence_score = Some(85.7142835884354);
                 e.regimen = Some("1a-New".to_string());
                 e.regimen_status = Some("CONTINUE".to_string());
@@ -503,7 +503,7 @@ fn encounter_hiv_care_3(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.arv_medication = Some(inline_init(
             |e: &mut hiv_care_encounter::HivcareEncounterArvMedication| {
                 e.remaining_pill_count = Some(5.0);
-                e.quantity_prescribed = Some(8.0);
+                e.quantity_prescribed = Some(9.0);
                 e.adherence_score = Some(42.85714108560097);
                 e.regimen = Some("2a-New".to_string());
                 e.regimen_status = Some("CHANGE".to_string());

--- a/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
@@ -451,8 +451,8 @@
           "options": {
             "values": [
               {
-                "field": "arvMedication.adherenceStatus",
-                "label": "Adherence Status",
+                "field": "arvMedication.adherenceScore",
+                "label": "Adherence Score",
                 "unit": "%"
               }
             ]

--- a/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter_ui_schema.json
@@ -411,7 +411,10 @@
           "scope": "#",
           "label": "Adherence Score",
           "options": {
-            "previousCountField": "arvMedication.quantityPrescribed",
+            "previousCount": {
+              "source": "EncounterEvent",
+              "eventType": "arvMedicationQuantityPrescribed"
+            },
             "remainingCountField": "arvMedication.remainingPillCount",
             "countPerDay": 1,
             "targetField": "arvMedication.adherenceScore"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1340
Fixes #920

# 👩🏻‍💻 What does this PR do? 
- For #1340 it was just about fixing a recent variable rename
- While doing it I also quickly fixed the live data update for graphs
- Then I noticed an inconsistency with the Adherence score control, e.g. in the UI the `Pill Count (at last visit end):` was displayed from the previous event but the adherence score still used the previous encounter. (The previous encounter may not have an previous count though which leads to inconsistent results. Using the event makes it more robust...) The Adherence score control can not take the `previous pill count` from the previous encounter or from the previous event.

# Testing:

- [ ] Adherence graph is not working
- [ ] When updating a graph value the graph should update as well (e.g. change `Pill Count (at visit start)` to update the score)
- [ ] Adherence score control should work if previous encounter has no `Quantity of pills dispensed`, e.g. the one latest Care encounter in the demo data