### PR TITLE
873 extract value bar component

### DIFF
--- a/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.stories.tsx
+++ b/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.stories.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ValueBar } from './ValueBar';
+
+const Template: ComponentStory<typeof ValueBar> = ({
+  value,
+  total,
+  label,
+  colour,
+  startDivider,
+  endDivider,
+}) => (
+  <Box display="flex" width="25%">
+    <ValueBar
+      value={value}
+      total={total}
+      label={label}
+      colour={colour}
+      startDivider={startDivider}
+      endDivider={endDivider}
+    />
+  </Box>
+);
+
+export const Default = Template.bind({});
+export const NoDividers = Template.bind({});
+export const BothDividers = Template.bind({});
+
+Default.args = {
+  value: 10,
+  total: 20,
+  label: 'Stock on Hand',
+  colour: 'gray.main',
+};
+
+NoDividers.args = {
+  value: 10,
+  total: 20,
+  label: 'Stock on Hand',
+  colour: 'gray.main',
+  startDivider: false,
+  endDivider: false,
+};
+
+BothDividers.args = {
+  value: 10,
+  total: 20,
+  label: 'Stock on Hand',
+  colour: 'gray.main',
+  startDivider: true,
+  endDivider: true,
+};
+
+export default {
+  title: 'Charts/ValueBar',
+  component: ValueBar,
+} as ComponentMeta<typeof ValueBar>;

