### PR TITLE
1510 api for creating program requisitions 

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -178,7 +178,7 @@
   "label.server": "Server",
   "label.settings-central-site-id": "Central server Site ID",
   "label.settings-interval": "Interval (seconds)",
-  "label.settings-password": "Sync password",
+  "label.settings-password": "Site password",
   "label.settings-site-id": "Site ID",
   "label.settings-url": "Central server URL",
   "label.settings-username": "Site name",

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -98,6 +98,28 @@ export const useInboundShipmentColumns = () => {
         },
       ],
       [
+        'itemUnit',
+        {
+          getSortValue: row => {
+            if ('lines' in row) {
+              return row.lines[0]?.item.unitName ?? '';
+            } else {
+              return row.item.unitName ?? '';
+            }
+          },
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const items = rowData.lines.map(({ item }) => item);
+              return (
+                ArrayUtils.ifTheSameElseDefault(items, 'unitName', '') ?? ''
+              );
+            } else {
+              return rowData.item.unitName ?? '';
+            }
+          },
+        },
+      ],
+      [
         'batch',
         {
           accessor: ({ rowData }) => {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -115,6 +115,28 @@ export const useOutboundColumns = ({
         },
       ],
       [
+        'itemUnit',
+        {
+          getSortValue: row => {
+            if ('lines' in row) {
+              return row.lines[0]?.item.unitName ?? '';
+            } else {
+              return row.item.unitName ?? '';
+            }
+          },
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const items = rowData.lines.map(({ item }) => item);
+              return (
+                ArrayUtils.ifTheSameElseDefault(items, 'unitName', '') ?? ''
+              );
+            } else {
+              return rowData.item.unitName ?? '';
+            }
+          },
+        },
+      ],
+      [
         'batch',
         {
           getSortValue: row => {
@@ -192,28 +214,6 @@ export const useOutboundColumns = ({
               return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
             } else {
               return rowData.location?.name ?? '';
-            }
-          },
-        },
-      ],
-      [
-        'itemUnit',
-        {
-          getSortValue: row => {
-            if ('lines' in row) {
-              return row.lines[0]?.item.unitName ?? '';
-            } else {
-              return row.item.unitName ?? '';
-            }
-          },
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const items = rowData.lines.map(({ item }) => item);
-              return (
-                ArrayUtils.ifTheSameElseDefault(items, 'unitName', '') ?? ''
-              );
-            } else {
-              return rowData.item.unitName ?? '';
             }
           },
         },

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -18,9 +18,13 @@ const useItemFilter = () => {
   };
 };
 
-const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) =>
-  RegexUtils.includes(itemFilter, name ?? '') ||
-  RegexUtils.includes(itemFilter, code ?? '');
+const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+  const filter = RegexUtils.escapeChars(itemFilter);
+  return (
+    RegexUtils.includes(filter, name ?? '') ||
+    RegexUtils.includes(filter, code ?? '')
+  );
+};
 
 export const useRequestLines = () => {
   const { on } = useHideOverStocked();

--- a/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
@@ -9,8 +9,8 @@ import { ResponseRowFragment } from '../api';
 export const Toolbar: FC<{
   filter: FilterController;
 }> = ({ filter }) => {
-  const key = 'comment' as keyof ResponseRowFragment;
-  const filterString = filter.filterBy?.[key]?.like as string;
+  const key = 'otherPartyName' as keyof ResponseRowFragment;
+  const filterString = (filter.filterBy?.[key]?.like as string) || '';
 
   return (
     <AppBarContentPortal

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -42,6 +42,15 @@ const ItemListComponent: FC = () => {
     [
       'code',
       'name',
+      {
+        accessor: ({ rowData }) =>
+          rowData.unitName ?? '',
+        align: ColumnAlign.Right,
+        key: 'unitName',
+        label: 'label.unit',
+        sortable: false,
+        width: 100,
+      },
       [
         'stockOnHand',
         {

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -18,6 +18,7 @@ import {
   CircularProgress,
 } from '@openmsupply-client/common';
 import { StockLineRowFragment } from '../api';
+import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
 
 const StyledInputRow = ({ label, Input }: InputWithLabelRowProps) => (
   <InputWithLabelRow
@@ -28,7 +29,7 @@ const StyledInputRow = ({ label, Input }: InputWithLabelRowProps) => (
     sx={{
       justifyContent: 'space-between',
       '.MuiFormControl-root > .MuiInput-root, > input': {
-        maxWidth: '120px',
+        maxWidth: '160px',
       },
     }}
   />
@@ -147,6 +148,18 @@ export const StockLineForm: FC<StockLineFormProps> = ({ draft, onUpdate }) => {
             <Checkbox
               checked={draft.onHold}
               onChange={(_, onHold) => onUpdate({ onHold })}
+            />
+          }
+        />
+        <StyledInputRow
+          label={t('label.location')}
+          Input={
+            <LocationSearchInput
+              autoFocus={false}
+              disabled={false}
+              value={draft.location ?? null}
+              width={160}
+              onChange={location => onUpdate({ locationId: location?.id })}
             />
           }
         />

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type StockLineRowFragment = { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } };
+export type StockLineRowFragment = { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } };
 
 export type StockLinesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -16,7 +16,7 @@ export type StockLinesQueryVariables = Types.Exact<{
 }>;
 
 
-export type StockLinesQuery = { __typename: 'Queries', stockLines: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } }> } };
+export type StockLinesQuery = { __typename: 'Queries', stockLines: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } }> } };
 
 export type StockLineQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
@@ -24,7 +24,7 @@ export type StockLineQueryVariables = Types.Exact<{
 }>;
 
 
-export type StockLineQuery = { __typename: 'Queries', stockLines: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } }> } };
+export type StockLineQuery = { __typename: 'Queries', stockLines: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } }> } };
 
 export type UpdateStockLineMutationVariables = Types.Exact<{
   input: Types.UpdateStockLineInput;
@@ -32,7 +32,7 @@ export type UpdateStockLineMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateStockLineMutation = { __typename: 'Mutations', updateStockLine: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } } | { __typename: 'UpdateStockLineError' } };
+export type UpdateStockLineMutation = { __typename: 'Mutations', updateStockLine: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, locationId?: string | null, locationName?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, supplierName?: string | null, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null, item: { __typename: 'ItemNode', code: string, name: string, unitName?: string | null } } | { __typename: 'UpdateStockLineError' } };
 
 export const StockLineRowFragmentDoc = gql`
     fragment StockLineRow on StockLineNode {
@@ -50,6 +50,12 @@ export const StockLineRowFragmentDoc = gql`
   storeId
   totalNumberOfPacks
   supplierName
