### PR TITLE
Don't show 0 sync badge

### DIFF
--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -18,10 +18,13 @@ export const SyncNavLink = () => {
     POLLING_INTERVAL_IN_MILLISECONDS
   );
 
+  // the Badge does not show if the content is 0
+  // somehow though the numberOfRecordsInPushQueue can be '0' which does show
   const badgeContent = (
     !numberOfRecordsInPushQueue
       ? 0
-      : Number.parseFloat(`${numberOfRecordsInPushQueue}`)
+      : // parse, after casting to string to satisfy ts
+        Number.parseFloat(`${numberOfRecordsInPushQueue}`)
   ) as React.ReactNode;
 
   const badgeProps = {

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -18,8 +18,14 @@ export const SyncNavLink = () => {
     POLLING_INTERVAL_IN_MILLISECONDS
   );
 
+  const badgeContent = (
+    !numberOfRecordsInPushQueue
+      ? 0
+      : Number.parseFloat(`${numberOfRecordsInPushQueue}`)
+  ) as React.ReactNode;
+
   const badgeProps = {
-    badgeContent: numberOfRecordsInPushQueue as React.ReactNode,
+    badgeContent,
     max: 99,
     color: 'primary' as 'primary' | 'default',
   };

--- a/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
+++ b/client/packages/host/src/components/AppDrawer/SyncNavLink.tsx
@@ -6,7 +6,7 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useHost } from '../../api/hooks';
 
 const POLLING_INTERVAL_IN_MILLISECONDS = 60 * 1000;
@@ -20,12 +20,8 @@ export const SyncNavLink = () => {
 
   // the Badge does not show if the content is 0
   // somehow though the numberOfRecordsInPushQueue can be '0' which does show
-  const badgeContent = (
-    !numberOfRecordsInPushQueue
-      ? 0
-      : // parse, after casting to string to satisfy ts
-        Number.parseFloat(`${numberOfRecordsInPushQueue}`)
-  ) as React.ReactNode;
+  const syncCount = Number(numberOfRecordsInPushQueue);
+  const badgeContent = Number.isNaN(syncCount) ? 0 : (syncCount as ReactNode);
 
   const badgeProps = {
     badgeContent,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1469

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Fixed when looking at something else, so have put in a PR. Sorry for the distraction.
The problem is that the sync count is coming through as a string, i.e. `'0'` the Badge component won't show `0` by default, but the string is being shown.

Have parsed as a number to prevent the 0 showing.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Take my word for it? 🤷 It's only showing up sometimes. I passed in the value `'0'` to the `badgeContent` prop when testing

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
