### PR TITLE
1465 allow inventory adjsutment reason when counted quantity is 0

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeDecimalCell.tsx
@@ -13,7 +13,7 @@ export const NonNegativeDecimalCell = <T extends RecordWithId>({
   max,
 }: CellProps<T> & { max?: number }): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
-    column.accessor({ rowData }) || ''
+    column.accessor({ rowData }) ?? ''
   );
 
   const updater = useDebounceCallback(column.setter, [column.setter], 250);

--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -13,6 +13,12 @@ import {
   InventoryAdjustmentReasonRowFragment,
 } from '../api';
 
+export enum Adjustment {
+  Reduction,
+  Addition,
+  None,
+}
+
 interface InventoryAdjustmentReasonSearchInputProps {
   value: InventoryAdjustmentReasonRowFragment | null;
   width?: number | string;
@@ -20,27 +26,20 @@ interface InventoryAdjustmentReasonSearchInputProps {
     inventoryAdjustmentReason: InventoryAdjustmentReasonRowFragment | null
   ) => void;
   autoFocus?: boolean;
-  stockReduction: number;
+  adjustment: Adjustment;
   isError?: boolean;
 }
 
 export const InventoryAdjustmentReasonSearchInput: FC<
   InventoryAdjustmentReasonSearchInputProps
-> = ({
-  value,
-  width,
-  onChange,
-  autoFocus = false,
-  stockReduction,
-  isError,
-}) => {
+> = ({ value, width, onChange, autoFocus = false, adjustment, isError }) => {
   const { data, isLoading } =
     useInventoryAdjustmentReason.document.listAllActive();
-  const disabled = data?.totalCount === 0 || stockReduction === 0;
-  const isRequired = !disabled && stockReduction !== 0;
+  const isRequired = data?.totalCount !== 0;
+  const isDisable = adjustment === Adjustment.None || !isRequired;
   const reasonFilter = (reason: InventoryAdjustmentReasonRowFragment) => {
-    if (stockReduction === 0) return false;
-    if (stockReduction < 0)
+    if (adjustment === Adjustment.None) return false;
+    if (adjustment === Adjustment.Addition)
       return reason.type === InventoryAdjustmentReasonNodeType.Positive;
     return reason.type === InventoryAdjustmentReasonNodeType.Negative;
   };
@@ -50,7 +49,7 @@ export const InventoryAdjustmentReasonSearchInput: FC<
     <Box display="flex" flexDirection="row" width={120}>
       <Autocomplete
         autoFocus={autoFocus}
-        disabled={disabled}
+        disabled={isDisable}
         width={`${width}px`}
         clearable={false}
         value={

--- a/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
+++ b/client/packages/system/src/InventoryAdjustmentReason/Components/InventoryAdjustmentReasonSearchInput.tsx
@@ -36,7 +36,7 @@ export const InventoryAdjustmentReasonSearchInput: FC<
   const { data, isLoading } =
     useInventoryAdjustmentReason.document.listAllActive();
   const isRequired = data?.totalCount !== 0;
-  const isDisable = adjustment === Adjustment.None || !isRequired;
+  const isDisabled = adjustment === Adjustment.None || !isRequired;
   const reasonFilter = (reason: InventoryAdjustmentReasonRowFragment) => {
     if (adjustment === Adjustment.None) return false;
     if (adjustment === Adjustment.Addition)
@@ -49,7 +49,7 @@ export const InventoryAdjustmentReasonSearchInput: FC<
     <Box display="flex" flexDirection="row" width={120}>
       <Autocomplete
         autoFocus={autoFocus}
-        disabled={isDisable}
+        disabled={isDisabled}
         width={`${width}px`}
         clearable={false}
         value={


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1465

# 👩🏻‍💻 What does this PR do? 

Allows adjustment reason when counted quantity is zero (fixing `rowData.countedNumberOfPacks || rowData.snapshotNumberOfPacks` when countedNumberOfPacks is zero)
Using Adjustment enum type to handle adjustment, to simplify adjustment representation

Bonus: Fixes countedNumberOfPacks being wiped when it's set to 0

# 🧪 How has/should this change been tested? 


For adjustment reason not available when counted quantity is zero:
* Datafile with positive and negative inventory adjustment reasons set up
* Try setting number of packs to zero (in stocktake) when snapshot number of packs is not zero, should be able to set correct reason

For counted number of packs wiped when set to zero:
* Set number of packs to non zero value in stocktake
* Focus out of the input
* Focus back in the input and set number of packs to 0, it should not disappear