+  location {
+    code
+    id
+    name
+    onHold
+  }
   item {
     code
     name

--- a/client/packages/system/src/Stock/api/operations.graphql
+++ b/client/packages/system/src/Stock/api/operations.graphql
@@ -13,6 +13,12 @@ fragment StockLineRow on StockLineNode {
   storeId
   totalNumberOfPacks
   supplierName
+  location {
+    code
+    id
+    name
+    onHold
+  }
   item {
     code
     name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2030,7 +2030,6 @@ dependencies = [
  "async-std",
  "async-trait",
  "chrono",
- "cookie",
  "repository",
  "reqwest",
  "serde 1.0.137",
@@ -4765,9 +4764,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2030,6 +2030,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "chrono",
+ "cookie",
  "repository",
  "reqwest",
  "serde 1.0.137",

--- a/server/graphql/core/Cargo.toml
+++ b/server/graphql/core/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 
 tokio = { version = "1.17.0", features = ["macros" ] }
 async-std = "1.9.0" 
+cookie = "0.16"
 
 [features]
 default = ["sqlite"]

--- a/server/graphql/core/Cargo.toml
+++ b/server/graphql/core/Cargo.toml
@@ -13,7 +13,7 @@ repository = { path = "../../repository" }
 service = { path = "../../service" }
 util = { path = "../../util" }
 
-actix-web = { workspace = true }
+actix-web = { features=["cookies"], workspace = true }
 anymap= { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-actix-web = { workspace = true }
@@ -26,7 +26,7 @@ thiserror = { workspace = true }
 
 tokio = { version = "1.17.0", features = ["macros" ] }
 async-std = "1.9.0" 
-cookie = "0.16"
+
 
 [features]
 default = ["sqlite"]

--- a/server/graphql/requisition/src/lib.rs
+++ b/server/graphql/requisition/src/lib.rs
@@ -56,6 +56,15 @@ impl RequisitionMutations {
         request_requisition::insert(ctx, &store_id, input)
     }
 
+    async fn insert_program_request_requisition(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: request_requisition::InsertProgramRequestRequisitionInput,
+    ) -> Result<request_requisition::InsertResponse> {
+        request_requisition::insert_program(ctx, &store_id, input)
+    }
+
     async fn update_request_requisition(
         &self,
         ctx: &Context<'_>,

--- a/server/graphql/requisition/src/mutations/request_requisition/insert.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/insert.rs
@@ -108,7 +108,7 @@ impl InsertInput {
     }
 }
 
-fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
+pub fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
     use StandardGraphqlError::*;
     let formatted_error = format!("{:#?}", error);
 

--- a/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
@@ -1,11 +1,6 @@
 use async_graphql::*;
 use chrono::NaiveDate;
-use graphql_core::{
-    simple_generic_errors::{OtherPartyNotASupplier, OtherPartyNotVisible},
-    standard_graphql_error::validate_auth,
-    standard_graphql_error::StandardGraphqlError,
-    ContextExt,
-};
+use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use graphql_types::types::RequisitionNode;
 use repository::Requisition;
 use service::{
@@ -16,9 +11,7 @@ use service::{
 };
 use util::{constants::expected_delivery_date_offset, date_now_with_offset};
 
-use crate::mutations::request_requisition::InsertErrorInterface;
-
-use super::{InsertError, InsertResponse};
+use super::{map_error, InsertError, InsertResponse};
 
 #[derive(InputObject)]
 #[graphql(name = "InsertProgramRequestRequisitionInput")]
@@ -95,36 +88,6 @@ impl InsertProgramRequestRequisitionInput {
             period_id,
         }
     }
-}
-
-fn map_error(error: InsertRequestRequisitionError) -> Result<InsertErrorInterface> {
-    use StandardGraphqlError::*;
-    let formatted_error = format!("{:#?}", error);
-
-    let graphql_error = match error {
-        // Structured Errors
-        InsertRequestRequisitionError::OtherPartyNotASupplier => {
-            return Ok(InsertErrorInterface::OtherPartyNotASupplier(
-                OtherPartyNotASupplier,
-            ))
-        }
-        InsertRequestRequisitionError::OtherPartyNotVisible => {
-            return Ok(InsertErrorInterface::OtherPartyNotVisible(
-                OtherPartyNotVisible,
-            ))
-        }
-        // Standard Graphql Errors
-        InsertRequestRequisitionError::RequisitionAlreadyExists => BadUserInput(formatted_error),
-        InsertRequestRequisitionError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
-
-        InsertRequestRequisitionError::OtherPartyIsNotAStore => BadUserInput(formatted_error),
-        InsertRequestRequisitionError::NewlyCreatedRequisitionDoesNotExist => {
-            InternalError(formatted_error)
-        }
-        InsertRequestRequisitionError::DatabaseError(_) => InternalError(formatted_error),
-    };
-
-    Err(graphql_error.extend())
 }
 
 #[cfg(test)]

--- a/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/insert_program.rs
@@ -1,0 +1,386 @@
+use async_graphql::*;
+use chrono::NaiveDate;
+use graphql_core::{
+    simple_generic_errors::{OtherPartyNotASupplier, OtherPartyNotVisible},
+    standard_graphql_error::validate_auth,
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
+};
+use graphql_types::types::RequisitionNode;
+use repository::Requisition;
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    requisition::request_requisition::{
+        InsertProgramRequestRequisition, InsertRequestRequisitionError,
+    },
+};
+use util::{constants::expected_delivery_date_offset, date_now_with_offset};
+
+use crate::mutations::request_requisition::InsertErrorInterface;
+
+use super::{InsertError, InsertResponse};
+
+#[derive(InputObject)]
+#[graphql(name = "InsertProgramRequestRequisitionInput")]
+pub struct InsertProgramRequestRequisitionInput {
+    pub id: String,
+    pub other_party_id: String,
+    pub colour: Option<String>,
+    pub their_reference: Option<String>,
+    pub comment: Option<String>,
+    pub program_order_type_id: String,
+    pub period_id: String,
+    /// Defaults to 2 weeks from now
+    pub expected_delivery_date: Option<NaiveDate>,
+}
+
+pub fn insert_program(
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: InsertProgramRequestRequisitionInput,
+) -> Result<InsertResponse> {
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutateRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
+
+    map_response(
+        service_provider
+            .requisition_service
+            .insert_program_request_requisition(&service_context, input.to_domain()),
+    )
+}
+
+pub fn map_response(
+    from: Result<Requisition, InsertRequestRequisitionError>,
+) -> Result<InsertResponse> {
+    let result = match from {
+        Ok(requisition) => InsertResponse::Response(RequisitionNode::from_domain(requisition)),
+        Err(error) => InsertResponse::Error(InsertError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
+}
+
+impl InsertProgramRequestRequisitionInput {
+    pub fn to_domain(self) -> InsertProgramRequestRequisition {
+        let InsertProgramRequestRequisitionInput {
+            id,
+            other_party_id,
+            colour,
+            their_reference,
+            comment,
+            expected_delivery_date,
+            program_order_type_id,
+            period_id,
+        } = self;
+
+        InsertProgramRequestRequisition {
+            id,
+            other_party_id,
+            colour,
+            their_reference,
+            comment,
+            expected_delivery_date: expected_delivery_date
+                .or(Some(date_now_with_offset(expected_delivery_date_offset()))),
+            program_order_type_id,
+            period_id,
+        }
+    }
+}
+
+fn map_error(error: InsertRequestRequisitionError) -> Result<InsertErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        InsertRequestRequisitionError::OtherPartyNotASupplier => {
+            return Ok(InsertErrorInterface::OtherPartyNotASupplier(
+                OtherPartyNotASupplier,
+            ))
+        }
+        InsertRequestRequisitionError::OtherPartyNotVisible => {
+            return Ok(InsertErrorInterface::OtherPartyNotVisible(
+                OtherPartyNotVisible,
+            ))
+        }
+        // Standard Graphql Errors
+        InsertRequestRequisitionError::RequisitionAlreadyExists => BadUserInput(formatted_error),
+        InsertRequestRequisitionError::OtherPartyDoesNotExist => BadUserInput(formatted_error),
+
+        InsertRequestRequisitionError::OtherPartyIsNotAStore => BadUserInput(formatted_error),
+        InsertRequestRequisitionError::NewlyCreatedRequisitionDoesNotExist => {
+            InternalError(formatted_error)
+        }
+        InsertRequestRequisitionError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::EmptyMutation;
+    use chrono::NaiveDate;
+    use graphql_core::{
+        assert_graphql_query, assert_standard_graphql_error, test_helpers::setup_graphl_test,
+    };
+    use repository::{
+        mock::{mock_request_draft_requisition, MockDataInserts},
+        Requisition, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use service::{
+        requisition::{
+            request_requisition::{InsertProgramRequestRequisition, InsertRequestRequisitionError},
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+    use util::{date_now, inline_init};
+
+    use crate::RequisitionMutations;
+
+    type InsertLineMethod = dyn Fn(InsertProgramRequestRequisition) -> Result<Requisition, InsertRequestRequisitionError>
+        + Sync
+        + Send;
+
+    pub struct TestService(pub Box<InsertLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn insert_program_request_requisition(
+            &self,
+            _: &ServiceContext,
+            input: InsertProgramRequestRequisition,
+        ) -> Result<Requisition, InsertRequestRequisitionError> {
+            self.0(input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone(), "app_data");
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+            "otherPartyId": "n/a",
+            "maxMonthsOfStock": 0,
+            "minMonthsOfStock": 0
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_request_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_graphl_test(
+            EmptyMutation,
+            RequisitionMutations,
+            "test_graphql_insert_program_program_request_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertProgramRequestRequisitionInput!, $storeId: String) {
+            insertRequestRequisition(storeId: $storeId, input: $input) {
+              ... on InsertRequestRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // OtherPartyNotASupplier
+        let test_service = TestService(Box::new(|_| {
+            Err(InsertRequestRequisitionError::OtherPartyNotASupplier)
+        }));
+
+        let expected = json!({
+            "insertRequestRequisition": {
+              "error": {
+                "__typename": "OtherPartyNotASupplier"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // RequisitionAlreadyExists
+        let test_service = TestService(Box::new(|_| {
+            Err(InsertRequestRequisitionError::RequisitionAlreadyExists)
+        }));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyDoesNotExist
+        let test_service = TestService(Box::new(|_| {
+            Err(InsertRequestRequisitionError::OtherPartyDoesNotExist)
+        }));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyIsNotAStore
+        let test_service = TestService(Box::new(|_| {
+            Err(InsertRequestRequisitionError::OtherPartyIsNotAStore)
+        }));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NewlyCreatedRequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_| {
+            Err(InsertRequestRequisitionError::NewlyCreatedRequisitionDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_program_request_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_graphl_test(
+            EmptyMutation,
+            RequisitionMutations,
+            "test_graphql_insert_program_request_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: InsertProgramRequestRequisitionInput!) {
+            insertRequestRequisition(storeId: $storeId, input: $input) {
+                ... on RequisitionNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|input| {
+            assert_eq!(
+                input,
+                InsertProgramRequestRequisition {
+                    id: "id input".to_string(),
+                    other_party_id: "other party input".to_string(),
+                    colour: Some("colour input".to_string()),
+                    their_reference: Some("reference input".to_string()),
+                    comment: Some("comment input".to_string()),
+                    expected_delivery_date: Some(NaiveDate::from_ymd_opt(2022, 01, 03).unwrap()),
+                    program_order_type_id: "program_order_type_id".to_string(),
+                    period_id: "period_id".to_string(),
+                }
+            );
+            Ok(inline_init(|r: &mut Requisition| {
+                r.requisition_row = mock_request_draft_requisition()
+            }))
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+            "otherPartyId": "other party input",
+            "maxMonthsOfStock": 1,
+            "minMonthsOfStock": 2,
+            "colour": "colour input",
+            "theirReference": "reference input",
+            "comment": "comment input",
+            "expectedDeliveryDate": "2022-01-03"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "insertRequestRequisition": {
+                "id": mock_request_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // Default expected_delivery_date
+        let test_service = TestService(Box::new(|input| {
+            let now = date_now();
+            let expected = input.expected_delivery_date.unwrap();
+            assert_eq!((expected - now), chrono::Duration::weeks(2));
+
+            Ok(inline_init(|r: &mut Requisition| {
+                r.requisition_row = mock_request_draft_requisition()
+            }))
+        }));
+
+        let expected = json!({
+            "insertRequestRequisition": {
+                "id": mock_request_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/graphql/requisition/src/mutations/request_requisition/mod.rs
+++ b/server/graphql/requisition/src/mutations/request_requisition/mod.rs
@@ -1,6 +1,9 @@
 pub mod insert;
 pub use insert::*;
 
+pub mod insert_program;
+pub use insert_program::*;
+
 pub mod delete;
 pub use delete::*;
 

--- a/server/repository/src/db_diesel/barcode.rs
+++ b/server/repository/src/db_diesel/barcode.rs
@@ -1,0 +1,130 @@
+use super::{
+    barcode_row::{barcode, barcode::dsl as barcode_dsl},
+    BarcodeRow, DBType, StorageConnection,
+};
+use diesel::prelude::*;
+
+use crate::{
+    diesel_macros::{apply_equal_filter, apply_sort_no_case},
+    repository_error::RepositoryError,
+};
+
+use crate::{EqualFilter, Pagination, Sort};
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct Barcode {
+    pub barcode_row: BarcodeRow,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct BarcodeFilter {
+    pub id: Option<EqualFilter<String>>,
+    pub value: Option<EqualFilter<String>>,
+    pub item_id: Option<EqualFilter<String>>,
+    pub pack_size: Option<EqualFilter<i32>>,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum BarcodeSortField {
+    Id,
+    Barcode,
+}
+
+pub type BarcodeSort = Sort<BarcodeSortField>;
+
+pub struct BarcodeRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> BarcodeRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        BarcodeRepository { connection }
+    }
+
+    pub fn count(&self, filter: Option<BarcodeFilter>) -> Result<i64, RepositoryError> {
+        let query = create_filtered_query(filter);
+        Ok(query.count().get_result(&self.connection.connection)?)
+    }
+
+    pub fn query_by_filter(&self, filter: BarcodeFilter) -> Result<Vec<Barcode>, RepositoryError> {
+        self.query(Pagination::all(), Some(filter), None)
+    }
+
+    pub fn query(
+        &self,
+        pagination: Pagination,
+        filter: Option<BarcodeFilter>,
+        sort: Option<BarcodeSort>,
+    ) -> Result<Vec<Barcode>, RepositoryError> {
+        let mut query = create_filtered_query(filter);
+        if let Some(sort) = sort {
+            match sort.key {
+                BarcodeSortField::Id => {
+                    apply_sort_no_case!(query, sort, barcode_dsl::id)
+                }
+                BarcodeSortField::Barcode => {
+                    apply_sort_no_case!(query, sort, barcode_dsl::value)
+                }
+            }
+        } else {
+            query = query.order(barcode_dsl::value.asc())
+        }
+
+        let result = query
+            .offset(pagination.offset as i64)
+            .limit(pagination.limit as i64)
+            .load::<BarcodeRow>(&self.connection.connection)?;
+
+        Ok(result.into_iter().map(to_domain).collect())
+    }
+}
+
+type BoxedLogQuery = barcode::BoxedQuery<'static, DBType>;
+
+fn create_filtered_query(filter: Option<BarcodeFilter>) -> BoxedLogQuery {
+    let mut query = barcode::table.into_boxed();
+
+    if let Some(filter) = filter {
+        apply_equal_filter!(query, filter.id, barcode_dsl::id);
+        apply_equal_filter!(query, filter.value, barcode_dsl::value);
+        apply_equal_filter!(query, filter.item_id, barcode_dsl::item_id);
+        apply_equal_filter!(query, filter.pack_size, barcode_dsl::pack_size);
+    }
+
+    query
+}
+
+pub fn to_domain(barcode_row: BarcodeRow) -> Barcode {
+    Barcode { barcode_row }
+}
+
+impl BarcodeFilter {
+    pub fn new() -> BarcodeFilter {
+        BarcodeFilter {
+            id: None,
+            value: None,
+            item_id: None,
+            pack_size: None,
+        }
+    }
+
+    pub fn id(mut self, filter: EqualFilter<String>) -> Self {
+        self.id = Some(filter);
+        self
+    }
+
+    pub fn value(mut self, filter: EqualFilter<String>) -> Self {
+        self.value = Some(filter);
+        self
+    }
+
+    pub fn item_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.item_id = Some(filter);
+        self
+    }
+
+    pub fn pack_size(mut self, filter: EqualFilter<i32>) -> Self {
+        self.pack_size = Some(filter);
+        self
+    }
+}

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -1,0 +1,78 @@
+use super::{barcode_row::barcode::dsl as barcode_dsl, StorageConnection};
+
+use crate::{
+    db_diesel::{invoice_line_row::invoice_line, item_row::item},
+    repository_error::RepositoryError,
+};
+
+use diesel::prelude::*;
+
+table! {
+    barcode (id) {
+        id -> Text,
+        value -> Text,
+        item_id -> Nullable<Text>,
+        manufacturer_id -> Nullable<Text>,
+        pack_size -> Nullable<Integer>,
+        parent_id -> Nullable<Text>,
+    }
+}
+
+joinable!(barcode -> item (item_id));
+joinable!(barcode -> invoice_line (id));
+
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[changeset_options(treat_none_as_null = "true")]
+#[table_name = "barcode"]
+pub struct BarcodeRow {
+    pub id: String,
+    pub value: String,
+    pub item_id: Option<String>,
+    pub manufacturer_id: Option<String>,
+    pub pack_size: Option<i32>,
+    pub parent_id: Option<String>,
+}
+
+pub struct BarcodeRowRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> BarcodeRowRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        BarcodeRowRepository { connection }
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn upsert_one(&self, row: &BarcodeRow) -> Result<(), RepositoryError> {
+        diesel::insert_into(barcode_dsl::barcode)
+            .values(row)
+            .on_conflict(barcode_dsl::id)
+            .do_update()
+            .set(row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "postgres"))]
+    pub fn upsert_one(&self, row: &BarcodeRow) -> Result<(), RepositoryError> {
+        diesel::replace_into(barcode_dsl::barcode)
+            .values(row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    pub fn find_one_by_id(&self, id: &str) -> Result<Option<BarcodeRow>, RepositoryError> {
+        let result = barcode_dsl::barcode
+            .filter(barcode_dsl::id.eq(id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
+    pub fn find_many_by_item_id(&self, item_id: &str) -> Result<Vec<BarcodeRow>, RepositoryError> {
+        let result = barcode_dsl::barcode
+            .filter(barcode_dsl::item_id.eq(item_id))
+            .get_results(&self.connection.connection)?;
+        Ok(result)
+    }
+}

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -52,6 +52,7 @@ pub enum ChangelogTableName {
     RequisitionLine,
     ActivityLog,
     InventoryAdjustmentReason,
+    Barcode,
 }
 
 #[derive(Clone, Queryable, Debug, PartialEq, Insertable)]

--- a/server/repository/src/db_diesel/mod.rs
+++ b/server/repository/src/db_diesel/mod.rs
@@ -2,6 +2,8 @@ use crate::repository_error::RepositoryError;
 
 mod activity_log;
 mod activity_log_row;
+mod barcode;
+mod barcode_row;
 mod changelog;
 mod consumption;
 pub mod diesel_schema;
@@ -60,6 +62,8 @@ mod user_store_join_row;
 
 pub use activity_log::*;
 pub use activity_log_row::*;
+pub use barcode::*;
+pub use barcode_row::*;
 pub use changelog::*;
 pub use consumption::*;
 pub use filter_sort_pagination::*;

--- a/server/repository/src/migrations/README.md
+++ b/server/repository/src/migrations/README.md
@@ -25,11 +25,11 @@ Diesel dsl can be used in data migrations, however, for some operations sql stat
 
 ## How to add migration
 
-Identify next version, see [package.json](../../../../package.json) for current version, then increment `patch` by one (we use semantic versioning syntax for our version number, but our app versioning wouldn't necesseraly follow SemVer guidelines which are aimed at publicly consumed packages and libraries, see [version.rs](./version.rs) for more details).
+Identify next version, see [package.json](../../../../package.json) for current version, then increment `patch` by one (we use semantic versioning syntax for our version number, but our app versioning wouldn't necessarily follow SemVer guidelines which are aimed at publicly consumed packages and libraries, see [version.rs](./version.rs) for more details).
 
-**note** everything after `patch` is condiered `pre-release`, and cannot be upgraded further (pre-relase version is really undefined, it could be a test branch or a release candidate), but `pre-release` versions can be used to manually test migrations/functionality in production.
+**note** everything after `patch` is considered `pre-release`, and cannot be upgraded further (pre-release version is really undefined, it could be a test branch or a release candidate), but `pre-release` versions can be used to manually test migrations/functionality in production.
 
-Increment [package.json](../../../../package.json) version to the new version and create new migration folder with the version number. Copy template or existing migration, and rename to new version approprately. 
+Increment [package.json](../../../../package.json) version to the new version and create new migration folder with the version number. Copy template or existing migration, and rename to new version appropriately. 
 
 Add new version mod to [root migrations mode](mod.rs) and add new version to `vec!` of visitors. Add actual migration code and tests, through tests you should be able to check sql syntax and data migration logic without starting server.
 
@@ -41,7 +41,7 @@ Ideally we would be using existing repositories for data migrations, but this wi
 * Since raw sql query still requires a struct to save a result in, I found that adding diesel `table!` with minimum fields has about the same amount of code and allows for a way to select a result into a tuple and opens a way to use diesel dsl for queries and updates, [again in data migration template, query/update in migration and query in test](templates/data_migration/mod.rs)
 * Updates in the templates could have been done with sql, using diesel dsl felt just as easy and in examples use cases updates were done in in `depth` of rust code, and for some reason use diesel dsl felt more natural
 
-A quick note about type safety in migrations, since the schema (before/after) is well know at the time of migration and since it shouldn't change in the future, unit test should be adequate to guarantee type safety (i.e. we dont' need compiler to tell use that our database types are not aligned with new future schema)
+A quick note about type safety in migrations, since the schema (before/after) is well know at the time of migration and since it shouldn't change in the future, unit test should be adequate to guarantee type safety (i.e. we don't need compiler to tell use that our database types are not aligned with new future schema)
 
 We've also considered using [SeaQL](https://github.com/SeaQL/sea-query), but haven't made any examples, mainly because it's another tool and pattern to learn and refine vs learning a bit more about diesel dsl and also there wasn't that much difference in schema sql syntax (which SeaQL also provides vs diesel), lastly couldn't find `CREATE VIEW` in SeaQL so thought we would at the very least have to use raw sql for that.
 

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -5,6 +5,7 @@ mod v1_01_02;
 mod v1_01_03;
 mod v1_01_05;
 mod v1_01_11;
+mod v1_01_12;
 mod version;
 pub(crate) use self::types::*;
 use self::v1_00_04::V1_00_04;
@@ -66,6 +67,7 @@ pub fn migrate(
         Box::new(V1_01_03),
         Box::new(v1_01_05::V1_01_05),
         Box::new(v1_01_11::V1_01_11),
+        Box::new(v1_01_12::V1_01_12),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_01_12/barcode.rs
+++ b/server/repository/src/migrations/v1_01_12/barcode.rs
@@ -1,0 +1,121 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+            CREATE TABLE barcode (
+                id text NOT NULL PRIMARY KEY,
+                value text NOT NULL UNIQUE,
+                item_id text REFERENCES item(id),
+                manufacturer_id text,
+                pack_size int4,
+                parent_id text
+            );            
+            "#
+    )?;
+
+    sql!(
+        connection,
+        r#"ALTER TABLE invoice_line ADD barcode_id text NULL REFERENCES barcode(id);"#
+    )?;
+
+    #[cfg(feature = "postgres")]
+    {
+        sql!(
+            connection,
+            r#"ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'barcode';"#
+        )?;
+
+        sql!(
+            connection,
+            r#"CREATE OR REPLACE FUNCTION upsert_barcode_changelog()
+        RETURNS trigger
+        LANGUAGE plpgsql
+       AS $function$
+         BEGIN
+           INSERT INTO changelog (table_name, record_id, row_action)
+                 VALUES ('barcode', NEW.id, 'UPSERT');
+           -- The return value is required, even though it is ignored for a row-level AFTER trigger
+           RETURN NULL;
+         END;
+       $function$
+       ;"#
+        )?;
+
+        sql!(
+            connection,
+            r#"CREATE OR REPLACE FUNCTION delete_barcode_changelog()
+        RETURNS trigger
+        LANGUAGE plpgsql
+       AS $function$
+         BEGIN
+           INSERT INTO changelog (table_name, record_id, row_action, name_id)
+                 VALUES ('barcode', OLD.id, 'DELETE', OLD.name_id);
+           -- The return value is required, even though it is ignored for a row-level AFTER trigger
+           RETURN NULL;
+         END;
+       $function$
+       ;"#
+        )?;
+
+        sql!(
+            connection,
+            r#"create trigger barcode_upsert_trigger after
+        insert
+            or
+        update
+            on
+            barcode for each row execute function upsert_barcode_changelog();
+        "#
+        )?;
+        sql!(
+            connection,
+            r#"create trigger barcode_delete_trigger after
+        delete
+            on
+            barcode for each row execute function delete_barcode_changelog();
+        "#
+        )?;
+    }
+    #[cfg(not(feature = "postgres"))]
+    {
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER barcode_insert_trigger
+                AFTER INSERT ON barcode
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ("barcode", NEW.id, "UPSERT");
+                END;
+            "#
+        )?;
+
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER barcode_update_trigger
+                AFTER UPDATE ON barcode
+                BEGIN
+                INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('barcode', NEW.id, 'UPSERT');
+                END;             
+            "#
+        )?;
+
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER barcode_delete_trigger
+                AFTER DELETE ON barcode
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('barcode', OLD.id, 'DELETE');
+                END;
+            "#
+        )?;
+    }
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_01_12/mod.rs
+++ b/server/repository/src/migrations/v1_01_12/mod.rs
@@ -1,0 +1,36 @@
+use super::{version::Version, Migration};
+mod barcode;
+
+use crate::StorageConnection;
+pub(crate) struct V1_01_12;
+
+impl Migration for V1_01_12 {
+    fn version(&self) -> Version {
+        Version::from_str("1.1.12")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        barcode::migrate(connection)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_01_12() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_01_12.version();
+
+    // This test allows checking sql syntax
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/mock/barcode.rs
+++ b/server/repository/src/mock/barcode.rs
@@ -1,0 +1,27 @@
+use crate::BarcodeRow;
+
+pub fn barcode_a() -> BarcodeRow {
+    BarcodeRow {
+        id: String::from("barcode_a"),
+        value: String::from("0123456789"),
+        item_id: Some(String::from("item_a")),
+        manufacturer_id: Some(String::from("manufacturer_a")),
+        pack_size: Some(1),
+        parent_id: None,
+    }
+}
+
+pub fn barcode_b() -> BarcodeRow {
+    BarcodeRow {
+        id: String::from("barcode_b"),
+        value: String::from("9876543210"),
+        item_id: Some(String::from("item_b")),
+        manufacturer_id: Some(String::from("manufacturer_a")),
+        pack_size: Some(1),
+        parent_id: None,
+    }
+}
+
+pub fn mock_barcodes() -> Vec<BarcodeRow> {
+    vec![barcode_a(), barcode_b()]
+}

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, ops::Index};
+use std::{collections::HashMap, ops::Index, vec};
 
 mod activity_log;
+mod barcode;
 pub mod common;
 mod full_invoice;
 mod full_master_list;
@@ -37,6 +38,7 @@ mod test_unallocated_line;
 mod unit;
 mod user_account;
 
+pub use barcode::*;
 use common::*;
 pub use full_invoice::*;
 pub use full_master_list::*;
@@ -71,14 +73,15 @@ pub use test_unallocated_line::*;
 pub use user_account::*;
 
 use crate::{
-    ActivityLogRow, ActivityLogRowRepository, InventoryAdjustmentReasonRow,
-    InventoryAdjustmentReasonRowRepository, InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow,
-    ItemRow, KeyValueStoreRepository, KeyValueStoreRow, LocationRow, LocationRowRepository,
-    NameTagRow, NameTagRowRepository, NumberRow, NumberRowRepository, PeriodRow,
-    PeriodRowRepository, PeriodScheduleRow, PeriodScheduleRowRepository, RequisitionLineRow,
-    RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository, StockLineRowRepository,
-    StocktakeLineRowRepository, StocktakeRowRepository, SyncBufferRow, SyncBufferRowRepository,
-    SyncLogRow, SyncLogRowRepository, UserAccountRow, UserAccountRowRepository, UserPermissionRow,
+    ActivityLogRow, ActivityLogRowRepository, BarcodeRow, BarcodeRowRepository,
+    InventoryAdjustmentReasonRow, InventoryAdjustmentReasonRowRepository, InvoiceLineRow,
+    InvoiceLineRowRepository, InvoiceRow, ItemRow, KeyValueStoreRepository, KeyValueStoreRow,
+    LocationRow, LocationRowRepository, NameTagRow, NameTagRowRepository, NumberRow,
+    NumberRowRepository, PeriodRow, PeriodRowRepository, PeriodScheduleRow,
+    PeriodScheduleRowRepository, RequisitionLineRow, RequisitionLineRowRepository, RequisitionRow,
+    RequisitionRowRepository, StockLineRowRepository, StocktakeLineRowRepository,
+    StocktakeRowRepository, SyncBufferRow, SyncBufferRowRepository, SyncLogRow,
+    SyncLogRowRepository, UserAccountRow, UserAccountRowRepository, UserPermissionRow,
     UserPermissionRowRepository, UserStoreJoinRow, UserStoreJoinRowRepository,
 };
 
@@ -120,6 +123,7 @@ pub struct MockData {
     pub activity_logs: Vec<ActivityLogRow>,
     pub sync_logs: Vec<SyncLogRow>,
     pub inventory_adjustment_reasons: Vec<InventoryAdjustmentReasonRow>,
+    pub barcodes: Vec<BarcodeRow>,
 }
 
 impl MockData {
@@ -164,6 +168,7 @@ pub struct MockDataInserts {
     pub activity_logs: bool,
     pub sync_logs: bool,
     pub inventory_adjustment_reasons: bool,
+    pub barcodes: bool,
 }
 
 impl MockDataInserts {
@@ -197,6 +202,7 @@ impl MockDataInserts {
             activity_logs: true,
             sync_logs: true,
             inventory_adjustment_reasons: true,
+            barcodes: true,
         }
     }
 
@@ -328,6 +334,11 @@ impl MockDataInserts {
         self.inventory_adjustment_reasons = true;
         self
     }
+
+    pub fn barcodes(mut self) -> Self {
+        self.barcodes = true;
+        self
+    }
 }
 
 #[derive(Default)]
@@ -393,6 +404,7 @@ fn all_mock_data() -> MockDataCollection {
             activity_logs: mock_activity_logs(),
             sync_logs: vec![],
             inventory_adjustment_reasons: vec![],
+            barcodes: vec![],
         },
     );
     data.insert(
@@ -649,6 +661,13 @@ pub fn insert_mock_data(
                 repo.upsert_one(row).unwrap();
             }
         }
+
+        if inserts.barcodes {
+            for row in &mock_data.barcodes {
+                let repo = BarcodeRowRepository::new(connection);
+                repo.upsert_one(row).unwrap();
+            }
+        }
     }
 
     mock_data
@@ -685,6 +704,7 @@ impl MockData {
             mut activity_logs,
             mut sync_logs,
             mut inventory_adjustment_reasons,
+            mut barcodes,
         } = other;
 
         self.user_accounts.append(&mut user_accounts);
@@ -713,6 +733,7 @@ impl MockData {
         self.sync_logs.append(&mut sync_logs);
         self.inventory_adjustment_reasons
             .append(&mut inventory_adjustment_reasons);
+        self.barcodes.append(&mut barcodes);
 
         self
     }

--- a/server/repository/src/mock/test_requisition_repository.rs
+++ b/server/repository/src/mock/test_requisition_repository.rs
@@ -58,3 +58,23 @@ pub fn mock_request_draft_requisition3() -> RequisitionRow {
         r.store_id = "store_b".to_owned();
     })
 }
+
+pub fn mock_program_request_draft_requisition() -> RequisitionRow {
+    inline_init(|r: &mut RequisitionRow| {
+        r.id = "mock_program_request_draft_requisition".to_owned();
+        r.requisition_number = 1;
+        r.name_id = "name_a".to_owned();
+        r.store_id = "store_a".to_owned();
+        r.r#type = RequisitionRowType::Request;
+        r.status = RequisitionRowStatus::Draft;
+        r.created_datetime = NaiveDate::from_ymd_opt(2021, 01, 01)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        r.max_months_of_stock = 1.0;
+        r.min_months_of_stock = 0.9;
+        r.program_id = Some("program_a".to_owned());
+        r.order_type = Some("order_type_a".to_owned());
+        r.period_id = Some("period_a".to_owned());
+    })
+}

--- a/server/repository/src/mock/test_requisition_repository.rs
+++ b/server/repository/src/mock/test_requisition_repository.rs
@@ -30,6 +30,7 @@ pub fn mock_request_draft_requisition() -> RequisitionRow {
             .unwrap();
         r.max_months_of_stock = 1.0;
         r.min_months_of_stock = 0.9;
+        r.is_sync_update = false;
     })
 }
 

--- a/server/service/src/requisition/mod.rs
+++ b/server/service/src/requisition/mod.rs
@@ -2,11 +2,12 @@ use self::{
     query::{get_requisition, get_requisition_by_number, get_requisitions},
     request_requisition::{
         add_from_master_list, batch_request_requisition, delete_request_requisition,
-        insert_request_requisition, update_request_requisition, use_suggested_quantity,
-        AddFromMasterList, AddFromMasterListError, BatchRequestRequisition,
+        insert_program_request_requisition, insert_request_requisition, update_request_requisition,
+        use_suggested_quantity, AddFromMasterList, AddFromMasterListError, BatchRequestRequisition,
         BatchRequestRequisitionResult, DeleteRequestRequisition, DeleteRequestRequisitionError,
-        InsertRequestRequisition, InsertRequestRequisitionError, UpdateRequestRequisition,
-        UpdateRequestRequisitionError, UseSuggestedQuantity, UseSuggestedQuantityError,
+        InsertProgramRequestRequisition, InsertRequestRequisition, InsertRequestRequisitionError,
+        UpdateRequestRequisition, UpdateRequestRequisitionError, UseSuggestedQuantity,
+        UseSuggestedQuantityError,
     },
     requisition_supply_status::{get_requisitions_supply_statuses, RequisitionLineSupplyStatus},
     response_requisition::{
@@ -75,6 +76,14 @@ pub trait RequisitionServiceTrait: Sync + Send {
         input: InsertRequestRequisition,
     ) -> Result<Requisition, InsertRequestRequisitionError> {
         insert_request_requisition(ctx, input)
+    }
+
+    fn insert_program_request_requisition(
+        &self,
+        ctx: &ServiceContext,
+        input: InsertProgramRequestRequisition,
+    ) -> Result<Requisition, InsertRequestRequisitionError> {
+        insert_program_request_requisition(ctx, input)
     }
 
     fn update_request_requisition(

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -1,0 +1,317 @@
+use crate::{
+    activity_log::activity_log_entry,
+    number::next_number,
+    requisition::{common::check_requisition_exists, query::get_requisition},
+    service_provider::ServiceContext,
+    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+};
+use chrono::{NaiveDate, Utc};
+use repository::{
+    requisition_row::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
+    ActivityLogType, NumberRowType, ProgramRequisitionOrderTypeRowRepository,
+    ProgramRequisitionSettingsRowRepository, ProgramRowRepository, RepositoryError, Requisition,
+    RequisitionRowRepository, StorageConnection,
+};
+
+use super::InsertRequestRequisitionError;
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct InsertProgramRequestRequisition {
+    pub id: String,
+    pub other_party_id: String,
+    pub colour: Option<String>,
+    pub their_reference: Option<String>,
+    pub comment: Option<String>,
+    pub expected_delivery_date: Option<NaiveDate>,
+    pub program_order_type_id: String,
+    pub period_id: String,
+}
+
+type OutError = InsertRequestRequisitionError;
+
+pub fn insert_program_request_requisition(
+    ctx: &ServiceContext,
+    input: InsertProgramRequestRequisition,
+) -> Result<Requisition, OutError> {
+    let requisition = ctx
+        .connection
+        .transaction_sync(|connection| {
+            validate(connection, &ctx.store_id, &input)?;
+            let new_requisition = generate(connection, &ctx.store_id, &ctx.user_id, input)?;
+            RequisitionRowRepository::new(&connection).upsert_one(&new_requisition)?;
+
+            activity_log_entry(
+                &ctx,
+                ActivityLogType::RequisitionCreated,
+                Some(new_requisition.id.to_owned()),
+                None,
+            )?;
+
+            get_requisition(ctx, None, &new_requisition.id)
+                .map_err(|error| OutError::DatabaseError(error))?
+                .ok_or(OutError::NewlyCreatedRequisitionDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(requisition)
+}
+
+fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &InsertProgramRequestRequisition,
+) -> Result<(), OutError> {
+    if let Some(_) = check_requisition_exists(connection, &input.id)? {
+        return Err(OutError::RequisitionAlreadyExists);
+    }
+
+    let other_party = check_other_party(
+        connection,
+        store_id,
+        &input.other_party_id,
+        CheckOtherPartyType::Supplier,
+    )
+    .map_err(|e| match e {
+        OtherPartyErrors::OtherPartyDoesNotExist => OutError::OtherPartyDoesNotExist {},
+        OtherPartyErrors::OtherPartyNotVisible => OutError::OtherPartyNotVisible,
+        OtherPartyErrors::TypeMismatched => OutError::OtherPartyNotASupplier,
+        OtherPartyErrors::DatabaseError(repository_error) => {
+            OutError::DatabaseError(repository_error)
+        }
+    })?;
+
+    other_party
+        .store_id()
+        .ok_or(OutError::OtherPartyIsNotAStore)?;
+
+    Ok(())
+}
+
+fn generate(
+    connection: &StorageConnection,
+    store_id: &str,
+    user_id: &str,
+    InsertProgramRequestRequisition {
+        id,
+        other_party_id,
+        colour,
+        comment,
+        their_reference,
+        expected_delivery_date,
+        program_order_type_id,
+        period_id,
+    }: InsertProgramRequestRequisition,
+) -> Result<RequisitionRow, RepositoryError> {
+    // Lookup order type
+    let order_type = ProgramRequisitionOrderTypeRowRepository::new(connection)
+        .find_one_by_id(&program_order_type_id)?;
+    let order_type = match order_type {
+        Some(order_type) => order_type,
+        None => return Err(RepositoryError::NotFound),
+    };
+
+    // Lookup program requisition settings
+    let program_requisition_settings = ProgramRequisitionSettingsRowRepository::new(connection)
+        .find_one_by_id(&order_type.program_requisition_settings_id)?;
+    let program_requisition_settings = match program_requisition_settings {
+        Some(program_requisition_settings) => program_requisition_settings,
+        None => return Err(RepositoryError::NotFound),
+    };
+
+    // Lookup program
+    let program = ProgramRowRepository::new(connection)
+        .find_one_by_id(&program_requisition_settings.program_id)?;
+    let program = match program {
+        Some(program) => program,
+        None => return Err(RepositoryError::NotFound),
+    };
+
+    let result = RequisitionRow {
+        id,
+        user_id: Some(user_id.to_string()),
+        requisition_number: next_number(connection, &NumberRowType::RequestRequisition, &store_id)?,
+        name_id: other_party_id,
+        store_id: store_id.to_owned(),
+        r#type: RequisitionRowType::Request,
+        status: RequisitionRowStatus::Draft,
+        created_datetime: Utc::now().naive_utc(),
+        colour,
+        comment,
+        expected_delivery_date,
+        their_reference,
+        max_months_of_stock: order_type.max_mos,
+        min_months_of_stock: order_type.threshold_mos,
+        // Default
+        sent_datetime: None,
+        approval_status: None,
+        finalised_datetime: None,
+        linked_requisition_id: None,
+        is_sync_update: false,
+        program_id: Some(program.id),
+        period_id: Some(period_id),
+        order_type: Some(order_type.name),
+    };
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test_insert {
+    use crate::{
+        requisition::request_requisition::{
+            InsertRequestRequisition, InsertRequestRequisitionError as ServiceError,
+        },
+        service_provider::ServiceProvider,
+    };
+    use chrono::{NaiveDate, Utc};
+    use repository::{
+        mock::{
+            mock_name_a, mock_name_store_b, mock_name_store_c, mock_request_draft_requisition,
+            mock_store_a, mock_user_account_a, MockData, MockDataInserts,
+        },
+        test_db::{setup_all, setup_all_with_data},
+        NameRow, RequisitionRowRepository,
+    };
+    use util::{inline_edit, inline_init};
+
+    #[actix_rt::test]
+    async fn insert_request_requisition_errors() {
+        fn not_visible() -> NameRow {
+            inline_init(|r: &mut NameRow| {
+                r.id = "not_visible".to_string();
+            })
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "insert_request_requisition_errors",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.names = vec![not_visible()];
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = service_provider.requisition_service;
+
+        // RequisitionAlreadyExists
+        assert_eq!(
+            service.insert_request_requisition(
+                &context,
+                inline_init(|r: &mut InsertRequestRequisition| {
+                    r.id = mock_request_draft_requisition().id;
+                }),
+            ),
+            Err(ServiceError::RequisitionAlreadyExists)
+        );
+
+        let name_store_b = mock_name_store_b();
+        // OtherPartyNotASupplier
+        assert_eq!(
+            service.insert_request_requisition(
+                &context,
+                inline_init(|r: &mut InsertRequestRequisition| {
+                    r.id = "new_request_requisition".to_owned();
+                    r.other_party_id = name_store_b.id.clone();
+                }),
+            ),
+            Err(ServiceError::OtherPartyNotASupplier)
+        );
+
+        // OtherPartyNotVisible
+        assert_eq!(
+            service.insert_request_requisition(
+                &context,
+                inline_init(|r: &mut InsertRequestRequisition| {
+                    r.id = "new_id".to_string();
+                    r.other_party_id = not_visible().id;
+                })
+            ),
+            Err(ServiceError::OtherPartyNotVisible)
+        );
+
+        // OtherPartyDoesNotExist
+        assert_eq!(
+            service.insert_request_requisition(
+                &context,
+                inline_init(|r: &mut InsertRequestRequisition| {
+                    r.id = "new_request_requisition".to_owned();
+                    r.other_party_id = "invalid".to_owned();
+                }),
+            ),
+            Err(ServiceError::OtherPartyDoesNotExist)
+        );
+
+        // OtherPartyIsNotAStore
+        assert_eq!(
+            service.insert_request_requisition(
+                &context,
+                inline_init(|r: &mut InsertRequestRequisition| {
+                    r.id = "new_request_requisition".to_owned();
+                    r.other_party_id = mock_name_a().id;
+                }),
+            ),
+            Err(ServiceError::OtherPartyIsNotAStore)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn insert_request_requisition_success() {
+        let (_, connection, connection_manager, _) =
+            setup_all("insert_request_requisition_success", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.requisition_service;
+
+        let before_insert = Utc::now().naive_utc();
+
+        let result = service
+            .insert_request_requisition(
+                &context,
+                InsertRequestRequisition {
+                    id: "new_request_requisition".to_owned(),
+                    other_party_id: mock_name_store_c().id,
+                    colour: Some("new colour".to_owned()),
+                    their_reference: Some("new their_reference".to_owned()),
+                    comment: Some("new comment".to_owned()),
+                    max_months_of_stock: 1.0,
+                    min_months_of_stock: 0.5,
+                    expected_delivery_date: Some(NaiveDate::from_ymd_opt(2022, 01, 03).unwrap()),
+                },
+            )
+            .unwrap();
+
+        let after_insert = Utc::now().naive_utc();
+
+        let new_row = RequisitionRowRepository::new(&connection)
+            .find_one_by_id(&result.requisition_row.id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            new_row,
+            inline_edit(&new_row, |mut u| {
+                u.id = "new_request_requisition".to_owned();
+                u.user_id = Some(mock_user_account_a().id);
+                u.name_id = mock_name_store_c().id;
+                u.colour = Some("new colour".to_owned());
+                u.their_reference = Some("new their_reference".to_owned());
+                u.comment = Some("new comment".to_owned());
+                u.max_months_of_stock = 1.0;
+                u.min_months_of_stock = 0.5;
+                u.expected_delivery_date = Some(NaiveDate::from_ymd_opt(2022, 01, 03).unwrap());
+                u
+            })
+        );
+
+        assert!(
+            new_row.created_datetime > before_insert && new_row.created_datetime < after_insert
+        );
+    }
+}

--- a/server/service/src/requisition/request_requisition/mod.rs
+++ b/server/service/src/requisition/request_requisition/mod.rs
@@ -4,6 +4,9 @@ pub use self::generate::*;
 mod insert;
 pub use self::insert::*;
 
+mod insert_program;
+pub use self::insert_program::*;
+
 mod batch;
 pub use self::batch::*;
 

--- a/server/service/src/sync/README.md
+++ b/server/service/src/sync/README.md
@@ -1,7 +1,7 @@
 ## Versioning
 
 Version number is set in [settings.rs](./settings.rs) and will be set in header to allow central server to check compatibility. 
-Central server records max and min version it's compatible with, and a simple comparision determines compatibility (`min_version <= site_version <= max_version`).
+Central server records max and min version it's compatible with, and a simple comparison determines compatibility (`min_version <= site_version <= max_version`).
 See [Versioning KDD](../../../../decisions/version-compatibility.md) and `syncV5API_checkVersion` on central server for more details, extract:
 
 **When to increment max_version and min_version**

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -32,6 +32,7 @@ const TRANSLATION_AND_INTEGRATION_ORDER: &[&str] = &[
     LegacyTableName::REQUISITION_LINE,
     LegacyTableName::NAME_STORE_JOIN,
     LegacyTableName::OM_ACTIVITY_LOG,
+    LegacyTableName::BARCODE,
 ];
 
 pub(crate) struct SyncBuffer<'a> {

--- a/server/service/src/sync/test/integration/central/test.rs
+++ b/server/service/src/sync/test/integration/central/test.rs
@@ -42,4 +42,9 @@ mod tests {
         test_central_sync_record("period_schedule_and_period", &PeriodScheduleAndPeriodTester)
             .await;
     }
+
+    #[actix_rt::test]
+    async fn integration_sync_central_barcode() {
+        test_central_sync_record("barcode", &ReportTester).await;
+    }
 }

--- a/server/service/src/sync/test/integration/remote/invoice.rs
+++ b/server/service/src/sync/test/integration/remote/invoice.rs
@@ -191,6 +191,7 @@ impl SyncRecordTester for InvoiceRecordTester {
             r.id = uuid();
             r.name_id = invoice_row_1.name_id.clone();
             r.store_id = store_id.clone();
+            r.is_sync_update = false;
             r
         });
 

--- a/server/service/src/sync/test/integration/remote/mod.rs
+++ b/server/service/src/sync/test/integration/remote/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod activity_log;
 pub(crate) mod invoice;
 pub(crate) mod location;
+pub(crate) mod program_requisition;
 pub(crate) mod requisition;
 pub(crate) mod stock_line;
 pub(crate) mod stocktake;

--- a/server/service/src/sync/test/integration/remote/program_requisition.rs
+++ b/server/service/src/sync/test/integration/remote/program_requisition.rs
@@ -1,0 +1,273 @@
+use crate::sync::{
+    test::integration::{
+        central_server_configurations::NewSiteProperties, SyncRecordTester, TestStepData,
+    },
+    translations::{IntegrationRecords, PullUpsertRecord},
+};
+use repository::{
+    MasterListLineRow, MasterListNameJoinRow, MasterListRow, NameTagRow, PeriodScheduleRow,
+    ProgramRequisitionOrderTypeRow, ProgramRequisitionSettingsRow, ProgramRow,
+};
+
+use serde_json::json;
+use util::uuid::uuid;
+
+pub(crate) struct ProgramRequisitionTester;
+
+impl SyncRecordTester for ProgramRequisitionTester {
+    fn test_step_data(&self, new_site_properties: &NewSiteProperties) -> Vec<TestStepData> {
+        let mut result = Vec::new();
+        // STEP 1 - insert
+        let period_schedule1 = PeriodScheduleRow {
+            id: uuid(),
+            name: "Weekly".to_string(),
+        };
+        let period_schedule_json1 = json!({
+            "ID": period_schedule1.id,
+            "name": period_schedule1.name,
+        });
+
+        let period_schedule2 = PeriodScheduleRow {
+            id: uuid(),
+            name: "Monthly".to_string(),
+        };
+        let period_schedule_json2 = json!({
+            "ID": period_schedule2.id,
+            "name": period_schedule2.name,
+        });
+
+        let name_tag1 = NameTagRow {
+            id: uuid(),
+            name: "NewProgramTag1".to_string(),
+        };
+        let name_tag_json1 = json!({
+            "ID": name_tag1.id,
+            "description": name_tag1.name,
+        });
+        let name_tag2 = NameTagRow {
+            id: uuid(),
+            name: "NewProgramTag2".to_string(),
+        };
+        let name_tag_json2 = json!({
+            "ID": name_tag2.id,
+            "description": name_tag2.name,
+        });
+
+        let master_list_row = MasterListRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            description: uuid(),
+        };
+        let master_list_json = json!({
+        "ID": master_list_row.id,
+        "description":  master_list_row.name,
+        "code": master_list_row.code,
+        "note": master_list_row.description,
+        "isProgram": true,
+        "programSettings": {
+            "elmisCode": "",
+            "storeTags": {
+                "NewProgramTag1": {
+                    "orderTypes": [
+                        {
+                            "isEmergency": false,
+                            "maxEmergencyOrders": "",
+                            "maxMOS": 3,
+                            "maxOrdersPerPeriod": 1,
+                            "name": "New order 1",
+                            "thresholdMOS": 3,
+                            "type": "Order type"
+                        },
+                        {
+                            "isEmergency": false,
+                            "maxEmergencyOrders": "",
+                            "maxMOS": 3,
+                            "maxOrdersPerPeriod": 1,
+                            "name": "New order 2",
+                            "thresholdMOS": 3,
+                            "type": "Order type"
+                        }
+                        ],
+                        "periodScheduleName": "Weekly"
+                    },
+                    "NewProgramTag2": {
+                        "orderTypes": [
+                            {
+                                "isEmergency": false,
+                                "maxEmergencyOrders": "",
+                                "maxMOS": 4,
+                                "maxOrdersPerPeriod": 1,
+                                "name": "New order 1",
+                                "thresholdMOS": 4,
+                                "type": "Order type"
+                            }
+                            ],
+                            "periodScheduleName": "Monthly"
+                        }
+                    }
+                }
+            });
+
+        let master_list_name_join_row = MasterListNameJoinRow {
+            id: uuid(),
+            master_list_id: master_list_row.id.clone(),
+            name_id: new_site_properties.name_id.clone(),
+        };
+        let master_list_name_join_json = json!({
+            "ID": master_list_name_join_row.id,
+            "list_master_ID":  master_list_name_join_row.master_list_id,
+            "name_ID": master_list_name_join_row.name_id,
+        });
+
+        let item_id = uuid();
+        let master_list_line_row = MasterListLineRow {
+            id: uuid(),
+            item_id: item_id.clone(),
+            master_list_id: master_list_row.id.clone(),
+        };
+        let master_list_line_json = json!({
+            "ID": master_list_line_row.id,
+            "item_master_ID": master_list_line_row.master_list_id,
+            "item_ID":  master_list_line_row.item_id,
+        });
+
+        let program = ProgramRow {
+            id: master_list_row.id.clone(),
+            name: master_list_row.name.clone(),
+            master_list_id: master_list_row.id.clone(),
+        };
+
+        let program_requisition_settings1 = ProgramRequisitionSettingsRow {
+            id: master_list_row.id.clone() + &name_tag1.id,
+            name_tag_id: name_tag1.id.clone(),
+            program_id: master_list_row.id.clone(),
+            period_schedule_id: period_schedule1.id.clone(),
+        };
+
+        let program_requisition_settings2 = ProgramRequisitionSettingsRow {
+            id: master_list_row.id.clone() + &name_tag2.id,
+            name_tag_id: name_tag2.id.clone(),
+            program_id: master_list_row.id.clone(),
+            period_schedule_id: period_schedule2.id.clone(),
+        };
+
+        let order_type1 = ProgramRequisitionOrderTypeRow {
+            id: program_requisition_settings1.id.clone() + "New order 1",
+            program_requisition_settings_id: program_requisition_settings1.id.clone(),
+            name: "New order 1".to_string(),
+            threshold_mos: 3.0,
+            max_mos: 3.0,
+            max_order_per_period: 1,
+        };
+
+        let order_type2 = ProgramRequisitionOrderTypeRow {
+            id: program_requisition_settings1.id.clone() + "New order 2",
+            program_requisition_settings_id: program_requisition_settings1.id.clone(),
+            name: "New order 2".to_string(),
+            threshold_mos: 3.0,
+            max_mos: 3.0,
+            max_order_per_period: 1,
+        };
+
+        let order_type3 = ProgramRequisitionOrderTypeRow {
+            id: program_requisition_settings2.id.clone() + "New order 1",
+            program_requisition_settings_id: program_requisition_settings2.id.clone(),
+            name: "New order 1".to_string(),
+            threshold_mos: 4.0,
+            max_mos: 4.0,
+            max_order_per_period: 1,
+        };
+
+        let master_list_row2 = MasterListRow {
+            id: uuid(),
+            name: uuid(),
+            code: uuid(),
+            description: uuid(),
+        };
+        let master_list_json2 = json!({
+        "ID": master_list_row2.id,
+        "description":  master_list_row2.name,
+        "code": master_list_row2.code,
+        "note": master_list_row2.description,
+        "isProgram": true,
+        "programSettings": {
+            "elmisCode": "",
+            "storeTags": {
+                "NewProgramTag1": {
+                    "orderTypes": [],
+                    "periodScheduleName": "Weekly"
+                    }
+                }
+        }});
+
+        let master_list_name_join_row2 = MasterListNameJoinRow {
+            id: uuid(),
+            master_list_id: master_list_row2.id.clone(),
+            name_id: new_site_properties.name_id.clone(),
+        };
+        let master_list_name_join_json2 = json!({
+            "ID": master_list_name_join_row2.id,
+            "list_master_ID":  master_list_name_join_row2.master_list_id,
+            "name_ID": master_list_name_join_row2.name_id,
+        });
+
+        let master_list_line_row2 = MasterListLineRow {
+            id: uuid(),
+            item_id: item_id.clone(),
+            master_list_id: master_list_row2.id.clone(),
+        };
+        let master_list_line_json2 = json!({
+            "ID": master_list_line_row2.id,
+            "item_master_ID": master_list_line_row2.master_list_id,
+            "item_ID":  master_list_line_row2.item_id,
+        });
+
+        let program2 = ProgramRow {
+            id: master_list_row2.id.clone(),
+            name: master_list_row2.name.clone(),
+            master_list_id: master_list_row2.id.clone(),
+        };
+
+        let program_requisition_settings3 = ProgramRequisitionSettingsRow {
+            id: master_list_row2.id.clone() + &name_tag1.id,
+            name_tag_id: name_tag1.id.clone(),
+            program_id: master_list_row2.id.clone(),
+            period_schedule_id: period_schedule1.id.clone(),
+        };
+
+        result.push(TestStepData {
+            central_upsert: json!({
+                "periodSchedule": [period_schedule_json1, period_schedule_json2],
+                "name_tag": [name_tag_json1, name_tag_json2],
+                "list_master": [master_list_json, master_list_json2],
+                "list_master_name_join": [master_list_name_join_json, master_list_name_join_json2],
+                "list_master_line": [master_list_line_json, master_list_line_json2],
+                "item": [{"ID": item_id, "type_of": "general"}]
+            }),
+            central_delete: json!({}),
+            integration_records: IntegrationRecords::from_upserts(vec![
+                PullUpsertRecord::PeriodSchedule(period_schedule1),
+                PullUpsertRecord::PeriodSchedule(period_schedule2),
+                PullUpsertRecord::NameTag(name_tag1),
+                PullUpsertRecord::NameTag(name_tag2),
+                PullUpsertRecord::MasterList(master_list_row),
+                PullUpsertRecord::MasterList(master_list_row2),
+                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row),
+                PullUpsertRecord::MasterListNameJoin(master_list_name_join_row2),
+                PullUpsertRecord::MasterListLine(master_list_line_row),
+                PullUpsertRecord::MasterListLine(master_list_line_row2),
+                PullUpsertRecord::Program(program),
+                PullUpsertRecord::Program(program2),
+                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings1),
+                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings2),
+                PullUpsertRecord::ProgramRequisitionSettings(program_requisition_settings3),
+                PullUpsertRecord::ProgramRequisitionOrderType(order_type1),
+                PullUpsertRecord::ProgramRequisitionOrderType(order_type2),
+                PullUpsertRecord::ProgramRequisitionOrderType(order_type3),
+            ]),
+        });
+
+        result
+    }
+}

--- a/server/service/src/sync/test/integration/remote/requisition.rs
+++ b/server/service/src/sync/test/integration/remote/requisition.rs
@@ -16,8 +16,9 @@ pub(crate) struct RequisitionRecordTester;
 impl SyncRecordTester for RequisitionRecordTester {
     fn test_step_data(&self, new_site_properties: &NewSiteProperties) -> Vec<TestStepData> {
         let mut result = Vec::new();
-        // STEP 1 - insert
         let store_id = &new_site_properties.store_id;
+
+        // STEP 1 - insert
         let base_requisition_row = RequisitionRow {
             id: uuid(),
             store_id: store_id.to_string(),
@@ -39,6 +40,11 @@ impl SyncRecordTester for RequisitionRecordTester {
             max_months_of_stock: 10.0,
             min_months_of_stock: 5.0,
             linked_requisition_id: None,
+            approval_status: None,
+            is_sync_update: false,
+            program_id: None,
+            period_id: None,
+            order_type: None,
         };
         let requisition_row_1 = base_requisition_row.clone();
         let requisition_line_row_1 = RequisitionLineRow {
@@ -52,6 +58,9 @@ impl SyncRecordTester for RequisitionRecordTester {
             average_monthly_consumption: 15,
             comment: None,
             snapshot_datetime: None,
+            approved_quantity: 0,
+            approval_comment: None,
+            is_sync_update: false,
         };
 
         let requisition_row_2 = inline_edit(&base_requisition_row, |mut d| {

--- a/server/service/src/sync/test/integration/remote/test.rs
+++ b/server/service/src/sync/test/integration/remote/test.rs
@@ -2,9 +2,9 @@
 mod tests {
     use crate::sync::test::integration::remote::{
         activity_log::ActivityLogRecordTester, invoice::InvoiceRecordTester,
-        location::LocationRecordTester, requisition::RequisitionRecordTester,
-        stock_line::StockLineRecordTester, stocktake::StocktakeRecordTester,
-        test_remote_sync_record,
+        location::LocationRecordTester, program_requisition::ProgramRequisitionTester,
+        requisition::RequisitionRecordTester, stock_line::StockLineRecordTester,
+        stocktake::StocktakeRecordTester, test_remote_sync_record,
     };
 
     #[actix_rt::test]
@@ -35,5 +35,10 @@ mod tests {
     #[actix_rt::test]
     async fn integration_sync_remote_activity_log() {
         test_remote_sync_record("om_activity_log", &ActivityLogRecordTester).await;
+    }
+
+    #[actix_rt::test]
+    async fn intergration_sync_program_requisition() {
+        test_remote_sync_record("program_requisition", &ProgramRequisitionTester).await;
     }
 }

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -115,6 +115,28 @@ pub(crate) async fn insert_all_extra_data(
     }
 }
 
+macro_rules! check_record_by_id_ignore_is_sync_update {
+    ($repository:ident, $connection:ident, $comparison_record:ident, $record_type:tt, $record_string:expr) => {{
+        let record = $repository::new(&$connection)
+            .find_one_by_id(&$comparison_record.id)
+            .unwrap()
+            .expect(&format!(
+                "{} row not found: {}",
+                $record_string, $comparison_record.id
+            ));
+        assert_eq!(
+            $record_type {
+                is_sync_update: false,
+                ..record
+            },
+            $record_type {
+                is_sync_update: false,
+                ..$comparison_record
+            }
+        )
+    }};
+}
+
 macro_rules! check_record_by_id {
     ($repository:ident, $connection:ident, $comparison_record:ident, $record_string:expr) => {{
         assert_eq!(
@@ -202,10 +224,22 @@ pub(crate) async fn check_records_against_database(
                 check_record_by_id!(StocktakeLineRowRepository, con, record, "StocktakeLine");
             }
             Requisition(record) => {
-                check_record_by_id!(RequisitionRowRepository, con, record, "Requisition");
+                check_record_by_id_ignore_is_sync_update!(
+                    RequisitionRowRepository,
+                    con,
+                    record,
+                    RequisitionRow,
+                    "Requisition"
+                );
             }
             RequisitionLine(record) => {
-                check_record_by_id!(RequisitionLineRowRepository, con, record, "RequisitionLine");
+                check_record_by_id_ignore_is_sync_update!(
+                    RequisitionLineRowRepository,
+                    con,
+                    record,
+                    RequisitionLineRow,
+                    "RequisitionLine"
+                );
             }
             Unit(record) => {
                 check_record_by_option_id!(UnitRowRepository, con, record, "Unit");
@@ -266,6 +300,7 @@ pub(crate) async fn check_records_against_database(
             StorePreference(record) => {
                 check_record_by_id!(StorePreferenceRowRepository, con, record, "StorePreference")
             }
+            Barcode(record) => check_record_by_id!(BarcodeRowRepository, con, record, "Barcode"),
         }
     }
 

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -103,10 +103,10 @@ async fn test_sync_pull_and_push() {
     ]
     .concat();
     insert_all_extra_data(&test_records, &connection).await;
-    let sync_reords: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
+    let sync_records: Vec<SyncBufferRow> = extract_sync_buffer_rows(&test_records);
 
     SyncBufferRowRepository::new(&connection)
-        .upsert_many(&sync_reords)
+        .upsert_many(&sync_records)
         .unwrap();
 
     integrate_and_translate_sync_buffer(&connection, true).unwrap();

--- a/server/service/src/sync/test/test_data/barcode.rs
+++ b/server/service/src/sync/test/test_data/barcode.rs
@@ -1,0 +1,87 @@
+use crate::sync::{
+    test::{TestSyncPullRecord, TestSyncPushRecord},
+    translations::{barcode::LegacyBarcodeRow, LegacyTableName, PullUpsertRecord},
+};
+
+use repository::BarcodeRow;
+use serde_json::json;
+
+const BARCODE_1: (&'static str, &'static str) = (
+    "barcode_a",
+    r#"{
+    "ID": "barcode_a",
+    "barcode": "0123456789",
+    "itemID": "item_a",
+    "manufacturerID": "manufacturer_a",
+    "packSize": 1
+    }"#,
+);
+
+const BARCODE_2: (&'static str, &'static str) = (
+    "barcode_b",
+    r#"{
+    "ID": "barcode_b",
+    "barcode": "9876543210",
+    "itemID": "item_b",
+    "manufacturerID": "manufacturer_a",
+    "packSize": 1
+    }"#,
+);
+
+pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
+    vec![
+        TestSyncPullRecord::new_pull_upsert(
+            LegacyTableName::BARCODE,
+            BARCODE_1,
+            PullUpsertRecord::Barcode(BarcodeRow {
+                id: BARCODE_1.0.to_string(),
+                value: "0123456789".to_string(),
+                item_id: Some("item_a".to_string()),
+                manufacturer_id: Some("manufacturer_a".to_string()),
+                pack_size: Some(1),
+                parent_id: None,
+            }),
+        ),
+        TestSyncPullRecord::new_pull_upsert(
+            LegacyTableName::BARCODE,
+            BARCODE_2,
+            PullUpsertRecord::Barcode(BarcodeRow {
+                id: BARCODE_2.0.to_string(),
+                value: "9876543210".to_string(),
+                item_id: Some("item_b".to_string()),
+                manufacturer_id: Some("manufacturer_a".to_string()),
+                pack_size: Some(1),
+                parent_id: None,
+            }),
+        ),
+    ]
+}
+
+pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
+    vec![
+        TestSyncPushRecord {
+            record_id: BARCODE_1.0.to_string(),
+            table_name: LegacyTableName::BARCODE.to_string(),
+            push_data: json!(LegacyBarcodeRow {
+                id: BARCODE_1.0.to_string(),
+                value: "0123456789".to_string(),
+                item_id: Some("item_a".to_string()),
+                manufacturer_id: Some("manufacturer_a".to_string()),
+                pack_size: Some(1),
+                parent_id: None,
+            }),
+        },
+        TestSyncPushRecord {
+            record_id: BARCODE_2.0.to_string(),
+            table_name: LegacyTableName::BARCODE.to_string(),
+            push_data: json!(LegacyBarcodeRow {
+                id: BARCODE_2.0.to_string(),
+                value: "9876543210".to_string(),
+                item_id: Some("item_b".to_string()),
+                manufacturer_id: Some("manufacturer_a".to_string()),
+                pack_size: Some(1),
+                parent_id: None,
+            }),
+        },
+    ]
+}

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -1,6 +1,7 @@
 use super::{TestSyncPullRecord, TestSyncPushRecord};
 
 pub(crate) mod activity_log;
+pub(crate) mod barcode;
 pub(crate) mod inventory_adjustment_reason;
 pub(crate) mod invoice;
 pub(crate) mod invoice_line;
@@ -45,6 +46,7 @@ pub(crate) fn get_all_pull_upsert_central_test_records() -> Vec<TestSyncPullReco
     // Central but site specific
     test_records.append(&mut name_store_join::test_pull_upsert_records());
     test_records.append(&mut special::name_to_name_store_join::test_pull_upsert_records());
+    test_records.append(&mut barcode::test_pull_upsert_records());
     test_records
 }
 
@@ -102,6 +104,7 @@ pub(crate) fn get_all_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records.append(&mut invoice_line::test_push_records());
     test_records.append(&mut invoice::test_push_records());
     test_records.append(&mut activity_log::test_push_records());
+    test_records.append(&mut barcode::test_push_records());
 
     test_records
 }

--- a/server/service/src/sync/test/test_data/program_requisition_settings.rs
+++ b/server/service/src/sync/test/test_data/program_requisition_settings.rs
@@ -85,70 +85,124 @@ const MASTER_LIST_WITH_PROGRAM_1: (&'static str, &'static str) = (
 }"#,
 );
 
+const MASTER_LIST_WITH_PROGRAM_2: (&'static str, &'static str) = (
+    "program_test_2",
+    r#"{
+    "ID": "program_test_2",
+    "description": "Program Test 02",
+    "date_created": "2017-08-17",
+    "created_by_user_ID": "0763E2E3053D4C478E1E6B6B03FEC207",
+    "note": "note 4",
+    "gets_new_items": false,
+    "tags": null,
+    "isProgram": true,
+    "programSettings": {
+        "elmisCode": "",
+        "storeTags": {
+            "NewProgramTag1": {
+                "orderTypes": [],
+                "periodScheduleName": "Monthly"
+            }
+        }
+    },
+    "code": "",
+    "isPatientList": false,
+    "is_hiv": false,
+    "isSupplierHubCatalog": false
+}"#,
+);
+
 pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
-    vec![TestSyncPullRecord::new_pull_upserts(
-        LegacyTableName::LIST_MASTER,
-        MASTER_LIST_WITH_PROGRAM_1,
-        vec![
-            PullUpsertRecord::Program(ProgramRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
-                name: "Program Test 01".to_owned(),
-                master_list_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
-            }),
-            PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_1().id,
-                name_tag_id: mock_name_tag_1().id,
-                program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
-                period_schedule_id: mock_period_schedule_1().id,
-            }),
-            PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_1().id + "New order 1",
-                program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
-                    + &mock_name_tag_1().id,
-                name: "New order 1".to_owned(),
-                threshold_mos: 3.0,
-                max_mos: 3.0,
-                max_order_per_period: 1,
-            }),
-            PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_1().id + "New order 2",
-                program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
-                    + &mock_name_tag_1().id,
-                name: "New order 2".to_owned(),
-                threshold_mos: 3.0,
-                max_mos: 3.0,
-                max_order_per_period: 1,
-            }),
-            PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_2().id,
-                name_tag_id: mock_name_tag_2().id,
-                program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
-                period_schedule_id: mock_period_schedule_1().id,
-            }),
-            PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_2().id + "New order 1",
-                program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
-                    + &mock_name_tag_2().id,
-                name: "New order 1".to_owned(),
-                threshold_mos: 4.0,
-                max_mos: 4.0,
-                max_order_per_period: 1,
-            }),
-            PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_3().id,
-                name_tag_id: mock_name_tag_3().id,
-                program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
-                period_schedule_id: mock_period_schedule_2().id,
-            }),
-            PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
-                id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_3().id + "New order 1",
-                program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
-                    + &mock_name_tag_3().id,
-                name: "New order 1".to_owned(),
-                threshold_mos: 2.0,
-                max_mos: 2.0,
-                max_order_per_period: 3,
-            }),
-        ],
-    )]
+    vec![
+        TestSyncPullRecord::new_pull_upserts(
+            LegacyTableName::LIST_MASTER,
+            MASTER_LIST_WITH_PROGRAM_1,
+            vec![
+                PullUpsertRecord::Program(ProgramRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                    name: "Program Test 01".to_owned(),
+                    master_list_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                }),
+                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_1().id,
+                    name_tag_id: mock_name_tag_1().id,
+                    program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                    period_schedule_id: mock_period_schedule_1().id,
+                }),
+                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_1().id
+                        + "New order 1",
+                    program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_1().id,
+                    name: "New order 1".to_owned(),
+                    threshold_mos: 3.0,
+                    max_mos: 3.0,
+                    max_order_per_period: 1,
+                }),
+                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_1().id
+                        + "New order 2",
+                    program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_1().id,
+                    name: "New order 2".to_owned(),
+                    threshold_mos: 3.0,
+                    max_mos: 3.0,
+                    max_order_per_period: 1,
+                }),
+                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_2().id,
+                    name_tag_id: mock_name_tag_2().id,
+                    program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                    period_schedule_id: mock_period_schedule_1().id,
+                }),
+                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_2().id
+                        + "New order 1",
+                    program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_2().id,
+                    name: "New order 1".to_owned(),
+                    threshold_mos: 4.0,
+                    max_mos: 4.0,
+                    max_order_per_period: 1,
+                }),
+                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned() + &mock_name_tag_3().id,
+                    name_tag_id: mock_name_tag_3().id,
+                    program_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned(),
+                    period_schedule_id: mock_period_schedule_2().id,
+                }),
+                PullUpsertRecord::ProgramRequisitionOrderType(ProgramRequisitionOrderTypeRow {
+                    id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_3().id
+                        + "New order 1",
+                    program_requisition_settings_id: MASTER_LIST_WITH_PROGRAM_1.0.to_owned()
+                        + &mock_name_tag_3().id,
+                    name: "New order 1".to_owned(),
+                    threshold_mos: 2.0,
+                    max_mos: 2.0,
+                    max_order_per_period: 3,
+                }),
+            ],
+        ),
+        TestSyncPullRecord::new_pull_upserts(
+            LegacyTableName::LIST_MASTER,
+            MASTER_LIST_WITH_PROGRAM_2,
+            vec![
+                PullUpsertRecord::Program(ProgramRow {
+                    id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
+                    name: "Program Test 02".to_owned(),
+                    master_list_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
+                }),
+                PullUpsertRecord::ProgramRequisitionSettings(ProgramRequisitionSettingsRow {
+                    id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned() + &mock_name_tag_1().id,
+                    name_tag_id: mock_name_tag_1().id,
+                    program_id: MASTER_LIST_WITH_PROGRAM_2.0.to_owned(),
+                    period_schedule_id: mock_period_schedule_1().id,
+                }),
+            ],
+        ),
+    ]
 }

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -203,6 +203,7 @@ impl PullUpsertRecord {
                 InventoryAdjustmentReasonRowRepository::new(con).upsert_one(record)
             }
             StorePreference(record) => StorePreferenceRowRepository::new(con).upsert_one(record),
