### PR TITLE
1403 Form expects required fields to be filled out even if it is hidden 

### DIFF
--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -139,6 +139,26 @@ mod hiv_care_encounter {
             }
         }
     }
+
+    impl Default for HivcareEncounterArvMedication {
+        fn default() -> Self {
+            Self {
+                regimen_status: Default::default(),
+                adherence_score: None,
+                end_of_supply: None,
+                prophylaxis_medication: None,
+                quantity_prescribed: None,
+                regimen: None,
+                regimen_change_note: None,
+                regimen_change_reason: None,
+                relevant_co_medication: None,
+                remaining_pill_count: None,
+                other_regimen: None,
+                quantity_dispensed: None,
+                regimen_type: None,
+            }
+        }
+    }
 }
 
 const PATIENT_SCHEMA: &'static str = std::include_str!("./program_schemas/patient.json");
@@ -451,7 +471,7 @@ fn encounter_hiv_care_1(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.quantity_prescribed = Some(8.0);
                 e.regimen = Some("1a-New".to_string());
                 e.regimen_type = Some("First Line - Adult".to_string());
-                e.regimen_status = Some("START".to_string());
+                e.regimen_status = "START".to_string();
                 e.regimen_change_reason = Some("51".to_string())
             },
         ));
@@ -481,7 +501,7 @@ fn encounter_hiv_care_2(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.adherence_score = Some(85.7142835884354);
                 e.regimen = Some("1a-New".to_string());
                 e.regimen_type = Some("First Line - Adult".to_string());
-                e.regimen_status = Some("CONTINUE".to_string());
+                e.regimen_status = "CONTINUE".to_string();
             },
         ));
     })
@@ -510,7 +530,7 @@ fn encounter_hiv_care_3(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.adherence_score = Some(42.85714108560097);
                 e.regimen = Some("2a-New".to_string());
                 e.regimen_type = Some("Second Line - Adult".to_string());
-                e.regimen_status = Some("CHANGE".to_string());
+                e.regimen_status = "CHANGE".to_string();
                 e.regimen_change_reason = Some("52".to_string())
             },
         ));

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -206,6 +206,7 @@
               "type": "number"
             }
           },
+          "required": ["regimenStatus"],
           "then": {
             "required": ["regimen", "regimenChangeReason"]
           },


### PR DESCRIPTION
Fixes #1403

# 👩🏻‍💻 What does this PR do? 
Make `regimen status` a required field since there is a continued option for it. If Regimen Status isn't updated to continued and other fields in the ARV/Medication has been edited, then the user cannot save the form since the previous status will trigger the `New ARV Regimen` and `Regimen Reason` to become required fields even if it is still hidden.