### PR TITLE
Refactor intl utils

### DIFF
--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -1,4 +1,4 @@
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { AuthCookie, AuthError, setAuthCookie } from '../../AuthContext';
 import { useGetAuthToken } from './useGetAuthToken';
 import {
@@ -43,7 +43,7 @@ export const useLogin = (
   setCookie: React.Dispatch<React.SetStateAction<AuthCookie | undefined>>
 ) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
-  const changeLanguage = IntlUtils.useChangeLanguage();
+  const { changeLanguage, getUserLocale } = useIntlUtils();
   const { setHeader, setSkipRequest } = useGql();
   const { mutateAsync: getUserDetails } = useGetUserDetails();
   const queryClient = useQueryClient();
@@ -113,7 +113,7 @@ export const useLogin = (
       },
     };
 
-    const userLocale = IntlUtils.getUserLocale(username);
+    const userLocale = getUserLocale(username);
     if (userLocale === undefined) {
       changeLanguage(userDetails?.language);
     }

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -10,7 +10,7 @@ import {
   useLocalStorage,
   useQueryClient,
 } from '@openmsupply-client/common';
-import { UserNode } from '@common/types';
+import { LanguageType, UserNode } from '@common/types';
 
 import { DefinitionNode, DocumentNode, OperationDefinitionNode } from 'graphql';
 
@@ -43,7 +43,7 @@ export const useLogin = (
   setCookie: React.Dispatch<React.SetStateAction<AuthCookie | undefined>>
 ) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
-  const { changeLanguage, getUserLocale } = useIntlUtils();
+  const { changeLanguage, getLocaleCode, getUserLocale } = useIntlUtils();
   const { setHeader, setSkipRequest } = useGql();
   const { mutateAsync: getUserDetails } = useGetUserDetails();
   const queryClient = useQueryClient();
