### PR TITLE
#1319 extending default query to have store logo with name address 1 and 2

### DIFF
--- a/server/service/src/report/default_queries.rs
+++ b/server/service/src/report/default_queries.rs
@@ -52,6 +52,8 @@ query InvoiceQuery($storeId: String, $dataId: String) {
         isCustomer
         id
         code
+        address1
+        address2
       }
       lines {
         nodes {
@@ -122,6 +124,7 @@ query InvoiceQuery($storeId: String, $dataId: String) {
       }
       code
       storeName
+      logo
     }
     ... on NodeError {
       __typename
@@ -326,6 +329,7 @@ const REQUISITION_QUERY: &str = r#"query RequisitionQuery($storeId: String, $dat
       }
       code
       storeName
+      logo
     }
     ... on NodeError {
       __typename


### PR DESCRIPTION
Fixes #1319 

# 👩🏻‍💻 What does this PR do? 

Ability to use the default query for Outbound and Inbound invoices, take off to have a new .graphql