--- a/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
+++ b/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
@@ -14,6 +14,8 @@ interface ValueBarProps {
   total: number;
   label: string;
   colour: string;
+  startDivider?: boolean;
+  endDivider?: boolean;
 }
 
 export const ValueBar: FC<ValueBarProps> = ({
@@ -21,6 +23,8 @@ export const ValueBar: FC<ValueBarProps> = ({
   total,
   label,
   colour,
+  startDivider = false,
+  endDivider = true,
 }) => {
   const formatNumber = useFormatNumber();
   if (value === 0) return null;
@@ -29,6 +33,7 @@ export const ValueBar: FC<ValueBarProps> = ({
 
   return (
     <>
+      {startDivider ? <Divider /> : null}
       <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
         <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
           <Box sx={{ backgroundColor: colour, height: '20px' }} />
@@ -53,7 +58,7 @@ export const ValueBar: FC<ValueBarProps> = ({
           </Box>
         </Box>
       </Tooltip>
-      <Divider />
+      {endDivider ? <Divider /> : null}
     </>
   );
 };

--- a/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
+++ b/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
@@ -27,7 +27,7 @@ export const ValueBar: FC<ValueBarProps> = ({
   endDivider = true,
 }) => {
   const formatNumber = useFormatNumber();
-  if (value === 0) return null;
+  if (value === 0) return startDivider ? <Divider /> : null;
 
   const flexBasis = Math.min(Math.round((100 * value) / total), 100);
 

--- a/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
+++ b/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
@@ -1,0 +1,59 @@
+import React, { FC } from 'react';
+import { Box, Tooltip, Typography } from '@openmsupply-client/common';
+import { useFormatNumber } from '@common/intl';
+
+const MIN_FLEX_BASIS_TO_SHOW_LABEL = 10;
+const MIN_FLEX_BASIS_TO_SHOW_VALUE = 5;
+
+const Divider = () => (
+  <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
+);
+
+interface ValueBarProps {
+  value: number;
+  total: number;
+  label: string;
+  colour: string;
+}
+
+export const ValueBar: FC<ValueBarProps> = ({
+  value,
+  total,
+  label,
+  colour,
+}) => {
+  const formatNumber = useFormatNumber();
+  if (value === 0) return null;
+
+  const flexBasis = Math.min(Math.round((100 * value) / total), 100);
+
+  return (
+    <>
+      <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
+        <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
+          <Box sx={{ backgroundColor: colour, height: '20px' }} />
+          <Box
+            style={{
+              textAlign: 'end',
+              paddingRight: 10,
+              paddingTop: 10,
+            }}
+          >
+            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_LABEL ? (
+              <Typography
+                fontSize={12}
+                style={{ textOverflow: 'ellipsis', height: 20 }}
+              >
+                {label}
+              </Typography>
+            ) : null}
+            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
+              <Typography fontSize={12}>{formatNumber.round(value)}</Typography>
+            ) : null}
+          </Box>
+        </Box>
+      </Tooltip>
+      <Divider />
+    </>
+  );
+};

--- a/client/packages/common/src/ui/components/charts/ValueBar/index.ts
+++ b/client/packages/common/src/ui/components/charts/ValueBar/index.ts
@@ -1,0 +1,1 @@
+export * from './ValueBar';

--- a/client/packages/common/src/ui/components/charts/index.ts
+++ b/client/packages/common/src/ui/components/charts/index.ts
@@ -29,3 +29,5 @@ export {
   XAxis,
   YAxis,
 };
+
+export * from './ValueBar';

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Tooltip,
   Typography,
+  ValueBar,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useRequest } from '../../../api';
@@ -14,60 +15,11 @@ export interface StockDistributionProps {
   suggestedQuantity?: number;
 }
 
-const MIN_FLEX_BASIS_TO_SHOW_LABEL = 10;
-const MIN_FLEX_BASIS_TO_SHOW_VALUE = 5;
 const MIN_MC_WIDTH_TO_SHOW_TEXT = 5;
 
 const Divider = () => (
   <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
 );
-
-const ValueBar = ({
-  value,
-  total,
-  label,
-  colour,
-}: {
-  value: number;
-  total: number;
-  label: string;
-  colour: string;
-}) => {
-  const formatNumber = useFormatNumber();
-  if (value === 0) return null;
-
-  const flexBasis = Math.min(Math.round((100 * value) / total), 100);
-
-  return (
-    <>
-      <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
-        <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
-          <Box sx={{ backgroundColor: colour, height: '20px' }} />
-          <Box
-            style={{
-              textAlign: 'end',
-              paddingRight: 10,
-              paddingTop: 10,
-            }}
-          >
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_LABEL ? (
-              <Typography
-                fontSize={12}
-                style={{ textOverflow: 'ellipsis', height: 20 }}
-              >
-                {label}
-              </Typography>
-            ) : null}
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
-              <Typography fontSize={12}>{formatNumber.round(value)}</Typography>
-            ) : null}
-          </Box>
-        </Box>
-      </Tooltip>
-      <Divider />
-    </>
-  );
-};
 
 const MonthlyConsumption = ({
   month,

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -17,10 +17,6 @@ export interface StockDistributionProps {
 
 const MIN_MC_WIDTH_TO_SHOW_TEXT = 5;
 
-const Divider = () => (
-  <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
-);
-
 const MonthlyConsumption = ({
   month,
   flexBasis,
@@ -158,12 +154,12 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
         </Box>
 
         <Box display="flex" alignItems="flex-start" width="100%">
-          <Divider />
           <ValueBar
             value={availableStockOnHand}
             total={targetQuantity}
             label={t('label.stock-on-hand')}
             colour="gray.main"
+            startDivider
           />
           <ValueBar
             value={suggestedQuantity}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Tooltip,
   Typography,
+  ValueBar,
 } from '@openmsupply-client/common';
 
 export interface RequestStoreStatsProps {
@@ -14,60 +15,11 @@ export interface RequestStoreStatsProps {
   averageMonthlyConsumption: number;
 }
 
-const MIN_FLEX_BASIS_TO_SHOW_LABEL = 10;
-const MIN_FLEX_BASIS_TO_SHOW_VALUE = 5;
 const MIN_MC_WIDTH_TO_SHOW_TEXT = 5;
 
 const Divider = () => (
   <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
 );
-
-const ValueBar = ({
-  value,
-  total,
-  label,
-  colour,
-}: {
-  value: number;
-  total: number;
-  label: string;
-  colour: string;
-}) => {
-  const formatNumber = useFormatNumber();
-  if (value === 0) return null;
-
-  const flexBasis = Math.min(Math.round((100 * value) / total), 100);
-
-  return (
-    <>
-      <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
-        <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
-          <Box sx={{ backgroundColor: colour, height: '20px' }} />
-          <Box
-            style={{
-              textAlign: 'end',
-              paddingRight: 10,
-              paddingTop: 10,
-            }}
-          >
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_LABEL ? (
-              <Typography
-                fontSize={12}
-                style={{ textOverflow: 'ellipsis', height: 20 }}
-              >
-                {label}
-              </Typography>
-            ) : null}
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
-              <Typography fontSize={12}>{formatNumber.round(value)}</Typography>
-            ) : null}
-          </Box>
-        </Box>
-      </Tooltip>
-      <Divider />
-    </>
-  );
-};
 
 const MonthlyConsumption = ({
   month,

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/RequestStoreStats.tsx
@@ -17,10 +17,6 @@ export interface RequestStoreStatsProps {
 
 const MIN_MC_WIDTH_TO_SHOW_TEXT = 5;
 
-const Divider = () => (
-  <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
-);
-
 const MonthlyConsumption = ({
   month,
   flexBasis,
@@ -166,12 +162,12 @@ export const RequestStoreStats: React.FC<RequestStoreStatsProps> = ({
           </Box>
 
           <Box display="flex" alignItems="flex-start" width="100%">
-            <Divider />
             <ValueBar
               value={availableStockOnHand}
               total={targetQuantity}
               label={t('label.stock-on-hand')}
               colour="gray.main"
+              startDivider
             />
             <ValueBar
               value={suggestedQuantity}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -10,10 +10,6 @@ export interface ResponseStoreStatsProps {
   otherRequestedQuantity: number;
 }
 
-const Divider = () => (
-  <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
-);
-
 export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
   stockOnHand,
   incomingStock,
@@ -54,12 +50,12 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
             alignItems="flex-start"
             width={predictedStockPercent}
           >
-            <Divider />
             <ValueBar
               value={stockOnHand}
               total={predictedStockLevels}
               label={t('label.stock-on-hand')}
               colour="gray.dark"
+              startDivider
             />
             <ValueBar
               value={incomingStock}
@@ -86,12 +82,12 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
       >
         <>
           <Box display="flex" alignItems="flex-start" width={requestedPercent}>
-            <Divider />
             <ValueBar
               value={requestedQuantity}
               total={totalRequested}
               label={t('label.requested-quantity')}
               colour="primary.main"
+              startDivider
             />
             <ValueBar
               value={otherRequestedQuantity}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useFormatNumber, useTranslation } from '@common/intl';
-import { Box, Tooltip, Typography } from '@openmsupply-client/common';
+import { useTranslation } from '@common/intl';
+import { Box, ValueBar } from '@openmsupply-client/common';
 
 export interface ResponseStoreStatsProps {
   stockOnHand: number;
@@ -10,59 +10,9 @@ export interface ResponseStoreStatsProps {
   otherRequestedQuantity: number;
 }
 
-const MIN_FLEX_BASIS_TO_SHOW_LABEL = 10;
-const MIN_FLEX_BASIS_TO_SHOW_VALUE = 5;
-
 const Divider = () => (
   <Box sx={{ backgroundColor: 'gray.dark', width: '1px', height: '45px' }} />
 );
-
-const ValueBar = ({
-  value,
-  total,
-  label,
-  colour,
-}: {
-  value: number;
-  total: number;
-  label: string;
-  colour: string;
-}) => {
-  const formatNumber = useFormatNumber();
-  if (value === 0) return null;
-
-  const flexBasis = Math.min(Math.round((100 * value) / total), 100);
-
-  return (
-    <>
-      <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
-        <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
-          <Box sx={{ backgroundColor: colour, height: '20px' }} />
-          <Box
-            style={{
-              textAlign: 'end',
-              paddingRight: 10,
-              paddingTop: 10,
-            }}
-          >
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_LABEL ? (
-              <Typography
-                fontSize={12}
-                style={{ textOverflow: 'ellipsis', height: 20 }}
-              >
-                {label}
-              </Typography>
-            ) : null}
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
-              <Typography fontSize={12}>{formatNumber.round(value)}</Typography>
-            ) : null}
-          </Box>
-        </Box>
-      </Tooltip>
-      <Divider />
-    </>
-  );
-};
 
 export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
   stockOnHand,
@@ -77,7 +27,9 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
 
   const predictedStockPercent =
     predictedStockLevels < totalRequested
-      ? `${Math.round((100 * predictedStockLevels) / totalRequested).toString()}%`
+      ? `${Math.round(
+          (100 * predictedStockLevels) / totalRequested
+        ).toString()}%`
       : '100%';
   const requestedPercent =
     totalRequested < predictedStockLevels
@@ -133,11 +85,7 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
         }}
       >
         <>
-          <Box
-            display="flex"
-            alignItems="flex-start"
-            width={requestedPercent}
-          >
+          <Box display="flex" alignItems="flex-start" width={requestedPercent}>
             <Divider />
             <ValueBar
               value={requestedQuantity}


### PR DESCRIPTION
Fixes #873

# 👩🏻‍💻 What does this PR do? 
 - Extracts the ValueBar component from StockDistribution, RequestStoreStats, ResponseStoreStats  in client/packages/host, and moved it to /common/src/ui/components/charts/
 - An option has been added to include or remove the starting and trailing Divider as this was also floating around in each of the components where it was before.  Defaults are leave off Divider at the start, and include Divider at the end of ValueBar.
 - Adds Storybook for Charts

# 🧪 How has/should this change been tested? 
- No functional logic was changed.
- Tests are visual. i.e navigating to Replenishment>Internal Orders, selecting an order with "Draft" status.  Find an order with detail lines where AMC > 0.

## 💌 Any notes for the reviewer?
- Not sure my naming convention of "startDivider" and "endDivider" are very descriptive in the ValueBar component.

## 📃 Documentation
- The strength of this component is when 2 or more ValueBar components are put together in a Flexbox.  I wasn't sure of the best way to convey that in StoryBook, or anywhere else for that matter.