+            Barcode(record) => BarcodeRowRepository::new(con).upsert_one(record),
         }
     }
 }

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -1,0 +1,138 @@
+use repository::{
+    BarcodeRow, BarcodeRowRepository, ChangelogRow, ChangelogTableName, StorageConnection,
+    SyncBufferRow,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::sync::api::RemoteSyncRecordV5;
+
+use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+
+const LEGACY_TABLE_NAME: &'static str = LegacyTableName::BARCODE;
+
+fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
+    sync_record.table_name == LEGACY_TABLE_NAME
+}
+fn match_push_table(changelog: &ChangelogRow) -> bool {
+    changelog.table_name == ChangelogTableName::Barcode
+}
+
+#[allow(non_snake_case)]
+#[derive(Deserialize, Serialize)]
+pub struct LegacyBarcodeRow {
+    #[serde(rename = "ID")]
+    pub id: String,
+    #[serde(rename = "barcode")]
+    pub value: String,
+    #[serde(rename = "itemID")]
+    pub item_id: Option<String>,
+    #[serde(rename = "manufacturerID")]
+    pub manufacturer_id: Option<String>,
+    #[serde(rename = "packSize")]
+    pub pack_size: Option<i32>,
+    #[serde(rename = "parentID")]
+    pub parent_id: Option<String>,
+}
+
+pub(crate) struct BarcodeTranslation {}
+impl SyncTranslation for BarcodeTranslation {
+    fn try_translate_pull_upsert(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
+        if !match_pull_table(sync_record) {
+            return Ok(None);
+        }
+
+        let deserialised_row = match serde_json::from_str::<LegacyBarcodeRow>(&sync_record.data) {
+            Ok(row) => row,
+            Err(e) => {
+                log::warn!("Failed to deserialise barcode row: {:?}", e);
+                return Ok(None);
+            }
+        };
+        let LegacyBarcodeRow {
+            id,
+            value,
+            item_id,
+            manufacturer_id,
+            pack_size,
+            parent_id,
+        } = deserialised_row;
+
+        let result = BarcodeRow {
+            id,
+            value,
+            item_id,
+            manufacturer_id,
+            pack_size,
+            parent_id,
+        };
+
+        Ok(Some(IntegrationRecords::from_upsert(
+            PullUpsertRecord::Barcode(result),
+        )))
+    }
+
+    fn try_translate_push_upsert(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<RemoteSyncRecordV5>>, anyhow::Error> {
+        if !match_push_table(changelog) {
+            return Ok(None);
+        }
+
+        let BarcodeRow {
+            id,
+            value,
+            item_id,
+            manufacturer_id,
+            pack_size,
+            parent_id,
+        } = BarcodeRowRepository::new(connection)
+            .find_one_by_id(&changelog.record_id)?
+            .ok_or(anyhow::Error::msg(format!(
+                "Barcode row ({}) not found",
+                changelog.record_id
+            )))?;
+
+        let legacy_row = LegacyBarcodeRow {
+            id,
+            value,
+            item_id,
+            manufacturer_id,
+            pack_size,
+            parent_id,
+        };
+        Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
+            changelog,
+            LEGACY_TABLE_NAME,
+            serde_json::to_value(&legacy_row)?,
+        )]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    #[actix_rt::test]
+    async fn test_barcode_translation() {
+        use crate::sync::test::test_data::barcode as test_data;
+        let translator = BarcodeTranslation {};
+
+        let (_, connection, _, _) =
+            setup_all("test_barcode_translation", MockDataInserts::none()).await;
+
+        for record in test_data::test_pull_upsert_records() {
+            let translation_result = translator
+                .try_translate_pull_upsert(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+    }
+}

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -168,7 +168,7 @@ impl SyncTranslation for InvoiceLineTranslation {
             Some(ref stock_line_id) => StockLineRowRepository::new(connection)
                 .find_one_by_id(&stock_line_id)
                 .is_ok(),
-            None => false,
+            None => true,
         };
 
         if !is_stock_line_valid {

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod activity_log;
+pub(crate) mod barcode;
 pub(crate) mod inventory_adjustment_reason;
 pub(crate) mod invoice;
 pub(crate) mod invoice_line;
@@ -60,6 +61,7 @@ pub(crate) fn all_translators() -> SyncTanslators {
         Box::new(requisition::RequisitionTranslation {}),
         Box::new(requisition_line::RequisitionLineTranslation {}),
         Box::new(activity_log::ActivityLogTranslation {}),
+        Box::new(barcode::BarcodeTranslation {}),
         // Remote-Central (site specific)
         Box::new(name_store_join::NameStoreJoinTranslation {}),
         // Special translations
@@ -83,6 +85,7 @@ pub(crate) mod LegacyTableName {
     pub(crate) const STORE_PREFERENCE: &str = "pref";
     pub(crate) const PERIOD_SCHEDULE: &str = "periodSchedule";
     pub(crate) const PERIOD: &str = "period";
+    pub(crate) const BARCODE: &str = "barcode";
     // Remote
     pub(crate) const LOCATION: &str = "Location";
     pub(crate) const ITEM_LINE: &str = "item_line";
@@ -127,6 +130,7 @@ pub(crate) enum PullUpsertRecord {
     ActivityLog(ActivityLogRow),
     InventoryAdjustmentReason(InventoryAdjustmentReasonRow),
     StorePreference(StorePreferenceRow),
+    Barcode(BarcodeRow),
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -6,9 +6,7 @@ use repository::{
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
-};
+use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
@@ -94,21 +92,6 @@ impl SyncTranslation for ProgramRequisitionSettingsTranslation {
             });
 
         Ok(Some(IntegrationRecords::from_upserts(upserts)))
-    }
-
-    fn try_translate_pull_delete(
-        &self,
-        _: &StorageConnection,
-        sync_record: &SyncBufferRow,
-    ) -> Result<Option<IntegrationRecords>, anyhow::Error> {
-        let result = match_pull_table(sync_record).then(|| {
-            IntegrationRecords::from_delete(
-                &sync_record.record_id,
-                PullDeleteRecordTable::MasterList,
-            )
-        });
-
-        Ok(result)
     }
 }
 


### PR DESCRIPTION
Fixes #1510 

# 👩🏻‍💻 What does this PR do? 
New graphql request `insertProgramRequestRequisition`
this takes in additional parameters `programOrderTypeId` and `periodId`

`program_id`, `max_mos`, `min_mos` and `order_type` are set on the requisition based on the new fields.

Follow up after merging other PRs #1599

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Will be best tested when integrated with #1509


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

I've copied most of the generation and validation logic from `insert` for request requisition.
Maybe some of that should be extracted so code can be shared between the two? Not entirely clear what kinds of things will be different between the types at this stage.

Should there be any additional validations added for program requistions

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
