### PR TITLE
#1525 HIV Testing enrolment/encounter updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # common location for local config file containing connection credentials
 server/report_builder/config.yaml
 .vscode/*
+
+# Temp export files
+server/data

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
   plugins: ['react', , '@typescript-eslint'],
   rules: {
     camelcase: ['error', { allow: ['_ONLY_FOR_TESTING'] }],
-    'require-jsdoc': 0,
+    'require-jsdoc': 'off',
+    'valid-jsdoc': 'off',
     'react/display-name': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -61,14 +61,14 @@ const formatIfValid = (
 ): string => (isValid(date) ? format(date, dateFormat, options) : '');
 
 // Adds the current time to a date object (that presumably has 00:00 as its time
-// component)
-const addCurrentTime = (date: Date | null) => {
+// component) -- does not mutate input Date object)
+const addCurrentTime = (date: Date | null): Date | null => {
   if (date === null) return date;
   const d = new Date();
   const e = new Date(d);
   const msSinceMidnight = d.getTime() - e.setHours(0, 0, 0, 0);
   const newDate = new Date(date);
-  newDate.setTime(date.getTime() + msSinceMidnight);
+  newDate.setTime(e.getTime() + msSinceMidnight);
   return newDate;
 };
 

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -65,10 +65,9 @@ const formatIfValid = (
 const addCurrentTime = (date: Date | null): Date | null => {
   if (date === null) return date;
   const d = new Date();
-  const e = new Date(d);
-  const msSinceMidnight = d.getTime() - e.setHours(0, 0, 0, 0);
+  const msSinceMidnight = d.getTime() - new Date(d).setHours(0, 0, 0, 0);
   const newDate = new Date(date);
-  newDate.setTime(e.getTime() + msSinceMidnight);
+  newDate.setTime(newDate.setHours(0, 0, 0, 0) + msSinceMidnight);
   return newDate;
 };
 

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -60,6 +60,18 @@ const formatIfValid = (
   }
 ): string => (isValid(date) ? format(date, dateFormat, options) : '');
 
+// Adds the current time to a date object (that presumably has 00:00 as its time
+// component)
+const addCurrentTime = (date: Date | null) => {
+  if (date === null) return date;
+  const d = new Date();
+  const e = new Date(d);
+  const msSinceMidnight = d.getTime() - e.setHours(0, 0, 0, 0);
+  const newDate = new Date(date);
+  newDate.setTime(date.getTime() + msSinceMidnight);
+  return newDate;
+};
+
 // Time constants in [ms]
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
@@ -71,6 +83,7 @@ export const DateUtils = {
   addMinutes,
   addDays,
   addYears,
+  addCurrentTime,
   getDateOrNull: (date?: Date | string | null): Date | null => {
     if (!date) return null;
     if (date instanceof Date) return date;

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -60,8 +60,9 @@ const formatIfValid = (
   }
 ): string => (isValid(date) ? format(date, dateFormat, options) : '');
 
-// Adds the current time to a date object (that presumably has 00:00 as its time
-// component) -- does not mutate input Date object)
+/** Adds the current time to a date object (that presumably has 00:00 as its
+ * time component) -- does not mutate input Date object
+ */
 const addCurrentTime = (date: Date | null): Date | null => {
   if (date === null) return date;
   const d = new Date();

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -57,7 +57,6 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
 // Adds a final ":" to the label, but not if it already ends in a punctuation
 // character
 export const labelWithPunctuation = (labelString: string) => {
-  console.log('labelString', labelString, /[^A-z0-9\s]$/.test(labelString));
   if (/[^A-z0-9\s]$/.test(labelString)) return labelString;
   else return labelString + ':';
 };

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -40,7 +40,7 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
     <Box display="flex" alignItems="center" gap={1} sx={{ ...sx }}>
       <Box style={{ textAlign: 'end' }} flexBasis={labelFlexBasis}>
         <FormLabel sx={{ fontWeight: 'bold', ...labelSx }} {...labelPropsRest}>
-          {label}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       <Box
@@ -52,4 +52,12 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
       </Box>
     </Box>
   );
