### PR TITLE
#1351 no service charge improvement

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -48,7 +48,6 @@
   "error.no-report-permission": "No permission to view reports",
   "error.no-reports-available": "No reports available",
   "error.no-results": "Nothing here",
-  "error.no-service-charges": "There are no service charges assigned to this store",
   "error.something-wrong": "Oops! Something's gone wrong.",
   "error.unable-to-load-data": "An error has occurred: there was a problem loading the data.",
   "error.unable-to-read-barcode": "Unable to read a barcode",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -48,6 +48,7 @@
   "error.no-report-permission": "No permission to view reports",
   "error.no-reports-available": "No reports available",
   "error.no-results": "Nothing here",
+  "error.no-service-charges": "There are no service charges assigned to this store",
   "error.something-wrong": "Oops! Something's gone wrong.",
   "error.unable-to-load-data": "An error has occurred: there was a problem loading the data.",
   "error.unable-to-read-barcode": "Unable to read a barcode",

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
@@ -91,7 +91,7 @@ const InboundServiceLineEditComponent = ({
               dense
               noDataMessage={
                 !hasDefaultServiceItem.defaultServiceItem
-                  ? t('error.no-service-charges')
+                  ? 'There are no service charges assigned to this store'
                   : t('error.no-results')
               }
             />

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
@@ -91,7 +91,7 @@ const InboundServiceLineEditComponent = ({
               dense
               noDataMessage={
                 !hasDefaultServiceItem.defaultServiceItem
-                  ? 'There are no service charges assigned to this store'
+                  ? t('error.no-service-charges')
                   : t('error.no-results')
               }
             />

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundServiceLineEdit/InboundServiceLineEdit.tsx
@@ -17,7 +17,10 @@ import {
 import { useInbound } from '../../../api';
 import { useDraftServiceLines } from './useDraftServiceLines';
 import { useServiceLineColumns } from './useServiceLineColumns';
-import { ItemRowFragment } from '@openmsupply-client/system';
+import {
+  ItemRowFragment,
+  useDefaultServiceItem,
+} from '@openmsupply-client/system';
 
 interface InboundServiceLineEditProps {
   isOpen: boolean;
@@ -34,6 +37,7 @@ const InboundServiceLineEditComponent = ({
   const { lines, update, add, save, isLoading } = useDraftServiceLines();
   const columns = useServiceLineColumns(update);
   const t = useTranslation('replenishment');
+  const hasDefaultServiceItem = useDefaultServiceItem();
 
   return (
     <Modal
@@ -66,7 +70,7 @@ const InboundServiceLineEditComponent = ({
             display="flex"
           >
             <ButtonWithIcon
-              disabled={isDisabled}
+              disabled={isDisabled || !hasDefaultServiceItem.defaultServiceItem}
               color="primary"
               variant="outlined"
               onClick={add}
@@ -85,6 +89,11 @@ const InboundServiceLineEditComponent = ({
               columns={columns}
               data={lines.filter(({ isDeleted }) => !isDeleted)}
               dense
+              noDataMessage={
+                !hasDefaultServiceItem.defaultServiceItem
+                  ? 'There are no service charges assigned to this store'
+                  : t('error.no-results')
+              }
             />
           </TableProvider>
         </Box>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
@@ -17,7 +17,10 @@ import {
 import { useOutbound } from '../../api';
 import { useDraftServiceLines } from './useDraftServiceLines';
 import { useServiceLineColumns } from './useServiceLineColumns';
-import { ItemRowFragment } from '@openmsupply-client/system';
+import {
+  ItemRowFragment,
+  useDefaultServiceItem,
+} from '@openmsupply-client/system';
 interface OutboundServiceLineEditProps {
   isOpen: boolean;
   onClose: () => void;
@@ -33,6 +36,7 @@ const OutboundServiceLineEditComponent = ({
   const { lines, update, add, save, isLoading } = useDraftServiceLines();
   const columns = useServiceLineColumns(update);
   const t = useTranslation('distribution');
+  const hasDefaultServiceItem = useDefaultServiceItem();
 
   return (
     <Modal
@@ -65,7 +69,7 @@ const OutboundServiceLineEditComponent = ({
             display="flex"
           >
             <ButtonWithIcon
-              disabled={isDisabled}
+              disabled={isDisabled || !hasDefaultServiceItem.defaultServiceItem}
               color="primary"
               variant="outlined"
               onClick={add}
@@ -84,6 +88,11 @@ const OutboundServiceLineEditComponent = ({
               columns={columns}
               data={lines.filter(({ isDeleted }) => !isDeleted)}
               dense
+              noDataMessage={
+                !hasDefaultServiceItem.defaultServiceItem
+                  ? 'There are no service charges assigned to this store'
+                  : t('error.no-results')
+              }
             />
           </TableProvider>
         </Box>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
@@ -90,7 +90,7 @@ const OutboundServiceLineEditComponent = ({
               dense
               noDataMessage={
                 !hasDefaultServiceItem.defaultServiceItem
-                  ? t('error.no-service-charges')
+                  ? 'There are no service charges assigned to this store'
                   : t('error.no-results')
               }
             />

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/OutboundServiceLineEdit.tsx
@@ -90,7 +90,7 @@ const OutboundServiceLineEditComponent = ({
               dense
               noDataMessage={
                 !hasDefaultServiceItem.defaultServiceItem
-                  ? 'There are no service charges assigned to this store'
+                  ? t('error.no-service-charges')
                   : t('error.no-results')
               }
             />


### PR DESCRIPTION
Fixes #1351 

# 👩🏻‍💻 What does this PR do? 
 
- If no service charges (Outbound and Inbound):
   - Add charges will be disabled
   - With text `There are no service charges assigned to this store`
 
- If service charges exist (Outbound and Inbound):
   - Add charges will be enable
   - With text `Nothing here`


# 🧪 How has/should this change been tested? 

Require to setup central, Remote with client and follow below:

- If no service charges (Outbound and Inbound):
   - Add charges will be disabled
   - With text `There are no service charges assigned to this store`
 
- If service charges exist (Outbound and Inbound):
   - Add charges will be enable
   - With text `Nothing here`