### PR TITLE
#1494 Date input fix

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -75,7 +75,7 @@ export const BaseDatePickerInput: FC<
         const textInputProps: StandardTextFieldProps = {
           ...params,
           variant: 'standard',
-          // helperText: error ?? '',
+          helperText: error ?? '',
         };
         return (
           <BasicTextInput

--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -13,8 +13,9 @@ export const BaseDatePickerInput: FC<
   Omit<DatePickerProps<Date, Date>, 'renderInput' | 'value'> & {
     onChange(date: Date): void;
     value: Date | string | null;
+    error?: string | undefined;
   }
-> = ({ disabled, onChange, value, ...props }) => {
+> = ({ disabled, onChange, value, error, ...props }) => {
   const theme = useAppTheme();
   const [internalValue, setInternalValue] = useState<Date | null>(null);
 
@@ -74,12 +75,13 @@ export const BaseDatePickerInput: FC<
         const textInputProps: StandardTextFieldProps = {
           ...params,
           variant: 'standard',
+          // helperText: error ?? '',
         };
         return (
           <BasicTextInput
             disabled={!!disabled}
             {...textInputProps}
-            error={isInvalid(internalValue)}
+            error={isInvalid(internalValue) || !!error}
           />
         );
       }}

--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -1,13 +1,10 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { rankWith, ControlProps, isDateControl } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
-  TextFieldProps,
-  BasicTextInput,
   DetailInputWithLabelRow,
   useFormatDateTime,
-  DatePicker,
-  DatePickerProps,
+  BaseDatePickerInput,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
@@ -21,29 +18,6 @@ const Options = z
   .optional();
 
 type Options = z.infer<typeof Options>;
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DatePickerTextInput = ({ variant, ...props }: TextFieldProps) => (
-  <BasicTextInput
-    error={!!props.error}
-    helperText={props.error}
-    FormHelperTextProps={
-      !!props.error ? { sx: { color: 'error.main' } } : undefined
-    }
-    {...props}
-    variant="standard"
-  />
-);
-
-export const BaseDatePickerInput: FC<
-  Omit<DatePickerProps<Date, Date>, 'renderInput'> & { error: string }
-> = props => (
-  <DatePicker
-    disabled={props.disabled}
-    renderInput={DatePickerTextInput}
-    {...props}
-  />
-);
 
 export const dateTester = rankWith(5, isDateControl);
 

--- a/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/DateTime.tsx
@@ -8,11 +8,11 @@ import {
   DetailInputWithLabelRow,
   DateTimePicker,
   DateTimePickerProps,
+  BaseDatePickerInput,
 } from '@openmsupply-client/common';
 import { FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
-import { BaseDatePickerInput as DatePickerInput } from './Date';
 
 const Options = z
   .object({
@@ -106,7 +106,7 @@ const UIComponent = (props: ControlProps) => {
             {...sharedComponentProps}
           />
         ) : (
-          <DatePickerInput {...sharedComponentProps} />
+          <BaseDatePickerInput {...sharedComponentProps} />
         )
       }
     />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1494.

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

The JSONForms "Date" component was not using the common "BaseDatePicker", which had recently been updated to handle manual date entries more gracefully. So have replaced the "DatePicker" in "Date" to use that instead. Very little needed to be changed to make it work with it.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Can manually enter date of birth in the "New Patient" modal (first screen)
- Other JSONForm Date inputs (including DOB) work correctly.