### PR TITLE
#1543 request response searching line

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -18,9 +18,13 @@ const useItemFilter = () => {
   };
 };
 
-const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) =>
-  RegexUtils.includes(itemFilter, name ?? '') ||
-  RegexUtils.includes(itemFilter, code ?? '');
+const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+  const filter = RegexUtils.escapeChars(itemFilter);
+  return (
+    RegexUtils.includes(filter, name ?? '') ||
+    RegexUtils.includes(filter, code ?? '')
+  );
+};
 
 export const useRequestLines = () => {
   const { on } = useHideOverStocked();

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
@@ -9,8 +9,8 @@ import { ResponseRowFragment } from '../api';
 export const Toolbar: FC<{
   filter: FilterController;
 }> = ({ filter }) => {
-  const key = 'comment' as keyof ResponseRowFragment;
-  const filterString = filter.filterBy?.[key]?.like as string;
+  const key = 'otherPartyName' as keyof ResponseRowFragment;
+  const filterString = (filter.filterBy?.[key]?.like as string) || '';
 
   return (
     <AppBarContentPortal

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
@@ -5,6 +5,7 @@ import {
   Column,
   RegexUtils,
   useUrlQuery,
+  ItemNode
 } from '@openmsupply-client/common';
 import { ResponseLineFragment } from '../../operations.generated';
 import { useResponseColumns } from '../../../DetailView/columns';
@@ -20,12 +21,21 @@ interface UseResponseLinesController
 }
 
 const useItemFilter = () => {
-  const { urlQuery, updateQuery } = useUrlQuery();
+  // const { urlQuery, updateQuery } = useUrlQuery();
+  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['codeOrName'] });
   return {
-    itemFilter: urlQuery.itemName ?? '',
+    itemFilter: urlQuery.codeOrName ?? '',
     setItemFilter: (itemFilter: string) =>
-      updateQuery({ itemName: itemFilter }),
+      updateQuery({ codeOrName: itemFilter }),
   };
+};
+
+const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+  const filter = RegexUtils.escapeChars(itemFilter);
+  return (
+    RegexUtils.includes(filter, name ?? '') ||
+    RegexUtils.includes(filter, code ?? '')
+  );
 };
 
 export const useResponseLines = (): UseResponseLinesController => {
@@ -41,9 +51,12 @@ export const useResponseLines = (): UseResponseLinesController => {
           SortUtils.getColumnSorter(getSortValue, !!sortBy.isDesc)
         )
       : lines?.nodes;
-    return sortedLines.filter(({ item: { name } }) =>
-      RegexUtils.includes(itemFilter, name)
-    );
+    // return sortedLines.filter(({ item: { name } }) =>
+    // matchItem(itemFilter, name)
+    // );
+    return sortedLines.filter(
+      item => matchItem(itemFilter, item.item)
+    )
   }, [sortBy.key, sortBy.isDesc, lines, itemFilter]);
 
   return {

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
@@ -51,9 +51,6 @@ export const useResponseLines = (): UseResponseLinesController => {
           SortUtils.getColumnSorter(getSortValue, !!sortBy.isDesc)
         )
       : lines?.nodes;
-    // return sortedLines.filter(({ item: { name } }) =>
-    // matchItem(itemFilter, name)
-    // );
     return sortedLines.filter(
       item => matchItem(itemFilter, item.item)
     )


### PR DESCRIPTION
Fixes #1543 

# 👩🏻‍💻 What does this PR do? 

- Protect the APP panicking if searching line is by *
- On request order lines
   - Fixes the searching of lines by item code when item code have a 0 in it
      - was resetting to blank so searching got broken
- On a response line
   - Same as request order line
   - Added a searching by item code and name

# 🧪 How has/should this change been tested? 

- Setup omsupply
- Require
   - Response order with lines
      - Have some item with item code that has 0
   - Request order with lines
      - Have some item with item code that has 0