+};
+
+// Adds a final ":" to the label, but not if it already ends in a punctuation
+// character
+export const labelWithPunctuation = (labelString: string) => {
+  console.log('labelString', labelString, /[^A-z0-9\s]$/.test(labelString));
+  if (/[^A-z0-9\s]$/.test(labelString)) return labelString;
+  else return labelString + ':';
 };

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -57,6 +57,6 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
 // Adds a final ":" to the label, but not if it already ends in a punctuation
 // character
 export const labelWithPunctuation = (labelString: string) => {
-  if (/[^A-z0-9\s]$/.test(labelString)) return labelString;
+  if (/[\?:]$/.test(labelString)) return labelString;
   else return labelString + ':';
 };

--- a/client/packages/programs/src/JsonForms/common/components/Array/EnumArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/EnumArray.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   AutocompleteRenderInputParams,
   AutocompleteMui,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -114,7 +115,9 @@ export const EnumArrayComponent: FC<EnumArrayControlCustomProps> = ({
           style={{ textAlign: 'end', alignSelf: 'start', paddingTop: 5 }}
           flexBasis={FORM_LABEL_COLUMN_WIDTH}
         >
-          <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+          <FormLabel sx={{ fontWeight: 'bold' }}>
+            {labelWithPunctuation(label)}
+          </FormLabel>
         </Box>
         <Box sx={{ width: FORM_INPUT_COLUMN_WIDTH }}>
           <AutocompleteMui

--- a/client/packages/programs/src/JsonForms/common/components/Array/FirstItemArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/FirstItemArray.tsx
@@ -11,7 +11,11 @@ import {
   withJsonFormsArrayControlProps,
   JsonFormsDispatch,
 } from '@jsonforms/react';
-import { Box, Typography } from '@openmsupply-client/common';
+import {
+  Box,
+  Typography,
+  labelWithPunctuation,
+} from '@openmsupply-client/common';
 
 import { FORM_LABEL_COLUMN_WIDTH } from '../../styleConstants';
 import { JsonData } from '../../JsonForm';
@@ -68,7 +72,7 @@ const FirstItemArrayComponent = (props: FirstItemArrayControlCustomProps) => {
         <Box display="flex" width="100%" gap={2} alignItems="center">
           <Box width={FORM_LABEL_COLUMN_WIDTH}>
             <Typography sx={{ fontWeight: 'bold', textAlign: 'end' }}>
-              {label}:
+              {labelWithPunctuation(label)}
             </Typography>
           </Box>
         </Box>

--- a/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDownIcon,
   useTranslation,
   ConfirmationModal,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import { RegexUtils } from '@common/utils';
 import { z, ZodSchema } from 'zod';
@@ -181,7 +182,7 @@ export const ArrayCommonComponent = (props: ArrayControlCustomProps) => {
           <Typography
             sx={{ fontWeight: 'bold', textAlign: 'end', maxWidth: '100%' }}
           >
-            {label}:
+            {labelWithPunctuation(label)}
           </Typography>
         </Box>
         <Box width={FORM_INPUT_COLUMN_WIDTH} textAlign="right">

--- a/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
@@ -5,6 +5,7 @@ import {
   Autocomplete as AutocompleteCommon,
   Box,
   FormLabel,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
@@ -90,7 +91,9 @@ const UIComponent = (props: ControlProps) => {
   return (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}
+        </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
         <AutocompleteCommon

--- a/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { rankWith, isBooleanControl, ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { FormLabel, Box, Switch } from '@openmsupply-client/common';
+import {
+  FormLabel,
+  Box,
+  Switch,
+  labelWithPunctuation,
+} from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
@@ -16,10 +21,14 @@ const UIComponent = (props: ControlProps) => {
   if (!props.visible) {
     return null;
   }
+
+  console.log('LABEL', label);
   return (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}
+        </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
         <Switch

--- a/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
@@ -22,7 +22,6 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
 
-  console.log('LABEL', label);
   return (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>

--- a/client/packages/programs/src/JsonForms/common/components/ConditionalSelect.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/ConditionalSelect.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
-import { Autocomplete, FormLabel, Box } from '@openmsupply-client/common';
+import {
+  Autocomplete,
+  FormLabel,
+  Box,
+  labelWithPunctuation,
+} from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
@@ -72,7 +77,9 @@ const UIComponent = (props: ControlProps) => {
   return (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}
+        </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
         <Autocomplete

--- a/client/packages/programs/src/JsonForms/common/components/Select.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Select.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { rankWith, isEnumControl, ControlProps } from '@jsonforms/core';
 import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
-import { Autocomplete, FormLabel, Box } from '@openmsupply-client/common';
+import {
+  Autocomplete,
+  FormLabel,
+  Box,
+  labelWithPunctuation,
+} from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
@@ -270,7 +275,9 @@ const UIComponent = (props: ControlProps) => {
       marginLeft={0}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}
+        </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH} justifyContent="flex-start">
         <Autocomplete

--- a/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
+++ b/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
@@ -249,7 +249,7 @@ const UIComponent = (props: ControlProps) => {
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       <Box

--- a/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
+++ b/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
@@ -12,6 +12,7 @@ import {
   DateUtils,
   useTranslation,
   FormLabel,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_INPUT_COLUMN_WIDTH,
@@ -247,7 +248,9 @@ const UIComponent = (props: ControlProps) => {
       marginTop={1}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}:
+        </FormLabel>
       </Box>
       <Box
         flexBasis={FORM_INPUT_COLUMN_WIDTH}

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -375,7 +375,7 @@ const UIComponent = (props: ControlProps) => {
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       <Box

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -9,6 +9,7 @@ import {
   BasicTextInput,
   Button,
   FormLabel,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -373,7 +374,9 @@ const UIComponent = (props: ControlProps) => {
   return (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}:
+        </FormLabel>
       </Box>
       <Box
         flexBasis={FORM_INPUT_COLUMN_WIDTH}

--- a/client/packages/programs/src/JsonForms/components/PreviousEncounterField.tsx
+++ b/client/packages/programs/src/JsonForms/components/PreviousEncounterField.tsx
@@ -6,6 +6,7 @@ import {
   DetailInputWithLabelRow,
   NumericTextInput,
   FormLabel,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -63,7 +64,9 @@ const UIComponent = (props: ControlProps) => {
   ) : (
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}:
+        </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
         <NumericTextInput {...inputProps} />

--- a/client/packages/programs/src/JsonForms/components/PreviousEncounterField.tsx
+++ b/client/packages/programs/src/JsonForms/components/PreviousEncounterField.tsx
@@ -65,7 +65,7 @@ const UIComponent = (props: ControlProps) => {
     <Box sx={DefaultFormRowSx}>
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -163,7 +163,7 @@ const UIComponent = (props: ControlProps) => {
       >
         <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
           <FormLabel sx={{ fontWeight: 'bold' }}>
-            {labelWithPunctuation(label)}:
+            {labelWithPunctuation(label)}
           </FormLabel>
         </Box>
         <Box

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -9,6 +9,7 @@ import {
   useTranslation,
   FormLabel,
   Box,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -161,7 +162,9 @@ const UIComponent = (props: ControlProps) => {
         marginTop={1}
       >
         <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-          <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+          <FormLabel sx={{ fontWeight: 'bold' }}>
+            {labelWithPunctuation(label)}:
+          </FormLabel>
         </Box>
         <Box
           flexBasis={FORM_INPUT_COLUMN_WIDTH}

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
@@ -105,7 +105,7 @@ export const SearchWithDocumentSource = (
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       <Box

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   FormLabel,
   Typography,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -103,7 +104,9 @@ export const SearchWithDocumentSource = (
       marginLeft={0}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}:
+        </FormLabel>
       </Box>
       <Box
         display="flex"

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -10,6 +10,7 @@ import {
   EditIcon,
   BasicTextInput,
   Typography,
+  labelWithPunctuation,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -93,7 +94,9 @@ export const SearchWithUserSource = (
       marginLeft={0}
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+        <FormLabel sx={{ fontWeight: 'bold' }}>
+          {labelWithPunctuation(label)}:
+        </FormLabel>
       </Box>
       {editMode ? (
         <Box flexBasis={FORM_INPUT_COLUMN_WIDTH} justifyContent="flex-start">

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -95,7 +95,7 @@ export const SearchWithUserSource = (
     >
       <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
         <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
+          {labelWithPunctuation(label)}
         </FormLabel>
       </Box>
       {editMode ? (

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -79,7 +79,6 @@ export const CreateEncounterModal: FC = () => {
   };
 
   const setStartDatetime = (date: Date | null): void => {
-    date?.setTime(date.getTime() + 50000);
     const startDatetime = DateUtils.formatRFC3339(
       DateUtils.addCurrentTime(date)
     );

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -3,18 +3,17 @@ import {
   AlertIcon,
   BasicSpinner,
   Box,
-  DateTimePickerInput,
   DialogButton,
   EncounterNodeStatus,
   InputWithLabelRow,
   RouteBuilder,
   Stack,
-  TimePickerInput,
   Typography,
   useDialog,
   useNavigate,
   useNotification,
   useAuthContext,
+  DatePickerInput,
 } from '@openmsupply-client/common';
 import { DateUtils, useTranslation } from '@common/intl';
 import {
@@ -55,7 +54,6 @@ export const CreateEncounterModal: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const [startDateTimeError, setStartDateTimeError] = useState(false);
-  const [endDateTimeError, setEndDateTimeError] = useState(false);
 
   const handleSave = useEncounter.document.upsert(
     patientId,
@@ -81,7 +79,10 @@ export const CreateEncounterModal: FC = () => {
   };
 
   const setStartDatetime = (date: Date | null): void => {
-    const startDatetime = DateUtils.formatRFC3339(date);
+    date?.setTime(date.getTime() + 50000);
+    const startDatetime = DateUtils.formatRFC3339(
+      DateUtils.addCurrentTime(date)
+    );
     setDraft({
       createdDatetime,
       ...draft,
@@ -97,12 +98,6 @@ export const CreateEncounterModal: FC = () => {
     setStartDateTimeError(false);
   };
 
-  const setEndDatetime = (date: Date | null): void => {
-    const endDatetime = DateUtils.formatRFC3339(date);
-    setDraft({ createdDatetime, ...draft, endDatetime });
-    setEndDateTimeError(false);
-  };
-
   const setClinician = (option: ClinicianAutocompleteOption | null): void => {
     if (option === null) {
       setDraft({ createdDatetime, ...draft, clinician: undefined });
@@ -113,10 +108,7 @@ export const CreateEncounterModal: FC = () => {
   };
 
   const canSubmit = () =>
-    draft !== undefined &&
-    draft.startDatetime &&
-    !startDateTimeError &&
-    !endDateTimeError;
+    draft !== undefined && draft.startDatetime && !startDateTimeError;
 
   return (
     <Modal
@@ -164,21 +156,10 @@ export const CreateEncounterModal: FC = () => {
                 <InputWithLabelRow
                   label={t('label.visit-date')}
                   Input={
-                    <DateTimePickerInput
+                    <DatePickerInput
                       value={draft?.startDatetime ?? null}
                       onChange={setStartDatetime}
                       onError={() => setStartDateTimeError(true)}
-                    />
-                  }
-                />
-                <InputWithLabelRow
-                  label={t('label.visit-end')}
-                  Input={
-                    <TimePickerInput
-                      value={draft?.endDatetime ?? null}
-                      disabled={draft?.startDatetime === undefined}
-                      onChange={setEndDatetime}
-                      onError={() => setEndDateTimeError(true)}
                     />
                   }
                 />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1525

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Most of the changes are schema-only, and are done in the programschemas repo. This just includes code changes that were required for a couple of them to work, namely:

- Change "Create Encounter" modal to only collect date, not times (and generate a default start time of the current time)
- Don't add trailing ":" to component labels if they already end with punctuation (e.g. "?")

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Run `./dev_server_schema_update.sh` script from programschemas repo to update local server database, then Testing Program enrolments and encounters should work as per the issue requests.

**Enrolment**:
- [ ] don't show the patient id in the testing enrolment (remove "Enrolment Patient Id")

**Encounter**
- [ ] Clinician input: disallow text input and make it dropdown only (bonus if easy to do)
- [ ] Simplify start time entry (no time)
- [ ] Remove HIV Testing remove date input
- [ ] Testing type: reverse order and fix naming
- [ ] Spelling of questions, e.g. remove ":" for questions
- [ ] Risk group section: add separator after main risk group section

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

The ":" at the end of component labels was hard-coded in each component. I've made a little utility function `labelWithPunctuation` to only append this when the label doesn't already have a punctuation character at the end. I had to apply this function in more components than I would have liked -- this could be improved by doing https://github.com/openmsupply/open-msupply/issues/1255 and making them all use `DetailInputWithLabelRow` as suggested there.