### PR TITLE
1384 is sync update triggers

### DIFF
--- a/server/repository/migrations/postgres/2022-01-27T08-00_create_changelog_table/up.sql
+++ b/server/repository/migrations/postgres/2022-01-27T08-00_create_changelog_table/up.sql
@@ -20,7 +20,7 @@ CREATE TYPE row_action_type AS ENUM (
 
 CREATE TABLE changelog (
     cursor BIGSERIAL NOT NULL PRIMARY KEY,
-    -- the table name where the change happend
+    -- the table name where the change happened
     table_name changelog_table_name NOT NULL,
     -- row id of the modified row
     record_id TEXT NOT NULL,

--- a/server/repository/migrations/postgres/2022-03-27T10-00_update_changelog_upsert_with_sync_function/down.sql
+++ b/server/repository/migrations/postgres/2022-03-27T10-00_update_changelog_upsert_with_sync_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS update_changelog_upsert_with_sync CASCADE;

--- a/server/repository/migrations/postgres/2022-03-27T10-00_update_changelog_upsert_with_sync_function/up.sql
+++ b/server/repository/migrations/postgres/2022-03-27T10-00_update_changelog_upsert_with_sync_function/up.sql
@@ -1,0 +1,9 @@
+CREATE FUNCTION update_changelog_upsert_with_sync()
+RETURNS trigger AS
+$$
+  BEGIN
+    INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
+          VALUES (TG_TABLE_NAME::changelog_table_name, NEW.id, 'UPSERT', NEW.is_sync_update);
+    RETURN NULL;
+  END;
+$$ LANGUAGE 'plpgsql';

--- a/server/repository/migrations/postgres/2022-04-01T12-00_create_clinician_trigger/up.sql
+++ b/server/repository/migrations/postgres/2022-04-01T12-00_create_clinician_trigger/up.sql
@@ -1,15 +1,5 @@
 ALTER TYPE changelog_table_name ADD VALUE 'clinician' AFTER 'activity_log';
 
-CREATE FUNCTION upsert_clinician_changelog()
-RETURNS trigger AS
-$$
-  BEGIN
-    INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
-          VALUES ('clinician', NEW.id, 'UPSERT', NEW.is_sync_update);
-    RETURN NULL;
-  END;
-$$ LANGUAGE 'plpgsql';
-
 CREATE TRIGGER clinician_trigger
   AFTER INSERT OR UPDATE ON clinician
-  FOR EACH ROW EXECUTE FUNCTION upsert_clinician_changelog();
+  FOR EACH ROW EXECUTE FUNCTION update_changelog_upsert_with_sync();

--- a/server/repository/migrations/postgres/2022-04-27T13-05_create_document_trigger/up.sql
+++ b/server/repository/migrations/postgres/2022-04-27T13-05_create_document_trigger/up.sql
@@ -2,4 +2,4 @@ ALTER TYPE changelog_table_name ADD VALUE 'document' AFTER 'clinician_store_join
 
 CREATE TRIGGER document_trigger
   AFTER INSERT OR UPDATE OR DELETE ON document
-  FOR EACH ROW EXECUTE PROCEDURE update_changelog();
+  FOR EACH ROW EXECUTE PROCEDURE update_changelog_upsert_with_sync();

--- a/server/repository/migrations/postgres/2023-03-05-205307_create_name_trigger/up.sql
+++ b/server/repository/migrations/postgres/2023-03-05-205307_create_name_trigger/up.sql
@@ -1,13 +1,3 @@
-CREATE FUNCTION upsert_name_changelog()
-RETURNS trigger AS
-$$
-  BEGIN
-    INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
-          VALUES ('name', NEW.id, 'UPSERT', NEW.is_sync_update);
-    RETURN NULL;
-  END;
-$$ LANGUAGE 'plpgsql';
-
 CREATE TRIGGER name_upsert_trigger
   AFTER INSERT OR UPDATE ON "name"
-  FOR EACH ROW EXECUTE FUNCTION upsert_name_changelog();
+  FOR EACH ROW EXECUTE FUNCTION update_changelog_upsert_with_sync();

--- a/server/repository/migrations/sqlite/2022-04-27T13-05_create_document_trigger/up.sql
+++ b/server/repository/migrations/sqlite/2022-04-27T13-05_create_document_trigger/up.sql
@@ -1,15 +1,15 @@
 CREATE TRIGGER document_insert_trigger
   AFTER INSERT ON document
   BEGIN
-    INSERT INTO changelog (table_name, record_id, row_action)
-      VALUES ('document', NEW.id, 'UPSERT');
+    INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
+      VALUES ('document', NEW.id, 'UPSERT', NEW.is_sync_update);
   END;
 
 CREATE TRIGGER document_update_trigger
   AFTER UPDATE ON document
   BEGIN
-    INSERT INTO changelog (table_name, record_id, row_action)
-      VALUES ('document', NEW.id, 'UPSERT');
+    INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
+      VALUES ('document', NEW.id, 'UPSERT', NEW.is_sync_update);
   END;
 
 CREATE TRIGGER document_delete_trigger


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1384

# 👩🏻‍💻 What does this PR do? 

- Update document trigger to update `is_sync_update`
- For Postgres, create a common update function and us it for clinician, name and document

# Notes:

- all involved triggers (clinician, name, document) are not currently in develop and can be modified directly in the base schemas