### PR TITLE
#1541 sync password to site password

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -174,7 +174,7 @@
   "label.server": "Server",
   "label.settings-central-site-id": "Central server Site ID",
   "label.settings-interval": "Interval (seconds)",
-  "label.settings-password": "Sync password",
+  "label.settings-password": "Site password",
   "label.settings-site-id": "Site ID",
   "label.settings-url": "Central server URL",
   "label.settings-username": "Site name",


### PR DESCRIPTION
Fixes #1541 

# 👩🏻‍💻 What does this PR do? 

- Changes the label from Sync password to Site password