@@ -115,7 +115,7 @@ export const useLogin = (
 
     const userLocale = getUserLocale(username);
     if (userLocale === undefined) {
-      changeLanguage(userDetails?.language);
+      changeLanguage(getLocaleCode(userDetails?.language as LanguageType));
     }
     setMRUCredentials({ username, store });
     setAuthCookie(authCookie);

--- a/client/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/client/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -4,7 +4,7 @@ import DialogContent, { DialogContentProps } from '@mui/material/DialogContent';
 import { TransitionProps } from '@mui/material/transitions';
 import { Slide } from '../../ui/animations';
 import { BasicModal, ModalTitle } from '@common/components';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { SxProps, Theme } from '@mui/material';
 
 export interface ButtonProps {
@@ -104,7 +104,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
   const [open, setOpen] = React.useState(false);
   const showDialog = () => setOpen(true);
   const hideDialog = () => setOpen(false);
-  const isRtl = IntlUtils.useRtl();
+  const { isRtl } = useIntlUtils();
 
   useEffect(() => {
     if (isOpen != null) setOpen(isOpen);

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -1,5 +1,5 @@
 import currency from 'currency.js';
-import { IntlUtils } from '../utils';
+import { useIntlUtils } from '../utils';
 
 const trimCents = (centsString: string) => {
   const trimmed = Number(`.${centsString}`);
@@ -116,13 +116,13 @@ const currencyOptions = {
 };
 
 export const useCurrency = (dp?: number) => {
-  const language = IntlUtils.useCurrentLanguage();
-  const options = currencyOptions[language];
+  const { currentLanguage } = useIntlUtils();
+  const options = currencyOptions[currentLanguage];
   const precision = dp ?? options.precision;
   return {
     c: (value: currency.Any) => currency(value, { ...options, precision }),
     options,
-    language,
+    language: currentLanguage,
   };
 };
 

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -1,13 +1,13 @@
-import { IntlUtils } from '../utils';
+import { useIntlUtils } from '../utils';
 
 export const useFormatNumber = () => {
-  const language = IntlUtils.useCurrentLanguage();
+  const { currentLanguage } = useIntlUtils();
 
   return {
     format: (value: number, options?: Intl.NumberFormatOptions) =>
-      new Intl.NumberFormat(language, options).format(value),
+      new Intl.NumberFormat(currentLanguage, options).format(value),
     round: (value?: number, dp?: number): string => {
-      const intl = new Intl.NumberFormat(language, {
+      const intl = new Intl.NumberFormat(currentLanguage, {
         maximumFractionDigits: dp ?? 0,
       });
       return intl.format(value ?? 0);

--- a/client/packages/common/src/intl/utils/DateUtils.ts
+++ b/client/packages/common/src/intl/utils/DateUtils.ts
@@ -1,4 +1,4 @@
-import { IntlUtils, SupportedLocales } from '@common/intl';
+import { SupportedLocales, useIntlUtils } from '@common/intl';
 import {
   addMinutes,
   addDays,
@@ -134,8 +134,8 @@ const getLocale = (language: SupportedLocales) => {
 };
 
 export const useFormatDateTime = () => {
-  const language = IntlUtils.useCurrentLanguage();
-  const locale = getLocale(language);
+  const { currentLanguage } = useIntlUtils();
+  const locale = getLocale(currentLanguage);
 
   const localisedDate = (date: Date | string | number): string =>
     formatIfValid(dateInputHandler(date), 'P', { locale });

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -29,8 +29,11 @@ export const useIntlUtils = () => {
   const { i18n } = useTranslationNext();
   const { language } = i18n;
 
-  const changeLanguage = (language?: LanguageType) => {
-    const userLanguage = parseLanguage(language);
+  const changeLanguage = (language?: string) => {
+    const userLanguage =
+      // Longer name implies input is full language name, not the 2-letter
+      // locale code
+      language && language?.length > 2 ? parseLanguage(language) : language;
     if (!userLanguage) return;
     if (!locales.some(locale => userLanguage === locale)) return;
 
@@ -50,9 +53,9 @@ export const useIntlUtils = () => {
     return 'en';
   })();
 
-  const currentLanguageName = (() => {
-    return languageOptions.find(option => option.value === language)?.label;
-  })();
+  const currentLanguageName = languageOptions.find(
+    option => option.value === language
+  )?.label;
 
   const getUserLocale = (username: string) => {
     const locales = LocalStorage.getItem('/localisation/locale');
@@ -144,7 +147,7 @@ export const useIntlUtils = () => {
 //   },
 // };
 
-const parseLanguage = (language?: LanguageType) => {
+const parseLanguage = (language?: string) => {
   switch (language) {
     case LanguageType.English:
       return 'en';

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -1,4 +1,3 @@
-// import { i18n } from 'i18next';
 import { useTranslation as useTranslationNext } from 'react-i18next';
 import { EnvUtils } from '@common/utils';
 import { LanguageType } from '../../types/schema';
@@ -22,6 +21,8 @@ const locales = [
   'tet' as const,
 ] as const;
 
+const rtlLocales = ['ar'];
+
 export type SupportedLocales = (typeof locales)[number];
 type StringOrEmpty = string | null | undefined;
 
@@ -29,18 +30,14 @@ export const useIntlUtils = () => {
   const { i18n } = useTranslationNext();
   const { language } = i18n;
 
-  const changeLanguage = (language?: string) => {
-    const userLanguage =
-      // Longer name implies input is full language name, not the 2-letter
-      // locale code
-      language && language?.length > 2 ? parseLanguage(language) : language;
-    if (!userLanguage) return;
-    if (!locales.some(locale => userLanguage === locale)) return;
+  const changeLanguage = (languageCode?: string) => {
+    if (!languageCode) return;
+    if (!locales.some(locale => languageCode === locale)) return;
 
-    i18n.changeLanguage(userLanguage);
+    i18n.changeLanguage(languageCode);
   };
 
-  const isRtl = language === 'ar';
+  const isRtl = rtlLocales.includes(language);
 
   const currentLanguage = (() => {
     const supportedLanguage = language as SupportedLocales;
@@ -56,6 +53,8 @@ export const useIntlUtils = () => {
   const currentLanguageName = languageOptions.find(
     option => option.value === language
   )?.label;
+
+  const getLocaleCode = (language: LanguageType) => parseLanguage(language);
 
   const getUserLocale = (username: string) => {
     const locales = LocalStorage.getItem('/localisation/locale');
@@ -83,69 +82,12 @@ export const useIntlUtils = () => {
     languageOptions,
     currentLanguageName,
     changeLanguage,
+    getLocaleCode,
     getUserLocale,
     setUserLocale,
     getLocalisedFullName,
   };
 };
-
-// export const IntlUtils = {
-//   useChangeLanguage: () => {
-//     const { i18n } = useTranslationNext();
-//     return (language?: LanguageType) => {
-//       const userLanguage = parseLanguage(language);
-//       if (!userLanguage) return;
-//       if (!locales.some(locale => userLanguage === locale)) return;
-
-//       i18n.changeLanguage(userLanguage);
-//     };
-//   },
-//   useRtl: (): boolean => {
-//     const { i18n } = useTranslationNext();
-//     const { language } = i18n;
-//     const isRtl = language === 'ar';
-//     return isRtl;
-//   },
-//   useI18N: (): i18n => {
-//     const { i18n } = useTranslationNext();
-//     return i18n;
-//   },
-//   // TODO: When the server supports a query to find the deployments
-//   // default language, use a query to fetch it.
-//   useDefaultLanguage: (): SupportedLocales => {
-//     return 'en';
-//   },
-//   useCurrentLanguage: (): SupportedLocales => {
-//     const { i18n } = useTranslationNext();
-//     const { language } = i18n;
-//     const supportedLanguage = language as SupportedLocales;
-//     if (locales.includes(supportedLanguage)) {
-//       return supportedLanguage;
-//     }
-//     if (!EnvUtils.isProduction()) {
-//       throw new Error(`Language '${language}' not supported`);
-//     }
-//     return 'en';
-//   },
-//   languageOptions,
-//   getLanguageName: (language: string) =>
-//     languageOptions.find(option => option.value === language)?.label,
-//   getUserLocale: (username: string) => {
-//     const locales = LocalStorage.getItem('/localisation/locale');
-//     return !!locales ? locales[username] : undefined;
-//   },
-//   setUserLocale: (username: string, locale: SupportedLocales) => {
-//     const locales = LocalStorage.getItem('/localisation/locale') ?? {};
-//     locales[username] = locale;
-//     LocalStorage.setItem('/localisation/locale', locales);
-//   },
-//   useLocalisedFullName: () => {
-//     const { i18n } = useTranslationNext();
-//     const { language } = i18n;
-//     return (firstName: StringOrEmpty, lastName: StringOrEmpty) =>
-//       getFullName(language, firstName, lastName);
-//   },
-// };
 
 const parseLanguage = (language?: string) => {
   switch (language) {

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -1,4 +1,4 @@
-import { i18n } from 'i18next';
+// import { i18n } from 'i18next';
 import { useTranslation as useTranslationNext } from 'react-i18next';
 import { EnvUtils } from '@common/utils';
 import { LanguageType } from '../../types/schema';
@@ -25,35 +25,21 @@ const locales = [
 export type SupportedLocales = (typeof locales)[number];
 type StringOrEmpty = string | null | undefined;
 
-export const IntlUtils = {
-  useChangeLanguage: () => {
-    const { i18n } = useTranslationNext();
-    return (language?: LanguageType) => {
-      const userLanguage = parseLanguage(language);
-      if (!userLanguage) return;
-      if (!locales.some(locale => userLanguage === locale)) return;
+export const useIntlUtils = () => {
+  const { i18n } = useTranslationNext();
+  const { language } = i18n;
 
-      i18n.changeLanguage(userLanguage);
-    };
-  },
-  useRtl: (): boolean => {
-    const { i18n } = useTranslationNext();
-    const { language } = i18n;
-    const isRtl = language === 'ar';
-    return isRtl;
-  },
-  useI18N: (): i18n => {
-    const { i18n } = useTranslationNext();
-    return i18n;
-  },
-  // TODO: When the server supports a query to find the deployments
-  // default language, use a query to fetch it.
-  useDefaultLanguage: (): SupportedLocales => {
-    return 'en';
-  },
-  useCurrentLanguage: (): SupportedLocales => {
-    const { i18n } = useTranslationNext();
-    const { language } = i18n;
+  const changeLanguage = (language?: LanguageType) => {
+    const userLanguage = parseLanguage(language);
+    if (!userLanguage) return;
+    if (!locales.some(locale => userLanguage === locale)) return;
+
+    i18n.changeLanguage(userLanguage);
+  };
+
+  const isRtl = language === 'ar';
+
+  const currentLanguage = (() => {
     const supportedLanguage = language as SupportedLocales;
     if (locales.includes(supportedLanguage)) {
       return supportedLanguage;
@@ -62,26 +48,101 @@ export const IntlUtils = {
       throw new Error(`Language '${language}' not supported`);
     }
     return 'en';
-  },
-  languageOptions,
-  getLanguageName: (language: string) =>
-    languageOptions.find(option => option.value === language)?.label,
-  getUserLocale: (username: string) => {
+  })();
+
+  const currentLanguageName = (() => {
+    return languageOptions.find(option => option.value === language)?.label;
+  })();
+
+  const getUserLocale = (username: string) => {
     const locales = LocalStorage.getItem('/localisation/locale');
     return !!locales ? locales[username] : undefined;
-  },
-  setUserLocale: (username: string, locale: SupportedLocales) => {
+  };
+
+  const setUserLocale = (username: string, locale: SupportedLocales) => {
     const locales = LocalStorage.getItem('/localisation/locale') ?? {};
     locales[username] = locale;
     LocalStorage.setItem('/localisation/locale', locales);
-  },
-  useLocalisedFullName: () => {
-    const { i18n } = useTranslationNext();
-    const { language } = i18n;
-    return (firstName: StringOrEmpty, lastName: StringOrEmpty) =>
-      getFullName(language, firstName, lastName);
-  },
+  };
+
+  const getLocalisedFullName = (
+    firstName: StringOrEmpty,
+    lastName: StringOrEmpty
+  ) => getFullName(language, firstName, lastName);
+
+  return {
+    i18n,
+    // TODO: When the server supports a query to find the deployments
+    // default language, use a query to fetch it.
+    defaultLanguage: 'en',
+    isRtl,
+    currentLanguage,
+    languageOptions,
+    currentLanguageName,
+    changeLanguage,
+    getUserLocale,
+    setUserLocale,
+    getLocalisedFullName,
+  };
 };
+
+// export const IntlUtils = {
+//   useChangeLanguage: () => {
+//     const { i18n } = useTranslationNext();
+//     return (language?: LanguageType) => {
+//       const userLanguage = parseLanguage(language);
+//       if (!userLanguage) return;
+//       if (!locales.some(locale => userLanguage === locale)) return;
+
+//       i18n.changeLanguage(userLanguage);
+//     };
+//   },
+//   useRtl: (): boolean => {
+//     const { i18n } = useTranslationNext();
+//     const { language } = i18n;
+//     const isRtl = language === 'ar';
+//     return isRtl;
+//   },
+//   useI18N: (): i18n => {
+//     const { i18n } = useTranslationNext();
+//     return i18n;
+//   },
+//   // TODO: When the server supports a query to find the deployments
+//   // default language, use a query to fetch it.
+//   useDefaultLanguage: (): SupportedLocales => {
+//     return 'en';
+//   },
+//   useCurrentLanguage: (): SupportedLocales => {
+//     const { i18n } = useTranslationNext();
+//     const { language } = i18n;
+//     const supportedLanguage = language as SupportedLocales;
+//     if (locales.includes(supportedLanguage)) {
+//       return supportedLanguage;
+//     }
+//     if (!EnvUtils.isProduction()) {
+//       throw new Error(`Language '${language}' not supported`);
+//     }
+//     return 'en';
+//   },
+//   languageOptions,
+//   getLanguageName: (language: string) =>
+//     languageOptions.find(option => option.value === language)?.label,
+//   getUserLocale: (username: string) => {
+//     const locales = LocalStorage.getItem('/localisation/locale');
+//     return !!locales ? locales[username] : undefined;
+//   },
+//   setUserLocale: (username: string, locale: SupportedLocales) => {
+//     const locales = LocalStorage.getItem('/localisation/locale') ?? {};
+//     locales[username] = locale;
+//     LocalStorage.setItem('/localisation/locale', locales);
+//   },
+//   useLocalisedFullName: () => {
+//     const { i18n } = useTranslationNext();
+//     const { language } = i18n;
+//     return (firstName: StringOrEmpty, lastName: StringOrEmpty) =>
+//       getFullName(language, firstName, lastName);
+//   },
+// };
 
 const parseLanguage = (language?: LanguageType) => {
   switch (language) {

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -74,13 +74,10 @@ export const useIntlUtils = () => {
   ) => getFullName(language, firstName, lastName);
 
   return {
-    // TODO: When the server supports a query to find the deployments
-    // default language, use a query to fetch it.
-    defaultLanguage: 'en',
-    isRtl,
     currentLanguage,
-    languageOptions,
     currentLanguageName,
+    isRtl,
+    languageOptions,
     changeLanguage,
     getLocaleCode,
     getUserLocale,

--- a/client/packages/common/src/intl/utils/IntlUtils.ts
+++ b/client/packages/common/src/intl/utils/IntlUtils.ts
@@ -24,6 +24,7 @@ const locales = [
 const rtlLocales = ['ar'];
 
 export type SupportedLocales = (typeof locales)[number];
+
 type StringOrEmpty = string | null | undefined;
 
 export const useIntlUtils = () => {
@@ -73,7 +74,6 @@ export const useIntlUtils = () => {
   ) => getFullName(language, firstName, lastName);
 
   return {
-    i18n,
     // TODO: When the server supports a query to find the deployments
     // default language, use a query to fetch it.
     defaultLanguage: 'en',

--- a/client/packages/common/src/styles/RTLProvider.test.tsx
+++ b/client/packages/common/src/styles/RTLProvider.test.tsx
@@ -1,13 +1,11 @@
 import { act } from 'react-dom/test-utils';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { renderHookWithProvider } from '@common/utils';
 
 describe('RTLProvider', () => {
   it('Sets the direction of the body to be rtl when a rtl language is the current locale', () => {
     const useHook = () => {
-      const isRtl = IntlUtils.useRtl();
-      const i18n = IntlUtils.useI18N();
-
+      const { i18n, isRtl } = useIntlUtils();
       return { isRtl, i18n };
     };
     const { result } = renderHookWithProvider(useHook);

--- a/client/packages/common/src/styles/RTLProvider.test.tsx
+++ b/client/packages/common/src/styles/RTLProvider.test.tsx
@@ -5,15 +5,15 @@ import { renderHookWithProvider } from '@common/utils';
 describe('RTLProvider', () => {
   it('Sets the direction of the body to be rtl when a rtl language is the current locale', () => {
     const useHook = () => {
-      const { i18n, isRtl } = useIntlUtils();
-      return { isRtl, i18n };
+      const { isRtl, changeLanguage } = useIntlUtils();
+      return { isRtl, changeLanguage };
     };
     const { result } = renderHookWithProvider(useHook);
 
     expect(result.current.isRtl).toBe(false);
 
     act(() => {
-      result.current.i18n.changeLanguage('ar');
+      result.current.changeLanguage('ar');
     });
 
     expect(result.current.isRtl).toBe(true);

--- a/client/packages/common/src/styles/RTLProvider.tsx
+++ b/client/packages/common/src/styles/RTLProvider.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { PropsWithChildrenOnly } from '@common/types';
 
 export const RTLProvider: FC<PropsWithChildrenOnly> = props => {
-  const isRtl = IntlUtils?.useRtl();
+  const { isRtl } = useIntlUtils();
 
   return (
     <div

--- a/client/packages/common/src/styles/useAppTheme.ts
+++ b/client/packages/common/src/styles/useAppTheme.ts
@@ -1,12 +1,12 @@
 import { Direction } from '@mui/material/styles';
 import { Theme } from '@mui/material';
 import { themeOptions, createTheme } from './theme';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { useLocalStorage } from '../localStorage';
 import { merge } from '@common/utils';
 
 export const useAppTheme = (): Theme => {
-  const isRtl = IntlUtils?.useRtl(); // IntlUtils returning undefined when hot reloading
+  const { isRtl } = useIntlUtils();
   const [customTheme] = useLocalStorage('/theme/custom');
   const direction: Direction = isRtl ? 'rtl' : 'ltr';
   const rtlThemeOptions = { ...themeOptions, direction };

--- a/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/FlatButton/FlatButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button as MuiButton, styled, SxProps, Theme } from '@mui/material';
 import { Property } from 'csstype';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 interface ButtonProps {
   color?: 'inherit' | 'primary' | 'secondary';
   endIcon?: React.ReactNode;
@@ -36,7 +36,7 @@ export const FlatButton: React.FC<ButtonProps> = ({
   sx,
   disabled = false,
 }) => {
-  const isRtl = IntlUtils.useRtl();
+  const { isRtl } = useIntlUtils();
   return (
     <StyledButton
       disabled={disabled}

--- a/client/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { ButtonProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { StyledBaseButton } from './BaseButton';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 
 export const StyledShrinkableBaseButton = styled(StyledBaseButton, {
   shouldForwardProp: prop => prop !== 'shrink' && prop !== 'isRtl',
@@ -32,7 +32,7 @@ interface ShrinkableBaseButtonProps extends ButtonProps {
 
 export const ShrinkableBaseButton: FC<ShrinkableBaseButtonProps> =
   React.forwardRef(({ shrink = false, ...props }, ref) => {
-    const isRtl = IntlUtils.useRtl();
+    const { isRtl } = useIntlUtils();
     return (
       <StyledShrinkableBaseButton
         ref={ref}

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.stories.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.stories.tsx
@@ -83,11 +83,11 @@ const RTLComponent = () => {
   const [selectedOption, setSelectedOption] = useState<
     SplitButtonOption<string>
   >(options[0]);
-  const { i18n } = useIntlUtils();
+  const { changeLanguage } = useIntlUtils();
 
   useEffect(() => {
-    i18n.changeLanguage('ar');
-  }, [i18n]);
+    changeLanguage('ar');
+  }, [changeLanguage]);
 
   return (
     <Box>

--- a/client/packages/common/src/ui/components/buttons/standard/SplitButton.stories.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/SplitButton.stories.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box } from '@mui/material';
 import { ComponentMeta } from '@storybook/react';
 import { SplitButton, SplitButtonOption } from './SplitButton';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 
 const getOptions = (): [
   SplitButtonOption<string>,
@@ -83,7 +83,7 @@ const RTLComponent = () => {
   const [selectedOption, setSelectedOption] = useState<
     SplitButtonOption<string>
   >(options[0]);
-  const i18n = IntlUtils.useI18N();
+  const { i18n } = useIntlUtils();
 
   useEffect(() => {
     i18n.changeLanguage('ar');

--- a/client/packages/common/src/ui/components/modals/BasicModal/BasicModal.tsx
+++ b/client/packages/common/src/ui/components/modals/BasicModal/BasicModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import Dialog, { DialogProps as MuiDialogProps } from '@mui/material/Dialog';
-import { IntlUtils } from '@common/intl';
+import { useIntlUtils } from '@common/intl';
 import { SxProps, Theme } from '@mui/material';
 
 interface DialogProps extends MuiDialogProps {
@@ -16,7 +16,7 @@ export const BasicModal: FC<DialogProps> = ({
   sx,
   ...dialogProps
 }) => {
-  const isRtl = IntlUtils.useRtl();
+  const { isRtl } = useIntlUtils();
   return (
     <Dialog
       PaperProps={{

--- a/client/packages/host/src/components/Footer/Footer.tsx
+++ b/client/packages/host/src/components/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Box,
   HomeIcon,
-  IntlUtils,
+  useIntlUtils,
   styled,
   Tooltip,
   TranslateIcon,
@@ -17,7 +17,7 @@ import { LanguageSelector } from './LanguageSelector';
 export const Footer: React.FC = () => {
   const { user, store } = useAuthContext();
   const t = useTranslation('app');
-  const i18n = IntlUtils.useI18N();
+  const { currentLanguageName } = useIntlUtils();
   const PaddedCell = styled(Box)({ display: 'flex' });
   const iconStyles = { color: 'gray.main', height: '16px', width: '16px' };
   const textStyles = {
@@ -46,9 +46,7 @@ export const Footer: React.FC = () => {
         <PaddedCell>
           <TranslateIcon sx={iconStyles} />
           <Tooltip title={t('select-language', { ...store })}>
-            <Typography sx={textStyles}>
-              {IntlUtils.getLanguageName(i18n.language)}
-            </Typography>
+            <Typography sx={textStyles}>{currentLanguageName}</Typography>
           </Tooltip>
         </PaddedCell>
       </LanguageSelector>

--- a/client/packages/host/src/components/Footer/LanguageSelector.tsx
+++ b/client/packages/host/src/components/Footer/LanguageSelector.tsx
@@ -9,7 +9,7 @@ import {
 } from '@openmsupply-client/common';
 import { useIntlUtils, SupportedLocales, useUserName } from '@common/intl';
 
-import { LanguageType, PropsWithChildrenOnly } from '@common/types';
+import { PropsWithChildrenOnly } from '@common/types';
 
 export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const navigate = useNavigate();
@@ -25,7 +25,7 @@ export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
       label={l.label}
       disabled={l.value === currentLanguage}
       onClick={() => {
-        changeLanguage(l.value as LanguageType);
+        changeLanguage(l.value);
         setUserLocale(username, l.value as SupportedLocales);
         hide();
         navigate(0);

--- a/client/packages/host/src/components/Footer/LanguageSelector.tsx
+++ b/client/packages/host/src/components/Footer/LanguageSelector.tsx
@@ -17,13 +17,13 @@ export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const t = useTranslation('app');
   const username = useUserName();
 
-  const { i18n, languageOptions, changeLanguage, setUserLocale } =
+  const { languageOptions, currentLanguage, changeLanguage, setUserLocale } =
     useIntlUtils();
 
   const languageButtons = languageOptions.map(l => (
     <FlatButton
       label={l.label}
-      disabled={l.value === i18n.language}
+      disabled={l.value === currentLanguage}
       onClick={() => {
         changeLanguage(l.value as LanguageType);
         setUserLocale(username, l.value as SupportedLocales);

--- a/client/packages/host/src/components/Footer/LanguageSelector.tsx
+++ b/client/packages/host/src/components/Footer/LanguageSelector.tsx
@@ -7,9 +7,9 @@ import {
   useTranslation,
   useNavigate,
 } from '@openmsupply-client/common';
-import { IntlUtils, SupportedLocales, useUserName } from '@common/intl';
+import { useIntlUtils, SupportedLocales, useUserName } from '@common/intl';
 
-import { PropsWithChildrenOnly } from '@common/types';
+import { LanguageType, PropsWithChildrenOnly } from '@common/types';
 
 export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const navigate = useNavigate();
@@ -17,15 +17,16 @@ export const LanguageSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const t = useTranslation('app');
   const username = useUserName();
 
-  const i18n = IntlUtils.useI18N();
+  const { i18n, languageOptions, changeLanguage, setUserLocale } =
+    useIntlUtils();
 
-  const languageButtons = IntlUtils.languageOptions.map(l => (
+  const languageButtons = languageOptions.map(l => (
     <FlatButton
       label={l.label}
       disabled={l.value === i18n.language}
       onClick={() => {
-        i18n.changeLanguage(l.value);
-        IntlUtils.setUserLocale(username, l.value as SupportedLocales);
+        changeLanguage(l.value as LanguageType);
+        setUserLocale(username, l.value as SupportedLocales);
         hide();
         navigate(0);
       }}

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -5,16 +5,16 @@ import {
   MenuItem,
   Option,
 } from '@openmsupply-client/common';
-import { IntlUtils, SupportedLocales, useUserName } from '@common/intl';
+import { useIntlUtils, SupportedLocales, useUserName } from '@common/intl';
 
 export const LanguageMenu: React.FC = () => {
   const navigate = useNavigate();
-  const i18n = IntlUtils.useI18N();
+  const { i18n, setUserLocale, languageOptions } = useIntlUtils();
   const username = useUserName();
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     i18n.changeLanguage(value);
-    IntlUtils.setUserLocale(username, value as SupportedLocales);
+    setUserLocale(username, value as SupportedLocales);
     navigate(0);
   };
 
@@ -31,7 +31,7 @@ export const LanguageMenu: React.FC = () => {
   return (
     <Select
       onChange={handleChange}
-      options={IntlUtils.languageOptions}
+      options={languageOptions}
       value={i18n.language}
       renderOption={renderOption}
     />

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -4,16 +4,18 @@ import {
   Select,
   MenuItem,
   Option,
+  LanguageType,
 } from '@openmsupply-client/common';
 import { useIntlUtils, SupportedLocales, useUserName } from '@common/intl';
 
 export const LanguageMenu: React.FC = () => {
   const navigate = useNavigate();
-  const { i18n, setUserLocale, languageOptions } = useIntlUtils();
+  const { changeLanguage, setUserLocale, languageOptions, currentLanguage } =
+    useIntlUtils();
   const username = useUserName();
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
-    i18n.changeLanguage(value);
+    changeLanguage(value as LanguageType);
     setUserLocale(username, value as SupportedLocales);
     navigate(0);
   };
@@ -32,7 +34,7 @@ export const LanguageMenu: React.FC = () => {
     <Select
       onChange={handleChange}
       options={languageOptions}
-      value={i18n.language}
+      value={currentLanguage}
       renderOption={renderOption}
     />
   );

--- a/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
+++ b/client/packages/system/src/Clinician/ClinicianSearchInput.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, IntlUtils } from '@openmsupply-client/common';
+import { Autocomplete, useIntlUtils } from '@openmsupply-client/common';
 import { ClinicianFragment, useClinicians } from '@openmsupply-client/programs';
 import React from 'react';
 import { FC } from 'react';
@@ -18,7 +18,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
   clinicianValue,
 }) => {
   const { data } = useClinicians.document.list({});
-  const getFullName = IntlUtils.useLocalisedFullName();
+  const { getLocalisedFullName } = useIntlUtils();
   const clinicians: ClinicianFragment[] = data?.nodes ?? [];
 
   return (
@@ -33,7 +33,7 @@ export const ClinicianSearchInput: FC<ClinicianSearchInputProps> = ({
       }}
       options={clinicians.map(
         (clinician): ClinicianAutocompleteOption => ({
-          label: getFullName(clinician.firstName, clinician.lastName),
+          label: getLocalisedFullName(clinician.firstName, clinician.lastName),
           value: {
             firstName: clinician.firstName ?? '',
             lastName: clinician.lastName ?? '',

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -9,7 +9,7 @@ import {
   useBreadcrumbs,
   useFormatDateTime,
   Breadcrumb,
-  IntlUtils,
+  useIntlUtils,
 } from '@openmsupply-client/common';
 import {
   useEncounter,
@@ -28,7 +28,7 @@ export const DetailView: FC = () => {
   const navigate = useNavigate();
   const { setSuffix } = useBreadcrumbs([AppRoute.Encounter]);
   const dateFormat = useFormatDateTime();
-  const getFullName = IntlUtils.useLocalisedFullName();
+  const { getLocalisedFullName } = useIntlUtils();
 
   const {
     data: encounter,
@@ -85,7 +85,7 @@ export const DetailView: FC = () => {
               .addPart(encounter.patient.id)
               .build()}
           >
-            {getFullName(
+            {getLocalisedFullName(
               encounter.patient.firstName,
               encounter.patient.lastName
             )}

--- a/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
+++ b/client/packages/system/src/Encounter/DetailView/Toolbar.tsx
@@ -16,7 +16,7 @@ import {
   LocaleKey,
   TypedTFunction,
   Option,
-  IntlUtils,
+  useIntlUtils,
 } from '@openmsupply-client/common';
 import {
   EncounterFragment,
@@ -55,7 +55,7 @@ export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
   const [endDatetime, setEndDatetime] = useState<string | undefined | null>();
   const t = useTranslation('patients');
   const { localisedDate } = useFormatDateTime();
-  const getFullName = IntlUtils.useLocalisedFullName();
+  const { getLocalisedFullName } = useIntlUtils();
   const [clinician, setClinician] =
     useState<ClinicianAutocompleteOption | null>();
   const { data: programDocument } =
@@ -66,7 +66,7 @@ export const Toolbar: FC<ToolbarProps> = ({ encounter, onChange }) => {
     setStartDatetime(encounter.startDatetime);
     setEndDatetime(encounter.endDatetime);
     setClinician({
-      label: getFullName(
+      label: getLocalisedFullName(
         encounter.clinician?.firstName,
         encounter.clinician?.lastName
       ),

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -15,7 +15,7 @@ import {
   useAuthContext,
   DatePickerInput,
 } from '@openmsupply-client/common';
-import { DateUtils, IntlUtils, useTranslation } from '@common/intl';
+import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import {
   EncounterRegistryByProgram,
   PatientModal,
@@ -43,7 +43,7 @@ export const CreateEncounterModal: FC = () => {
   const patientId = usePatient.utils.id();
   const { user } = useAuthContext();
   const t = useTranslation('patients');
-  const getFullName = IntlUtils.useLocalisedFullName();
+  const { getLocalisedFullName } = useIntlUtils();
   const { current, setModal: selectModal } = usePatientModalStore();
   const [encounterRegistry, setEncounterRegistry] = useState<
     EncounterRegistryByProgram | undefined
@@ -167,7 +167,7 @@ export const CreateEncounterModal: FC = () => {
                   Input={
                     <ClinicianSearchInput
                       onChange={setClinician}
-                      clinicianLabel={getFullName(
+                      clinicianLabel={getLocalisedFullName(
                         draft?.clinician?.firstName,
                         draft?.clinician?.lastName
                       )}

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -21,7 +21,7 @@ import {
 } from '@openmsupply-client/programs';
 import { usePatient } from '../../api';
 import { getStatusTranslation } from '../utils';
-import { encounterEventCellValue } from 'packages/system/src/Encounter/ListView/columns';
+import { encounterEventCellValue } from '../../../Encounter/ListView/columns';
 
 const ProgramListComponent: FC = () => {
   const {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,6 @@
       "@common/styles": ["packages/common/src/styles"],
       "@common/types": ["packages/common/src/types"],
       "@common/utils": ["packages/common/src/utils"],
-      // the graphql-codegen v3.2.2 is relying on an internal export of graphql-request which was removed in v5.2.0
       "graphql-request/dist/types.dom": [
         "node_modules/graphql-request/src/types.dom"
       ]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Bit offtrack here, but just doing this quickly as discussed [here](https://github.com/openmsupply/open-msupply/pull/1563#discussion_r1171935055)

Just refactors the `IntlUtils` into a single hook `useIntlUtils` that returns all relevant values and methods, namely: 

**Values**
- defaultLanguage: 'en',
- isRtl,
- currentLanguage,
- languageOptions,
- currentLanguageName,

**Methods**
- changeLanguage,
- getLocaleCode,
- getUserLocale,
- setUserLocale,
- getLocalisedFullName,

A couple of the existing methods were no longer needed, or could be simplified too. (in particular, there's no need to return the whole `i18n` object now. I think it's tidier and more consistent now.

> the functions aren't all hooks in the IntlUtils tho - so I would just expose the hook based items. Otherwise you are forcing the consumer to use the utils as a hook, and that might be annoying? I guess check current usage and see.

Yes, all usages are components which were mostly already using one of the hooks, or easily can. In the unlikely event we need access to one of these values from a non-React element, we can just pass it in in from the caller. 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Can still switch language
- Uses default language if none specified in local storage
- existing locale-based functionality unchanged

Hope I haven't broken anything 😳