### PR TITLE
#715 Fix for manual entry in DatePicker

### DIFF
--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -15,6 +15,7 @@ import {
   fromUnixTime,
   formatRelative,
   formatDistanceToNow,
+  formatRFC3339,
 } from 'date-fns';
 // importing individually to reduce bundle size
 // the date-fns methods are tree shaking correctly
@@ -52,8 +53,9 @@ const formatIfValid = (
 
 export const DateUtils = {
   differenceInMinutes,
-  getDateOrNull: (date?: string | null): Date | null => {
+  getDateOrNull: (date?: Date | string | null): Date | null => {
     if (!date) return null;
+    if (date instanceof Date) return date;
     const maybeDate = new Date(date);
     return isValid(maybeDate) ? maybeDate : null;
   },
@@ -68,6 +70,9 @@ export const DateUtils = {
   isAfter,
   isBefore,
   isEqual,
+  isValid,
+  formatRFC3339: (date: Date | null | undefined) =>
+    isValid(date) ? formatRFC3339(date as Date) : undefined,
 };
 
 const getLocale = (language: SupportedLocales) => {

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import {
   DatePicker,
   DatePickerProps,
@@ -6,11 +6,37 @@ import {
 import { BasicTextInput } from '../../TextInput/BasicTextInput';
 import { StandardTextFieldProps, TextFieldProps } from '@mui/material';
 import { useAppTheme } from '@common/styles';
+import { DateUtils } from '@common/intl';
+import { useDebounceCallback } from '@common/hooks';
 
 export const BaseDatePickerInput: FC<
-  Omit<DatePickerProps<Date, Date>, 'renderInput'>
+  Omit<DatePickerProps<Date, Date>, 'renderInput' | 'value'> & {
+    value: Date | string | null;
+  }
 > = props => {
   const theme = useAppTheme();
+  const [internalValue, setInternalValue] = useState<Date | null>(null);
+
+  useEffect(() => {
+    // This sets the internal state from parent when first loading (i.e. when
+    // the internal date is still empty)
+    if (props.value && internalValue === null)
+      setInternalValue(DateUtils.getDateOrNull(props.value));
+  }, [props.value]);
+
+  const isInvalid = (value: Date | string | number | null | undefined) => {
+    const dateValue =
+      typeof value === 'string' ? DateUtils.getDateOrNull(value) : value;
+    return !!value && !DateUtils.isValid(dateValue);
+  };
+
+  const debouncedOnChange = useDebounceCallback(
+    value => {
+      // Only run the parent onChange method when the internal date is valid
+      if (DateUtils.isValid(value)) props.onChange(value);
+    },
+    [props.onChange]
+  );
 
   return (
     <DatePicker
@@ -50,10 +76,19 @@ export const BaseDatePickerInput: FC<
           variant: 'standard',
         };
         return (
-          <BasicTextInput disabled={!!props.disabled} {...textInputProps} />
+          <BasicTextInput
+            disabled={!!props.disabled}
+            {...textInputProps}
+            error={isInvalid(internalValue)}
+          />
         );
       }}
       {...props}
+      onChange={d => {
+        setInternalValue(d);
+        debouncedOnChange(d);
+      }}
+      value={internalValue}
     />
   );
 };

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -11,18 +11,19 @@ import { useDebounceCallback } from '@common/hooks';
 
 export const BaseDatePickerInput: FC<
   Omit<DatePickerProps<Date, Date>, 'renderInput' | 'value'> & {
+    onChange(date: Date): void;
     value: Date | string | null;
   }
-> = props => {
+> = ({ disabled, onChange, value, ...props }) => {
   const theme = useAppTheme();
   const [internalValue, setInternalValue] = useState<Date | null>(null);
 
   useEffect(() => {
     // This sets the internal state from parent when first loading (i.e. when
     // the internal date is still empty)
-    if (props.value && internalValue === null)
-      setInternalValue(DateUtils.getDateOrNull(props.value));
-  }, [props.value]);
+    if (value && internalValue === null)
+      setInternalValue(DateUtils.getDateOrNull(value));
+  }, [value]);
 
   const isInvalid = (value: Date | null) => {
     const dateValue = DateUtils.getDateOrNull(value);
@@ -32,14 +33,14 @@ export const BaseDatePickerInput: FC<
   const debouncedOnChange = useDebounceCallback(
     value => {
       // Only run the parent onChange method when the internal date is valid
-      if (DateUtils.isValid(value)) props.onChange(value);
+      if (DateUtils.isValid(value)) onChange(value);
     },
-    [props.onChange]
+    [onChange]
   );
 
   return (
     <DatePicker
-      disabled={props.disabled}
+      disabled={disabled}
       PopperProps={{
         sx: {
           '& .MuiTypography-root.Mui-selected': {
@@ -76,14 +77,14 @@ export const BaseDatePickerInput: FC<
         };
         return (
           <BasicTextInput
-            disabled={!!props.disabled}
+            disabled={!!disabled}
             {...textInputProps}
             error={isInvalid(internalValue)}
           />
         );
       }}
       {...props}
-      onChange={d => {
+      onChange={(d: Date | null) => {
         setInternalValue(d);
         debouncedOnChange(d);
       }}

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -24,9 +24,8 @@ export const BaseDatePickerInput: FC<
       setInternalValue(DateUtils.getDateOrNull(props.value));
   }, [props.value]);
 
-  const isInvalid = (value: Date | string | number | null | undefined) => {
-    const dateValue =
-      typeof value === 'string' ? DateUtils.getDateOrNull(value) : value;
+  const isInvalid = (value: Date | null) => {
+    const dateValue = DateUtils.getDateOrNull(value);
     return !!value && !DateUtils.isValid(dateValue);
   };
 

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { BaseDatePickerInput } from '../BaseDatePickerInput';
 
 interface DatePickerInputProps {
-  value: Date | null;
+  value: Date | string | null;
   onChange: (value: Date | null) => void;
   disabled?: boolean;
 }
@@ -17,7 +17,7 @@ export const DatePickerInput: FC<DatePickerInputProps> = ({
       disabled={disabled}
       inputFormat="dd/MM/yyyy"
       onChange={onChange}
-      value={value}
+      value={value || null}
     />
   );
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -22,7 +22,6 @@ export const Toolbar: FC = () => {
     useStocktake.document.fields(['isLocked', 'description', 'stocktakeDate']);
   const onDelete = useStocktake.line.deleteSelected();
   const [descriptionBuffer, setDescriptionBuffer] = useBufferState(description);
-  const [bufferedDate, setBufferedDate] = useBufferState(stocktakeDate);
   const infoMessage = isLocked
     ? t('messages.on-hold-stock-take')
     : t('messages.finalised-stock-take');
@@ -57,11 +56,9 @@ export const Toolbar: FC = () => {
             Input={
               <DatePickerInput
                 disabled={isDisabled}
-                value={bufferedDate ? new Date(bufferedDate) : null}
-                onChange={d => {
-                  const naiveDate = Formatter.naiveDate(d);
-                  setBufferedDate(naiveDate);
-                  update({ stocktakeDate: naiveDate });
+                value={stocktakeDate || null}
+                onChange={date => {
+                  update({ stocktakeDate: Formatter.naiveDate(date) });
                 }}
               />
             }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Additional fix to #1356 to handle manual date entry in updated DatePicker component. 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Have already implemented this in Programs branch, so this is just replicating some of that functionality (as the programs branch obviously won't be merged here for a while).

The basic idea is that the "BaseDatePicker" component keeps its own internal state for the current input value, and only executes the parent component's `onChange` method if the internal date is a valid date. It shows an error state if not.

Also includes debouncing.


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Tested with the DatePicker for Stocktakes and the Expiry date edit in stocktake lines. You should be able to use either the GUI picker or manually type the date.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

@mark-prins if you're happy with this, please merge it straight to your branch.