### PR TITLE
#1255 JSONForms component consistency

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -14,8 +14,9 @@ export const BaseDatePickerInput: FC<
     onChange(date: Date): void;
     value: Date | string | null;
     error?: string | undefined;
+    width?: number;
   }
-> = ({ disabled, onChange, value, error, ...props }) => {
+> = ({ disabled, onChange, value, error, width, ...props }) => {
   const theme = useAppTheme();
   const [internalValue, setInternalValue] = useState<Date | null>(null);
 
@@ -76,6 +77,7 @@ export const BaseDatePickerInput: FC<
           ...params,
           variant: 'standard',
           helperText: error ?? '',
+          sx: { width },
         };
         return (
           <BasicTextInput

--- a/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
@@ -6,6 +6,7 @@ interface DatePickerInputProps {
   onChange: (value: Date | null) => void;
   disabled?: boolean;
   onError?: () => void;
+  width?: number;
 }
 
 export const DatePickerInput: FC<DatePickerInputProps> = ({
@@ -13,6 +14,7 @@ export const DatePickerInput: FC<DatePickerInputProps> = ({
   onChange,
   disabled = false,
   onError,
+  width,
 }) => {
   return (
     <BaseDatePickerInput
@@ -21,6 +23,7 @@ export const DatePickerInput: FC<DatePickerInputProps> = ({
       onChange={onChange}
       value={value || null}
       onError={onError}
+      width={width}
     />
   );
 };

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -21,7 +21,7 @@ export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
       display="flex"
       justifyContent="flex-end"
       alignItems="center"
-      // flexBasis={style?.flexBasis}
+      flexBasis={style?.flexBasis}
     >
       <TextField
         ref={ref}

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -16,55 +16,53 @@ export type BasicTextInputProps = StandardTextFieldProps & {
  */
 
 export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
-  ({ sx, style, InputProps, error, required, textAlign, ...props }, ref) => {
-    return (
-      <Box
-        display="flex"
-        justifyContent="flex-end"
-        alignItems="center"
-        flexBasis={style?.flexBasis}
-      >
-        <TextField
-          ref={ref}
-          color="secondary"
-          sx={{
-            '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-            '& .MuiInput-input': { color: 'gray.dark', textAlign },
-            ...sx,
-          }}
-          variant="standard"
-          size="small"
-          InputProps={{
-            disableUnderline: error ? true : false,
-            ...InputProps,
-            sx: {
-              border: theme =>
-                error ? `2px solid ${theme.palette.error.main}` : 'none',
-              backgroundColor: theme =>
-                props.disabled
-                  ? theme.palette.background.toolbar
-                  : theme.palette.background.menu,
-              borderRadius: '8px',
-              padding: '4px 8px',
-              ...InputProps?.sx,
-            },
-          }}
-          {...props}
-        />
-        <Box width={2}>
-          {required && (
-            <Typography
-              sx={{
-                color: 'primary.light',
-                fontSize: '17px',
-                marginRight: 0.5,
-              }}
-            >
-              *
-            </Typography>
-          )}
-        </Box>
+  ({ sx, style, InputProps, error, required, textAlign, ...props }, ref) => (
+    <Box
+      display="flex"
+      justifyContent="flex-end"
+      alignItems="center"
+      // flexBasis={style?.flexBasis}
+    >
+      <TextField
+        ref={ref}
+        color="secondary"
+        sx={{
+          '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+          '& .MuiInput-input': { color: 'gray.dark', textAlign },
+          ...sx,
+        }}
+        variant="standard"
+        size="small"
+        InputProps={{
+          disableUnderline: error ? true : false,
+          ...InputProps,
+          sx: {
+            border: theme =>
+              error ? `2px solid ${theme.palette.error.main}` : 'none',
+            backgroundColor: theme =>
+              props.disabled
+                ? theme.palette.background.toolbar
+                : theme.palette.background.menu,
+            borderRadius: '8px',
+            padding: '4px 8px',
+            ...InputProps?.sx,
+          },
+        }}
+        {...props}
+      />
+      <Box width={2}>
+        {required && (
+          <Typography
+            sx={{
+              color: 'primary.light',
+              fontSize: '17px',
+              marginRight: 0.5,
+            }}
+          >
+            *
+          </Typography>
+        )}
       </Box>
-    );
-  }
+    </Box>
+  )
 );

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -16,48 +16,55 @@ export type BasicTextInputProps = StandardTextFieldProps & {
  */
 
 export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
-  ({ sx, InputProps, error, required, textAlign, ...props }, ref) => (
-    <Box display="flex" justifyContent="flex-end" alignItems="center">
-      <TextField
-        ref={ref}
-        color="secondary"
-        sx={{
-          '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-          '& .MuiInput-input': { color: 'gray.dark', textAlign },
-          ...sx,
-        }}
-        variant="standard"
-        size="small"
-        InputProps={{
-          disableUnderline: error ? true : false,
-          ...InputProps,
-          sx: {
-            border: theme =>
-              error ? `2px solid ${theme.palette.error.main}` : 'none',
-            backgroundColor: theme =>
-              props.disabled
-                ? theme.palette.background.toolbar
-                : theme.palette.background.menu,
-            borderRadius: '8px',
-            padding: '4px 8px',
-            ...InputProps?.sx,
-          },
-        }}
-        {...props}
-      />
-      <Box width={2}>
-        {required && (
-          <Typography
-            sx={{
-              color: 'primary.light',
-              fontSize: '17px',
-              marginRight: 0.5,
-            }}
-          >
-            *
-          </Typography>
-        )}
+  ({ sx, style, InputProps, error, required, textAlign, ...props }, ref) => {
+    return (
+      <Box
+        display="flex"
+        justifyContent="flex-end"
+        alignItems="center"
+        flexBasis={style?.flexBasis}
+      >
+        <TextField
+          ref={ref}
+          color="secondary"
+          sx={{
+            '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+            '& .MuiInput-input': { color: 'gray.dark', textAlign },
+            ...sx,
+          }}
+          variant="standard"
+          size="small"
+          InputProps={{
+            disableUnderline: error ? true : false,
+            ...InputProps,
+            sx: {
+              border: theme =>
+                error ? `2px solid ${theme.palette.error.main}` : 'none',
+              backgroundColor: theme =>
+                props.disabled
+                  ? theme.palette.background.toolbar
+                  : theme.palette.background.menu,
+              borderRadius: '8px',
+              padding: '4px 8px',
+              ...InputProps?.sx,
+            },
+          }}
+          {...props}
+        />
+        <Box width={2}>
+          {required && (
+            <Typography
+              sx={{
+                color: 'primary.light',
+                fontSize: '17px',
+                marginRight: 0.5,
+              }}
+            >
+              *
+            </Typography>
+          )}
+        </Box>
       </Box>
-    </Box>
-  )
+    );
+  }
 );

--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -54,8 +54,7 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
   );
 };
 
-// Adds a final ":" to the label, but not if it already ends in a punctuation
-// character
+// Adds a final ":" to the label, but not if it already ends in "?" or ":"
 export const labelWithPunctuation = (labelString: string) => {
   if (/[\?:]$/.test(labelString)) return labelString;
   else return labelString + ':';

--- a/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Autocomplete.tsx
@@ -3,17 +3,11 @@ import { ControlProps, rankWith, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
   Autocomplete as AutocompleteCommon,
-  Box,
-  FormLabel,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
-import {
-  DefaultFormRowSx,
-  FORM_INPUT_COLUMN_WIDTH,
-  FORM_LABEL_COLUMN_WIDTH,
-} from '../styleConstants';
+import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 
 type Options = {
   freeText?: boolean;
@@ -89,15 +83,17 @@ const UIComponent = (props: ControlProps) => {
     })
   );
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}
-        </FormLabel>
-      </Box>
-      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
         <AutocompleteCommon
-          sx={{ '.MuiFormControl-root': { minWidth: '100%' } }}
+          sx={{
+            '.MuiFormControl-root': { minWidth: '100%' },
+            flexBasis: '100%',
+          }}
           options={options}
           value={{ label: localData ?? '' }}
           // some type problem here, freeSolo seems to have type `undefined`
@@ -119,8 +115,8 @@ const UIComponent = (props: ControlProps) => {
           }}
           disabled={!props.enabled}
         />
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Boolean.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
 import { rankWith, isBooleanControl, ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import {
-  FormLabel,
-  Box,
-  Switch,
-  labelWithPunctuation,
-} from '@openmsupply-client/common';
-import {
-  FORM_LABEL_COLUMN_WIDTH,
-  FORM_INPUT_COLUMN_WIDTH,
-  DefaultFormRowSx,
-} from '../styleConstants';
+import { Switch, DetailInputWithLabelRow } from '@openmsupply-client/common';
+import { FORM_LABEL_WIDTH, DefaultFormRowSx } from '../styleConstants';
 
 export const booleanTester = rankWith(4, isBooleanControl);
 
@@ -22,15 +13,13 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
 
-  console.log('LABEL', label);
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}
-        </FormLabel>
-      </Box>
-      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
         <Switch
           labelPlacement="end"
           onChange={(_, checked) => {
@@ -40,8 +29,8 @@ const UIComponent = (props: ControlProps) => {
           checked={!!data}
           disabled={!enabled}
         />
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/common/components/ConditionalSelect.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/ConditionalSelect.tsx
@@ -3,15 +3,9 @@ import { rankWith, ControlProps, uiTypeIs } from '@jsonforms/core';
 import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
   Autocomplete,
-  FormLabel,
-  Box,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
-import {
-  FORM_LABEL_COLUMN_WIDTH,
-  FORM_INPUT_COLUMN_WIDTH,
-  DefaultFormRowSx,
-} from '../styleConstants';
+import { DefaultFormRowSx, FORM_LABEL_WIDTH } from '../styleConstants';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
 import { get as extractProperty } from 'lodash';
@@ -75,15 +69,17 @@ const UIComponent = (props: ControlProps) => {
   };
 
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}
-        </FormLabel>
-      </Box>
-      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH}>
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
         <Autocomplete
-          sx={{ '.MuiFormControl-root': { minWidth: '100%' } }}
+          sx={{
+            '.MuiFormControl-root': { minWidth: '100%' },
+            flexBasis: '100%',
+          }}
           options={options}
           value={value}
           onChange={onChange}
@@ -95,8 +91,8 @@ const UIComponent = (props: ControlProps) => {
           isOptionEqualToValue={option => option.label === data}
           disabled={!props.enabled}
         />
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/common/components/Select.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Select.tsx
@@ -3,14 +3,9 @@ import { rankWith, isEnumControl, ControlProps } from '@jsonforms/core';
 import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
   Autocomplete,
-  FormLabel,
-  Box,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
-import {
-  FORM_LABEL_COLUMN_WIDTH,
-  FORM_INPUT_COLUMN_WIDTH,
-} from '../styleConstants';
+import { FORM_LABEL_WIDTH, DefaultFormRowSx } from '../styleConstants';
 import { z } from 'zod';
 import { useZodOptionsValidation } from '../hooks/useZodOptionsValidation';
 import parse from 'autosuggest-highlight/parse';
@@ -265,23 +260,17 @@ const UIComponent = (props: ControlProps) => {
   const value = data ? options.find(o => o.value === data) : null;
 
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      gap={2}
-      justifyContent="space-around"
-      style={{ minWidth: 300 }}
-      margin={0.5}
-      marginLeft={0}
-    >
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}
-        </FormLabel>
-      </Box>
-      <Box flexBasis={FORM_INPUT_COLUMN_WIDTH} justifyContent="flex-start">
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
         <Autocomplete
-          sx={{ '.MuiFormControl-root': { minWidth: '100%' } }}
+          sx={{
+            '.MuiFormControl-root': { minWidth: '100%' },
+            flexBasis: '100%',
+          }}
           options={options}
           disabled={!enabled}
           value={value}
@@ -343,8 +332,8 @@ const UIComponent = (props: ControlProps) => {
           }}
           isOptionEqualToValue={option => option.value === data}
         />
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -128,6 +128,7 @@ const UIComponent = (props: ControlProps) => {
       inputProps={{
         value: text ?? '',
         sx: { width },
+        style: { flexBasis: '100%' },
         onChange: e => onChange(e.target.value || ''),
         disabled: !props.enabled,
         error,

--- a/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
+++ b/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
@@ -12,11 +12,12 @@ import {
   DateUtils,
   useTranslation,
   FormLabel,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
+  DefaultFormRowSx,
   FORM_INPUT_COLUMN_WIDTH,
-  FORM_LABEL_COLUMN_WIDTH,
+  FORM_LABEL_WIDTH,
   useZodOptionsValidation,
 } from '../common';
 import { z } from 'zod';
@@ -239,32 +240,30 @@ const UIComponent = (props: ControlProps) => {
     value: adherenceScore !== undefined ? `${adherenceScore.toFixed(1)}%` : '',
   };
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      gap={2}
-      justifyContent="space-around"
-      style={{ minWidth: 300 }}
-      marginTop={1}
-    >
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
-        </FormLabel>
-      </Box>
-      <Box
-        flexBasis={FORM_INPUT_COLUMN_WIDTH}
-        display="flex"
-        alignItems="center"
-      >
-        <BasicTextInput {...inputProps} />
-        <FormLabel
-          sx={{ color: 'warning.main', fontSize: '12px', marginLeft: '10px' }}
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        <Box
+          flexBasis={FORM_INPUT_COLUMN_WIDTH}
+          display="flex"
+          alignItems="center"
         >
-          {warning}
-        </FormLabel>
-      </Box>
-    </Box>
+          <BasicTextInput {...inputProps} />
+          <FormLabel
+            sx={{
+              color: 'warning.main',
+              fontSize: '12px',
+              marginLeft: '10px',
+            }}
+          >
+            {warning}
+          </FormLabel>
+        </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -14,12 +14,13 @@ import {
   useTranslation,
   FormLabel,
   Box,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
-  FORM_INPUT_COLUMN_WIDTH,
   FORM_LABEL_COLUMN_WIDTH,
   DefaultFormRowSx,
   FORM_GAP,
+  FORM_LABEL_WIDTH,
 } from '../common';
 
 export const dateOfBirthTester = rankWith(10, uiTypeIs('DateOfBirth'));
@@ -71,41 +72,39 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
-      </Box>
-      <Box
-        flexBasis={FORM_INPUT_COLUMN_WIDTH}
-        display="flex"
-        alignItems="center"
-        gap={FORM_GAP}
-      >
-        <BaseDatePickerInput
-          // undefined is displayed as "now" and null as unset
-          value={dob ?? null}
-          onChange={onChangeDoB}
-          inputFormat="dd/MM/yyyy"
-          InputProps={{ style: { width: 135 } }}
-          disableFuture
-          disabled={!props.enabled}
-        />
-        <Box
-          flex={0}
-          style={{ textAlign: 'end' }}
-          flexBasis={FORM_LABEL_COLUMN_WIDTH}
-        >
-          <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
-        </Box>
-        <Box flex={0}>
-          <NonNegativeIntegerInput
-            value={age}
-            style={{ width: 50 }}
-            onChange={onChangeAge}
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        <Box flexBasis="100%" display="flex" alignItems="center" gap={FORM_GAP}>
+          <BaseDatePickerInput
+            // undefined is displayed as "now" and null as unset
+            value={dob ?? null}
+            onChange={onChangeDoB}
+            inputFormat="dd/MM/yyyy"
+            InputProps={{ style: { width: 135 } }}
+            disableFuture
+            disabled={!props.enabled}
           />
+          <Box
+            flex={0}
+            style={{ textAlign: 'end' }}
+            flexBasis={FORM_LABEL_COLUMN_WIDTH}
+          >
+            <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
+          </Box>
+          <Box flex={0}>
+            <NonNegativeIntegerInput
+              value={age}
+              style={{ width: 50 }}
+              onChange={onChangeAge}
+            />
+          </Box>
         </Box>
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -14,13 +14,12 @@ import {
   useTranslation,
   FormLabel,
   Box,
-  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
+  FORM_INPUT_COLUMN_WIDTH,
   FORM_LABEL_COLUMN_WIDTH,
   DefaultFormRowSx,
   FORM_GAP,
-  FORM_LABEL_WIDTH,
 } from '../common';
 
 export const dateOfBirthTester = rankWith(10, uiTypeIs('DateOfBirth'));
@@ -72,39 +71,41 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
   return (
-    <DetailInputWithLabelRow
-      sx={DefaultFormRowSx}
-      label={label}
-      labelWidthPercentage={FORM_LABEL_WIDTH}
-      inputAlignment={'start'}
-      Input={
-        <Box flexBasis="100%" display="flex" alignItems="center" gap={FORM_GAP}>
-          <BaseDatePickerInput
-            // undefined is displayed as "now" and null as unset
-            value={dob ?? null}
-            onChange={onChangeDoB}
-            inputFormat="dd/MM/yyyy"
-            InputProps={{ style: { width: 135 } }}
-            disableFuture
-            disabled={!props.enabled}
-          />
-          <Box
-            flex={0}
-            style={{ textAlign: 'end' }}
-            flexBasis={FORM_LABEL_COLUMN_WIDTH}
-          >
-            <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
-          </Box>
-          <Box flex={0}>
-            <NonNegativeIntegerInput
-              value={age}
-              style={{ width: 50 }}
-              onChange={onChangeAge}
-            />
-          </Box>
+    <Box sx={DefaultFormRowSx}>
+      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
+        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
+      </Box>
+      <Box
+        flexBasis={FORM_INPUT_COLUMN_WIDTH}
+        display="flex"
+        alignItems="center"
+        gap={FORM_GAP}
+      >
+        <BaseDatePickerInput
+          // undefined is displayed as "now" and null as unset
+          value={dob ?? null}
+          onChange={onChangeDoB}
+          inputFormat="dd/MM/yyyy"
+          InputProps={{ style: { width: 135 } }}
+          disableFuture
+          disabled={!props.enabled}
+        />
+        <Box
+          flex={0}
+          style={{ textAlign: 'end' }}
+          flexBasis={FORM_LABEL_COLUMN_WIDTH}
+        >
+          <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
         </Box>
-      }
-    />
+        <Box flex={0}>
+          <NonNegativeIntegerInput
+            value={age}
+            style={{ width: 50 }}
+            onChange={onChangeAge}
+          />
+        </Box>
+      </Box>
+    </Box>
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -14,12 +14,13 @@ import {
   useTranslation,
   FormLabel,
   Box,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
-  FORM_INPUT_COLUMN_WIDTH,
   FORM_LABEL_COLUMN_WIDTH,
   DefaultFormRowSx,
   FORM_GAP,
+  FORM_LABEL_WIDTH,
 } from '../common';
 
 export const dateOfBirthTester = rankWith(10, uiTypeIs('DateOfBirth'));
@@ -71,41 +72,39 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>{label}:</FormLabel>
-      </Box>
-      <Box
-        flexBasis={FORM_INPUT_COLUMN_WIDTH}
-        display="flex"
-        alignItems="center"
-        gap={FORM_GAP}
-      >
-        <BaseDatePickerInput
-          // undefined is displayed as "now" and null as unset
-          value={dob ?? null}
-          onChange={onChangeDoB}
-          inputFormat="dd/MM/yyyy"
-          InputProps={{ style: { width: 135 } }}
-          disableFuture
-          disabled={!props.enabled}
-        />
-        <Box
-          flex={0}
-          style={{ textAlign: 'end' }}
-          flexBasis={FORM_LABEL_COLUMN_WIDTH}
-        >
-          <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
-        </Box>
-        <Box flex={0}>
-          <NonNegativeIntegerInput
-            value={age}
-            style={{ width: 50 }}
-            onChange={onChangeAge}
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        <Box display="flex" alignItems="center" gap={FORM_GAP} width="100%">
+          <BaseDatePickerInput
+            // undefined is displayed as "now" and null as unset
+            value={dob ?? null}
+            onChange={onChangeDoB}
+            inputFormat="dd/MM/yyyy"
+            InputProps={{ sx: { width: 135 } }}
+            disableFuture
+            disabled={!props.enabled}
           />
+          <Box
+            flex={0}
+            style={{ textAlign: 'end' }}
+            flexBasis={FORM_LABEL_COLUMN_WIDTH}
+          >
+            <FormLabel sx={{ fontWeight: 'bold' }}>{t('label.age')}:</FormLabel>
+          </Box>
+          <Box flex={0}>
+            <NonNegativeIntegerInput
+              value={age}
+              sx={{ width: 50 }}
+              onChange={onChangeAge}
+            />
+          </Box>
         </Box>
-      </Box>
-    </Box>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -8,13 +8,9 @@ import {
   useTranslation,
   BasicTextInput,
   Button,
-  FormLabel,
-  labelWithPunctuation,
   DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
-  FORM_LABEL_COLUMN_WIDTH,
-  FORM_INPUT_COLUMN_WIDTH,
   DefaultFormRowSx,
   JsonFormsConfig,
   useZodOptionsValidation,
@@ -374,50 +370,14 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
   return (
-    <>
-      <DetailInputWithLabelRow
-        sx={DefaultFormRowSx}
-        label={label}
-        labelWidthPercentage={FORM_LABEL_WIDTH}
-        inputAlignment={'start'}
-        Input={
-          <Box
-            flexBasis={'100%'}
-            display="flex"
-            alignItems="center"
-            gap={FORM_GAP}
-          >
-            <BasicTextInput
-              disabled={!props.enabled || !options?.allowManualEntry}
-              value={text}
-              style={{ flex: 1 }}
-              helperText={errors ?? customError}
-              onChange={e => onChange(e.target.value)}
-              error={!!errors || !!customError}
-            />
-
-            <Box>
-              <Button
-                disabled={error || !canGenerate}
-                onClick={
-                  requireConfirmation ? () => confirmRegenerate() : generate
-                }
-                variant="outlined"
-              >
-                {t('label.generate')}
-              </Button>
-            </Box>
-          </Box>
-        }
-      />
-      <Box sx={DefaultFormRowSx}>
-        <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-          <FormLabel sx={{ fontWeight: 'bold' }}>
-            {labelWithPunctuation(label)}:
-          </FormLabel>
-        </Box>
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
         <Box
-          flexBasis={FORM_INPUT_COLUMN_WIDTH}
+          flexBasis={'100%'}
           display="flex"
           alignItems="center"
           gap={FORM_GAP}
@@ -443,8 +403,8 @@ const UIComponent = (props: ControlProps) => {
             </Button>
           </Box>
         </Box>
-      </Box>
-    </>
+      }
+    />
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   FormLabel,
   labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
@@ -20,6 +21,7 @@ import {
   useDocument,
   useProgramEnrolments,
   FORM_GAP,
+  FORM_LABEL_WIDTH,
 } from '@openmsupply-client/programs';
 import { get as extractProperty } from 'lodash';
 import { z } from 'zod';
@@ -372,38 +374,77 @@ const UIComponent = (props: ControlProps) => {
     return null;
   }
   return (
-    <Box sx={DefaultFormRowSx}>
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
-        </FormLabel>
-      </Box>
-      <Box
-        flexBasis={FORM_INPUT_COLUMN_WIDTH}
-        display="flex"
-        alignItems="center"
-        gap={FORM_GAP}
-      >
-        <BasicTextInput
-          disabled={!props.enabled || !options?.allowManualEntry}
-          value={text}
-          style={{ flex: 1 }}
-          helperText={errors ?? customError}
-          onChange={e => onChange(e.target.value)}
-          error={!!errors || !!customError}
-        />
-
-        <Box>
-          <Button
-            disabled={error || !canGenerate}
-            onClick={requireConfirmation ? () => confirmRegenerate() : generate}
-            variant="outlined"
+    <>
+      <DetailInputWithLabelRow
+        sx={DefaultFormRowSx}
+        label={label}
+        labelWidthPercentage={FORM_LABEL_WIDTH}
+        inputAlignment={'start'}
+        Input={
+          <Box
+            flexBasis={'100%'}
+            display="flex"
+            alignItems="center"
+            gap={FORM_GAP}
           >
-            {t('label.generate')}
-          </Button>
+            <BasicTextInput
+              disabled={!props.enabled || !options?.allowManualEntry}
+              value={text}
+              style={{ flex: 1 }}
+              helperText={errors ?? customError}
+              onChange={e => onChange(e.target.value)}
+              error={!!errors || !!customError}
+            />
+
+            <Box>
+              <Button
+                disabled={error || !canGenerate}
+                onClick={
+                  requireConfirmation ? () => confirmRegenerate() : generate
+                }
+                variant="outlined"
+              >
+                {t('label.generate')}
+              </Button>
+            </Box>
+          </Box>
+        }
+      />
+      <Box sx={DefaultFormRowSx}>
+        <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
+          <FormLabel sx={{ fontWeight: 'bold' }}>
+            {labelWithPunctuation(label)}:
+          </FormLabel>
+        </Box>
+        <Box
+          flexBasis={FORM_INPUT_COLUMN_WIDTH}
+          display="flex"
+          alignItems="center"
+          gap={FORM_GAP}
+        >
+          <BasicTextInput
+            disabled={!props.enabled || !options?.allowManualEntry}
+            value={text}
+            style={{ flex: 1 }}
+            helperText={errors ?? customError}
+            onChange={e => onChange(e.target.value)}
+            error={!!errors || !!customError}
+          />
+
+          <Box>
+            <Button
+              disabled={error || !canGenerate}
+              onClick={
+                requireConfirmation ? () => confirmRegenerate() : generate
+              }
+              variant="outlined"
+            >
+              {t('label.generate')}
+            </Button>
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </>
   );
 };
 

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -6,7 +6,6 @@ import {
   NumericTextInput,
 } from '@openmsupply-client/common';
 import {
-  DefaultFormRowSpacing,
   DefaultFormRowSx,
   FORM_LABEL_WIDTH,
   useZodOptionsValidation,
@@ -210,7 +209,8 @@ const UIComponent = (props: ControlProps) => {
           inputProps={{
             value: displayOption ?? '',
             disabled: true,
-            sx: DefaultFormRowSpacing,
+            sx: { width: '100%' },
+            style: { flexBasis: '100%' },
             error: !!errors,
             helperText: errors,
             multiline,

--- a/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
+++ b/client/packages/programs/src/JsonForms/components/QuantityDispensed.tsx
@@ -9,12 +9,13 @@ import {
   useTranslation,
   FormLabel,
   Box,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
   FORM_LABEL_COLUMN_WIDTH,
-  FORM_INPUT_COLUMN_WIDTH,
   useZodOptionsValidation,
+  DefaultFormRowSx,
+  FORM_LABEL_WIDTH,
 } from '../common';
 import { get as extractProperty } from 'lodash';
 import { z } from 'zod';
@@ -153,25 +154,12 @@ const UIComponent = (props: ControlProps) => {
   }
   return (
     <>
-      <Box
-        display="flex"
-        alignItems="center"
-        gap={2}
-        justifyContent="space-around"
-        style={{ minWidth: 300 }}
-        marginTop={1}
-      >
-        <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-          <FormLabel sx={{ fontWeight: 'bold' }}>
-            {labelWithPunctuation(label)}:
-          </FormLabel>
-        </Box>
-        <Box
-          flexBasis={FORM_INPUT_COLUMN_WIDTH}
-          display="flex"
-          alignItems="center"
-          gap={2}
-        >
+      <DetailInputWithLabelRow
+        sx={DefaultFormRowSx}
+        label={label}
+        labelWidthPercentage={FORM_LABEL_WIDTH}
+        inputAlignment={'start'}
+        Input={
           <PositiveNumberInput
             min={0}
             type="number"
@@ -187,64 +175,54 @@ const UIComponent = (props: ControlProps) => {
             helperText={errors}
             value={localData ?? ''}
           />
-        </Box>
-      </Box>
+        }
+      />
+      <DetailInputWithLabelRow
+        sx={DefaultFormRowSx}
+        label={
+          options?.totalQuantityLabel
+            ? options?.totalQuantityLabel
+            : t('label.total-quantity', { ns: 'programs' })
+        }
+        labelWidthPercentage={FORM_LABEL_WIDTH}
+        inputAlignment={'start'}
+        Input={
+          <Box flexBasis="100%" display="flex" alignItems="center" gap={2}>
+            <PositiveNumberInput
+              min={0}
+              type="number"
+              InputProps={{
+                sx: { '& .MuiInput-input': { textAlign: 'right' } },
+              }}
+              onChange={value => {
+                if (value !== undefined) {
+                  setLocalData(value);
+                  onChange(value);
+                }
+              }}
+              disabled={true}
+              error={error}
+              helperText={errors}
+              value={remainingQuantity + (localData ?? 0)}
+            />
 
-      <Box
-        display="flex"
-        alignItems="center"
-        gap={2}
-        justifyContent="space-around"
-        style={{ minWidth: 300 }}
-        marginTop={1}
-      >
-        <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-          <FormLabel sx={{ fontWeight: 'bold' }}>
-            {options?.totalQuantityLabel
-              ? options?.totalQuantityLabel
-              : t('label.total-quantity', { ns: 'programs' })}
-          </FormLabel>
-        </Box>
-        <Box
-          flexBasis={FORM_INPUT_COLUMN_WIDTH}
-          display="flex"
-          alignItems="center"
-          gap={2}
-        >
-          <PositiveNumberInput
-            min={0}
-            type="number"
-            InputProps={{
-              sx: { '& .MuiInput-input': { textAlign: 'right' } },
-            }}
-            onChange={value => {
-              if (value !== undefined) {
-                setLocalData(value);
-                onChange(value);
-              }
-            }}
-            disabled={true}
-            error={error}
-            helperText={errors}
-            value={remainingQuantity + (localData ?? 0)}
-          />
-
-          <Box
-            flex={0}
-            style={{ textAlign: 'end' }}
-            flexBasis={FORM_LABEL_COLUMN_WIDTH}
-          >
-            <FormLabel sx={{ fontWeight: 'bold' }}>
-              {t('label.end-of-supply')}:
+            <Box
+              flex={0}
+              style={{ textAlign: 'end' }}
+              flexBasis={FORM_LABEL_COLUMN_WIDTH}
+            >
+              <FormLabel sx={{ fontWeight: 'bold' }}>
+                {t('label.end-of-supply')}:
+              </FormLabel>
+            </Box>
+            <FormLabel>
+              {endOfSupplySec
+                ? `${dateFormat.localisedDate(endOfSupplySec)}`
+                : ''}
             </FormLabel>
           </Box>
-          <FormLabel>
-            {endOfSupplySec
-              ? `${dateFormat.localisedDate(endOfSupplySec)}`
-              : ''}
-          </FormLabel>
-        </Box>
-      </Box>
+        }
+      />
     </>
   );
 };

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithDocumentSource.tsx
@@ -4,13 +4,13 @@ import { get as extractProperty } from 'lodash';
 import {
   useTranslation,
   Box,
-  FormLabel,
   Typography,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
-  FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
+  DefaultFormRowSx,
+  FORM_LABEL_WIDTH,
 } from '../../common/styleConstants';
 import { usePatientStore } from '@openmsupply-client/programs';
 import { useEncounter } from '../../../api';
@@ -95,27 +95,25 @@ export const SearchWithDocumentSource = (
   if (!visible) return null;
 
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      gap={2}
-      style={{ minWidth: 300 }}
-      margin={0.5}
-      marginLeft={0}
-    >
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
-        </FormLabel>
-      </Box>
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ width: FORM_INPUT_COLUMN_WIDTH }}
-      >
-        {!error ? displayElement : <Typography color="red">{error}</Typography>}
-      </Box>
-    </Box>
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ width: FORM_INPUT_COLUMN_WIDTH }}
+        >
+          {!error ? (
+            displayElement
+          ) : (
+            <Typography color="red">{error}</Typography>
+          )}
+        </Box>
+      }
+    />
   );
 };

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithUserSource.tsx
@@ -4,17 +4,17 @@ import {
   useDebounceCallback,
   useTranslation,
   Box,
-  FormLabel,
   Autocomplete,
   IconButton,
   EditIcon,
   BasicTextInput,
   Typography,
-  labelWithPunctuation,
+  DetailInputWithLabelRow,
 } from '@openmsupply-client/common';
 import {
-  FORM_LABEL_COLUMN_WIDTH,
   FORM_INPUT_COLUMN_WIDTH,
+  DefaultFormRowSx,
+  FORM_LABEL_WIDTH,
 } from '../../common/styleConstants';
 import { useSearchQueries } from './useSearchQueries';
 import { UserOptions } from './Search';
@@ -85,79 +85,73 @@ export const SearchWithUserSource = (
   if (!visible) return null;
 
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      gap={2}
-      style={{ minWidth: 300 }}
-      margin={0.5}
-      marginLeft={0}
-    >
-      <Box style={{ textAlign: 'end' }} flexBasis={FORM_LABEL_COLUMN_WIDTH}>
-        <FormLabel sx={{ fontWeight: 'bold' }}>
-          {labelWithPunctuation(label)}:
-        </FormLabel>
-      </Box>
-      {editMode ? (
-        <Box flexBasis={FORM_INPUT_COLUMN_WIDTH} justifyContent="flex-start">
-          <>
-            <Autocomplete
-              sx={{ '.MuiFormControl-root': { minWidth: '100%' } }}
-              options={results}
-              disabled={!props.enabled}
-              onChange={(_, option) => handleDataUpdate(option)}
-              onInputChange={(_, value) => {
-                debouncedOnChange(value);
-                setSearchText(value);
-                setNoResultsText(t('control.search.searching-label'));
-              }}
-              onBlur={() => {
-                if (data) setEditMode(false);
-              }}
-              getOptionLabel={getOptionLabel ?? undefined}
-              clearable={!props.config?.required}
-              inputProps={{
-                error: !!error,
-                helperText: error,
-              }}
-              noOptionsText={getNoOptionsText()}
-              renderInput={params => (
-                <BasicTextInput
-                  {...params}
-                  placeholder={
-                    placeholderText ?? t('control.search.search-placeholder')
-                  }
-                />
-              )}
-            />
-          </>
-        </Box>
-      ) : (
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="space-between"
-          sx={{ width: FORM_INPUT_COLUMN_WIDTH }}
-        >
-          {!error ? (
-            <>
-              {getDisplayElement && getDisplayElement(data)}
-              <IconButton
-                label={t('label.edit')}
-                icon={<EditIcon style={{ width: 16 }} />}
-                onClick={() => {
-                  setEditMode(true);
-                }}
-                color="primary"
-                height="20px"
-                width="20px"
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        editMode ? (
+          <Autocomplete
+            sx={{
+              '.MuiFormControl-root': { minWidth: '100%' },
+              flexBasis: '100%',
+            }}
+            options={results}
+            disabled={!props.enabled}
+            onChange={(_, option) => handleDataUpdate(option)}
+            onInputChange={(_, value) => {
+              debouncedOnChange(value);
+              setSearchText(value);
+              setNoResultsText(t('control.search.searching-label'));
+            }}
+            onBlur={() => {
+              if (data) setEditMode(false);
+            }}
+            getOptionLabel={getOptionLabel ?? undefined}
+            clearable={!props.config?.required}
+            inputProps={{
+              error: !!error,
+              helperText: error,
+            }}
+            noOptionsText={getNoOptionsText()}
+            renderInput={params => (
+              <BasicTextInput
+                {...params}
+                placeholder={
+                  placeholderText ?? t('control.search.search-placeholder')
+                }
               />
-            </>
-          ) : (
-            <Typography color="red">{error}</Typography>
-          )}
-        </Box>
-      )}
-    </Box>
+            )}
+          />
+        ) : (
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+            flexBasis="100%"
+            sx={{ width: FORM_INPUT_COLUMN_WIDTH }}
+          >
+            {!error ? (
+              <>
+                {getDisplayElement && getDisplayElement(data)}
+                <IconButton
+                  label={t('label.edit')}
+                  icon={<EditIcon style={{ width: 16 }} />}
+                  onClick={() => {
+                    setEditMode(true);
+                  }}
+                  color="primary"
+                  height="20px"
+                  width="20px"
+                />
+              </>
+            ) : (
+              <Typography color="red">{error}</Typography>
+            )}
+          </Box>
+        )
+      }
+    />
   );
 };

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -6,6 +6,7 @@ import { ClinicianAutocompleteOption, Clinician } from './utils';
 
 interface ClinicianSearchInputProps {
   onChange: (clinician: ClinicianAutocompleteOption | null) => void;
+  width?: number;
   clinicianLabel: string;
   clinicianValue?: Clinician;
 }
@@ -20,6 +21,7 @@ export const getClinicianName = (
 
 export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
   onChange,
+  width = 250,
   clinicianLabel,
   clinicianValue,
 }) => {
@@ -32,7 +34,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
         label: clinicianLabel,
         value: clinicianValue,
       }}
-      width={'200'}
+      width={`${width}px`}
       onChange={(_, option) => {
         onChange(option);
       }}

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -143,7 +143,11 @@ export const CreateEncounterModal: FC = () => {
           <InputWithLabelRow
             label={t('label.encounter')}
             Input={
-              <EncounterSearchInput onChange={onChangeEncounter} value={null} />
+              <EncounterSearchInput
+                onChange={onChangeEncounter}
+                value={null}
+                width={250}
+              />
             }
           />
           <RenderForm
@@ -159,6 +163,7 @@ export const CreateEncounterModal: FC = () => {
                       value={draft?.startDatetime ?? null}
                       onChange={setStartDatetime}
                       onError={() => setStartDateTimeError(true)}
+                      width={250}
                     />
                   }
                 />
@@ -169,6 +174,7 @@ export const CreateEncounterModal: FC = () => {
                       onChange={setClinician}
                       clinicianLabel={getClinicianName(draft?.clinician)}
                       clinicianValue={draft?.clinician}
+                      width={250}
                     />
                   }
                 />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1255

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Previously only about 60% of the components were using the `DetailInputWithLabelRow` wrapper even though they all tried to match the column widths for the label and input to varying degrees of success. Now they all do, which means we can adjust layout widths globally if we need to, plus they should all have consistent widths now.

![Screenshot 2023-04-18 at 10 20 55 AM](https://user-images.githubusercontent.com/5456533/232623079-bc7dd9b6-f65f-4b9f-9371-aba2127c0c59.png)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Load some of the forms, and switch branch between this one and `feature/programs`. The UI should look the same, or slightly better (text input widths should match the others).