### PR TITLE
Fix regimenStatus if condition to leave regimenStatus optional

### DIFF
--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -139,26 +139,6 @@ mod hiv_care_encounter {
             }
         }
     }
-
-    impl Default for HivcareEncounterArvMedication {
-        fn default() -> Self {
-            Self {
-                regimen_status: Default::default(),
-                adherence_score: None,
-                end_of_supply: None,
-                prophylaxis_medication: None,
-                quantity_prescribed: None,
-                regimen: None,
-                regimen_change_note: None,
-                regimen_change_reason: None,
-                relevant_co_medication: None,
-                remaining_pill_count: None,
-                other_regimen: None,
-                quantity_dispensed: None,
-                regimen_type: None,
-            }
-        }
-    }
 }
 
 const PATIENT_SCHEMA: &'static str = std::include_str!("./program_schemas/patient.json");
@@ -471,7 +451,7 @@ fn encounter_hiv_care_1(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.quantity_prescribed = Some(8.0);
                 e.regimen = Some("1a-New".to_string());
                 e.regimen_type = Some("First Line - Adult".to_string());
-                e.regimen_status = "START".to_string();
+                e.regimen_status = Some("START".to_string());
                 e.regimen_change_reason = Some("51".to_string())
             },
         ));
@@ -501,7 +481,7 @@ fn encounter_hiv_care_2(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.adherence_score = Some(85.7142835884354);
                 e.regimen = Some("1a-New".to_string());
                 e.regimen_type = Some("First Line - Adult".to_string());
-                e.regimen_status = "CONTINUE".to_string();
+                e.regimen_status = Some("CONTINUE".to_string());
             },
         ));
     })
@@ -530,7 +510,7 @@ fn encounter_hiv_care_3(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
                 e.adherence_score = Some(42.85714108560097);
                 e.regimen = Some("2a-New".to_string());
                 e.regimen_type = Some("Second Line - Adult".to_string());
-                e.regimen_status = "CHANGE".to_string();
+                e.regimen_status = Some("CHANGE".to_string());
                 e.regimen_change_reason = Some("52".to_string())
             },
         ));

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -41,7 +41,8 @@
               "regimenStatus": {
                 "enum": ["START", "CHANGE", "STOP"]
               }
-            }
+            },
+            "required": ["regimenStatus"]
           },
           "properties": {
             "adherenceScore": {
@@ -206,7 +207,6 @@
               "type": "number"
             }
           },
-          "required": ["regimenStatus"],
           "then": {
             "required": ["regimen", "regimenChangeReason"]
           },


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1403 

@roxy-dao I was reading your previous PR too late and had the following idea. I am a bit reluctant to make the field required because, for example, if the user selects an independent dropdown the medication object gets created and the field now becomes required. This action is not reversible -> bad UX, i.e. clearing the dropdown doesn't go into the previous state. Note, we don't have a way to unset number or string controls so this PR doesn't fix the undo problem...

Instead of making it required,  I fixed the `if` condition in the schema instead. Adding `"required": ["regimenStatus"]` to the if condition means if is only true if regimenStatus is set. The previous condition was always true if "regimenStatus" was unset. Bit counterintuitive when you don't know exactly how these JSONSchema if condition work...

Let me know what you think.