### PR TITLE
#1353 use numbers for measurements, update number inputs

### DIFF
--- a/client/packages/common/src/ui/components/inputs/TextInput/TextInput.stories.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/TextInput.stories.tsx
@@ -57,7 +57,7 @@ const Template: Story = () => (
 
 const NumericTemplate: Story = () => {
   const [nonNegative, setNonNegative] = useState(0);
-  const [positive, setPositive] = useState(1);
+  const [positive, setPositive] = useState<number | undefined>(1);
 
   return (
     <Grid>

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeIntegerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeIntegerInput.tsx
@@ -29,7 +29,9 @@ export const NonNegativeIntegerInput = React.forwardRef(
           sx: { ...sx, '& .MuiInput-input': { textAlign: 'right' } },
         }}
         onChange={value =>
-          onChange(NumUtils.constrain(Math.round(value), 0, max))
+          value
+            ? onChange(NumUtils.constrain(Math.round(value), 0, max))
+            : undefined
         }
         disabled={disabled}
         value={value}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeIntegerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeIntegerInput.tsx
@@ -29,7 +29,7 @@ export const NonNegativeIntegerInput = React.forwardRef(
           sx: { ...sx, '& .MuiInput-input': { textAlign: 'right' } },
         }}
         onChange={value =>
-          value
+          value !== undefined
             ? onChange(NumUtils.constrain(Math.round(value), 0, max))
             : undefined
         }

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
@@ -27,7 +27,9 @@ export const NonNegativeNumberInput = React.forwardRef(
       InputProps={{
         sx: { ...sx, '& .MuiInput-input': { textAlign: 'right' } },
       }}
-      onChange={value => onChange(NumUtils.constrain(value, 0, max))}
+      onChange={value =>
+        value ? onChange(NumUtils.constrain(value, 0, max)) : undefined
+      }
       disabled={disabled}
       value={value}
       {...rest}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NonNegativeNumberInput.tsx
@@ -28,7 +28,9 @@ export const NonNegativeNumberInput = React.forwardRef(
         sx: { ...sx, '& .MuiInput-input': { textAlign: 'right' } },
       }}
       onChange={value =>
-        value ? onChange(NumUtils.constrain(value, 0, max)) : undefined
+        value !== undefined
+          ? onChange(NumUtils.constrain(value, 0, max))
+          : undefined
       }
       disabled={disabled}
       value={value}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
@@ -3,7 +3,7 @@ import { StandardTextFieldProps } from '@mui/material';
 import { BasicTextInput } from '../BasicTextInput';
 export interface NumericTextInputProps
   extends Omit<StandardTextFieldProps, 'onChange'> {
-  onChange?: (value: number) => void;
+  onChange?: (value: number | undefined) => void;
   width?: number;
 }
 
@@ -17,6 +17,10 @@ export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
       }}
       InputProps={InputProps}
       onChange={e => {
+        if (e.target.value === '' && !!onChange) {
+          onChange(undefined);
+          return;
+        }
         const parsed = Number(e.target.value);
         if (!Number.isNaN(parsed) && !!onChange) onChange(parsed);
       }}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
@@ -32,7 +32,9 @@ export const PositiveNumberInput = React.forwardRef(
         }}
         onChange={value =>
           onChange(
-            value ? NumUtils.constrain(value, Math.max(0, min), max) : undefined
+            value !== undefined
+              ? NumUtils.constrain(value, Math.max(1, min), max)
+              : undefined
           )
         }
         disabled={disabled}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
@@ -6,7 +6,7 @@ import { NumericTextInputProps } from './NumericTextInput';
 interface PositiveNumberProps extends Omit<NumericTextInputProps, 'onChange'> {
   min?: number;
   max?: number;
-  onChange: (newValue: number) => void;
+  onChange: (newValue: number | undefined) => void;
 }
 
 // where Positive is n >=1
@@ -31,7 +31,9 @@ export const PositiveNumberInput = React.forwardRef(
           sx: { ...sx, '& .MuiInput-input': { textAlign: 'right' } },
         }}
         onChange={value =>
-          onChange(NumUtils.constrain(value, Math.max(0, min), max))
+          onChange(
+            value ? NumUtils.constrain(value, Math.max(0, min), max) : undefined
+          )
         }
         disabled={disabled}
         value={value}

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/PositiveNumberInput.tsx
@@ -33,7 +33,7 @@ export const PositiveNumberInput = React.forwardRef(
         onChange={value =>
           onChange(
             value !== undefined
-              ? NumUtils.constrain(value, Math.max(1, min), max)
+              ? NumUtils.constrain(value, Math.max(0, min), max)
               : undefined
           )
         }

--- a/client/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
@@ -20,7 +20,8 @@ export const getEditableQuantityColumn = <
     const [value, setValue] = useState(quantity);
     const [error, setError] = useState(false);
 
-    const tryUpdateValue = (value: number) => {
+    const tryUpdateValue = (value: number | undefined) => {
+      if (value === undefined) return;
       const isValid = Number.isInteger(value) && value >= 0;
 
       if (isValid) {

--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/PositiveNumberInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/PositiveNumberInputCell.tsx
@@ -27,6 +27,7 @@ export const PositiveNumberInputCell = <T extends RecordWithId>({
       error={isError}
       value={buffer}
       onChange={newValue => {
+        if (newValue === undefined) return;
         setBuffer(newValue.toString());
         updater({ ...rowData, [column.key]: newValue });
       }}

--- a/client/packages/host/src/Admin/SyncSettings.tsx
+++ b/client/packages/host/src/Admin/SyncSettings.tsx
@@ -97,16 +97,18 @@ const SyncSettingsForm = ({
         component={
           <NumericTextInput
             value={intervalSeconds}
-            onChange={seconds =>
-              setSettings(
-                'intervalSeconds',
-                NumUtils.constrain(
-                  Math.round(seconds),
-                  1,
-                  Number.MAX_SAFE_INTEGER
-                )
-              )
-            }
+            onChange={seconds => {
+              if (seconds !== undefined) {
+                setSettings(
+                  'intervalSeconds',
+                  NumUtils.constrain(
+                    Math.round(seconds),
+                    1,
+                    Number.MAX_SAFE_INTEGER
+                  )
+                );
+              }
+            }}
             disabled={isDisabled}
           />
         }

--- a/client/packages/programs/src/JsonForms/common/components/Number.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Number.tsx
@@ -17,7 +17,7 @@ const UIComponent = (props: ControlProps) => {
   const { data, handleChange, label, path, errors, schema } = props;
   const [localData, setLocalData] = useState<number | undefined>(data);
   const onChange = useDebounceCallback(
-    (value: number) => handleChange(path, value),
+    (value: number | undefined) => handleChange(path, value),
     [path]
   );
   const error = !!errors;

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -167,8 +167,10 @@ const UIComponent = (props: ControlProps) => {
               sx: { '& .MuiInput-input': { textAlign: 'right' } },
             }}
             onChange={value => {
-              setLocalData(value);
-              onChange(value);
+              if (value !== undefined) {
+                setLocalData(value);
+                onChange(value);
+              }
             }}
             disabled={!props.enabled || baseTime === undefined}
             error={error}
@@ -206,8 +208,10 @@ const UIComponent = (props: ControlProps) => {
               sx: { '& .MuiInput-input': { textAlign: 'right' } },
             }}
             onChange={value => {
-              setLocalData(value);
-              onChange(value);
+              if (value !== undefined) {
+                setLocalData(value);
+                onChange(value);
+              }
             }}
             disabled={true}
             error={error}

--- a/server/service/src/sync/init_programs_data.rs
+++ b/server/service/src/sync/init_programs_data.rs
@@ -114,6 +114,7 @@ mod hiv_care_encounter {
                 gender_based_violence: Default::default(),
                 physical_examination: Default::default(),
                 clinician: Default::default(),
+                created_by: Default::default(),
                 created_datetime: Default::default(),
                 start_datetime: Default::default(),
                 status: Default::default(),
@@ -457,7 +458,7 @@ fn encounter_hiv_care_1(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some("51.00".to_string());
+                exam.weight = Some(51.00);
                 exam.blood_pressure = Some(inline_init(
                     |blood_pressure: &mut HivcareEncounterPhysicalExaminationBloodPressure| {
                         blood_pressure.systolic = 120.0;
@@ -485,7 +486,7 @@ fn encounter_hiv_care_2(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some("52.00".to_string());
+                exam.weight = Some(52.00);
                 exam.blood_pressure = Some(inline_init(
                     |blood_pressure: &mut HivcareEncounterPhysicalExaminationBloodPressure| {
                         blood_pressure.systolic = 110.0;
@@ -514,7 +515,7 @@ fn encounter_hiv_care_3(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some("52.50".to_string());
+                exam.weight = Some(52.50);
                 exam.blood_pressure = Some(inline_init(
                     |blood_pressure: &mut HivcareEncounterPhysicalExaminationBloodPressure| {
                         blood_pressure.systolic = 150.0;
@@ -544,7 +545,7 @@ fn encounter_hiv_care_4(time: DateTime<Utc>) -> hiv_care_encounter::HivcareEncou
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some("51.00".to_string());
+                exam.weight = Some(51.00);
                 exam.blood_pressure = Some(inline_init(
                     |blood_pressure: &mut HivcareEncounterPhysicalExaminationBloodPressure| {
                         blood_pressure.systolic = 121.0;
@@ -566,7 +567,7 @@ fn encounter_hiv_care_5(
         e.start_datetime = time.to_rfc3339();
         e.physical_examination = Some(inline_init(
             |exam: &mut HivcareEncounterPhysicalExamination| {
-                exam.weight = Some("54.00".to_string());
+                exam.weight = Some(54.00);
                 exam.blood_pressure = Some(inline_init(
                     |blood_pressure: &mut HivcareEncounterPhysicalExaminationBloodPressure| {
                         blood_pressure.systolic = 112.0;

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -238,6 +238,10 @@
         "clinician": {
           "$ref": "#/definitions/Clinician"
         },
+        "createdBy": {
+          "$ref": "#/definitions/User",
+          "description": "User who created the encounter (could be different to \"Clinician\")"
+        },
         "createdDatetime": {
           "description": "Date time when the encounter was made, e.g. when an clinician schedule the encounter.",
           "format": "date-time",
@@ -398,17 +402,15 @@
             },
             "height": {
               "description": "50373000\tBody height measure [m]",
-              "examples": ["1.55", "0.92", "1.75"],
-              "pattern": "^\\d\\.\\d{2}$",
+              "minimum": 0,
               "title": "Height in m",
-              "type": "string"
+              "type": "number"
             },
             "midUpperArmCircumference": {
               "description": "284473002\tMid upper arm circumference (MUAC) [cm]",
-              "examples": ["23.0", "21.4"],
-              "pattern": "^\\d+\\.\\d+$",
-              "title": "MUAC in cm",
-              "type": "string"
+              "minimum": 0,
+              "title": "MUAC in cm]",
+              "type": "number"
             },
             "nutrition": {
               "properties": {
@@ -519,10 +521,9 @@
             },
             "weight": {
               "description": "735395000\tCurrent body weight [kg]",
-              "examples": ["75.1", "60.0"],
-              "pattern": "^\\d+\\.\\d+$",
+              "minimum": 0,
               "title": "Weight in kg",
-              "type": "string"
+              "type": "number"
             },
             "whoStaging": {
               "description": "420721002 Acquired immunodeficiency syndrome-associated disorder (disorder)",
@@ -581,11 +582,7 @@
               "type": "string"
             },
             "tbGeneXpert": {
-              "enum": [
-                "NOT_DETECTED",
-                "POSITIVE_RIF_SENSITIVE",
-                "POSITIVE_RIF_RESISTANT"
-              ],
+              "enum": ["NOT_DETECTED", "POSITIVE_RIF_SENSITIVE", "POSITIVE_RIF_RESISTANT"],
               "type": "string"
             },
             "tbScreening": {
@@ -596,18 +593,7 @@
               "type": "string"
             },
             "tbStatus": {
-              "enum": [
-                "CONFMC",
-                "CONFMS",
-                "CONFMX",
-                "INH",
-                "NO",
-                "REFER",
-                "SP",
-                "TBRX",
-                "TBRXC",
-                "YES"
-              ],
+              "enum": ["CONFMC", "CONFMS", "CONFMX", "INH", "NO", "REFER", "SP", "TBRX", "TBRXC", "YES"],
               "type": "string"
             }
           },
@@ -643,11 +629,7 @@
           "properties": {
             "location": {
               "description": "Location needed if visitType is 'Refill' or 'Outreach'",
-              "enum": [
-                "9 Mile Clinic, NCD",
-                "Angelicare Newtown",
-                "Angelicare StopAIDS, NCD"
-              ],
+              "enum": ["9 Mile Clinic, NCD", "Angelicare Newtown", "Angelicare StopAIDS, NCD"],
               "type": "string"
             },
             "visitType": {
@@ -662,18 +644,7 @@
       "type": "object"
     },
     "HIVRiskGroup": {
-      "enum": [
-        "LRM",
-        "MSM",
-        "MSW",
-        "MSMSW",
-        "HRM",
-        "LRW",
-        "HRW",
-        "FSW",
-        "TG",
-        "TGSW"
-      ],
+      "enum": ["LRM", "MSM", "MSW", "MSMSW", "HRM", "LRW", "HRW", "FSW", "TG", "TGSW"],
       "type": "string"
     },
     "Note": {
@@ -746,6 +717,17 @@
         "unprotectedVaginalSex": {
           "description": "Have you received any of the following in the past 12 months ?: Unprotected vaginal sex ?",
           "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "User": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/server/service/src/sync/program_schemas/hiv_care_encounter.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter.json
@@ -409,7 +409,7 @@
             "midUpperArmCircumference": {
               "description": "284473002\tMid upper arm circumference (MUAC) [cm]",
               "minimum": 0,
-              "title": "MUAC in cm]",
+              "title": "MUAC in cm",
               "type": "number"
             },
             "nutrition": {

--- a/server/service/src/sync/program_schemas/hiv_care_encounter_config.json
+++ b/server/service/src/sync/program_schemas/hiv_care_encounter_config.json
@@ -67,7 +67,7 @@
         "data": ""
       }
     },
-        {
+    {
       "type": "Field",
       "conditions": [
         {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1353

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

The actual change as per the issue is just a small tweak to the HIV Care Encounter schema. 

However, I noticed in the process of doing this that number inputs weren't clearable -- i.e. if you select the value and push "delete", it gets set to `0`, not an empty input. For non-required inputs, you should always be able to clear them, just like text inputs, and we don't want users putting `0` if the value is not actually zero. So I've updated the number inputs to reset their value back to `undefined` when cleared.

The side-effect of this is that there are a lot of places these number inputs are used, and they all required some kind of tweak -- I've either set them to allow `undefined` values, or adjusted their functionality to only update the value if the input is not `undefined`, on a case-by-case basis.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Checked all the instances where the changed inputs are used and checked the UI functionality still makes sense.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Maybe check if there's any cases where we *shouldn't* let the input be clearable?