### PR TITLE
1508.3 program settings program supplier

### DIFF
--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -47,7 +47,7 @@ impl<'a> MasterListRepository<'a> {
 
     pub fn count(&self, filter: Option<MasterListFilter>) -> Result<i64, RepositoryError> {
         // TODO (beyond M1), check that store_id matches current store
-        let query = create_filtered_query(filter, self.connection)?;
+        let query = Self::create_filtered_query(filter);
 
         Ok(query.count().get_result(&self.connection.connection)?)
     }
@@ -59,6 +59,38 @@ impl<'a> MasterListRepository<'a> {
         self.query(Pagination::new(), Some(filter), None)
     }
 
+    pub fn create_filtered_query(filter: Option<MasterListFilter>) -> BoxedMasterListQuery {
+        let mut query = master_list_dsl::master_list.into_boxed();
+
+        if let Some(f) = filter {
+            apply_equal_filter!(query, f.id, master_list_dsl::id);
+            apply_simple_string_filter!(query, f.name, master_list_dsl::name);
+            apply_simple_string_filter!(query, f.code, master_list_dsl::code);
+            apply_simple_string_filter!(query, f.description, master_list_dsl::description);
+
+            // Result master list should be unique, which would need extra logic if we were to join
+            // name table through master_list_name_join, thus query separately and use resulting
+            // master_list_ids in 'any' filter
+            if f.exists_for_name.is_some()
+                || f.exists_for_name_id.is_some()
+                || f.exists_for_store_id.is_some()
+            {
+                let mut name_join_query = master_list_name_join_dsl::master_list_name_join
+                    .select(master_list_name_join_dsl::master_list_id)
+                    .left_join(name_dsl::name.left_join(store_dsl::store))
+                    .into_boxed();
+
+                apply_simple_string_filter!(name_join_query, f.exists_for_name, name_dsl::name_);
+                apply_equal_filter!(name_join_query, f.exists_for_name_id, name_dsl::id);
+                apply_equal_filter!(name_join_query, f.exists_for_store_id, store_dsl::id);
+
+                query = query.filter(master_list_dsl::id.eq_any(name_join_query));
+            }
+        }
+
+        query
+    }
+
     pub fn query(
         &self,
         pagination: Pagination,
@@ -66,7 +98,7 @@ impl<'a> MasterListRepository<'a> {
         sort: Option<MasterListSort>,
     ) -> Result<Vec<MasterList>, RepositoryError> {
         // TODO (beyond M1), check that store_id matches current store
-        let mut query = create_filtered_query(filter, self.connection)?;
+        let mut query = Self::create_filtered_query(filter);
 
         if let Some(sort) = sort {
             match sort.key {
@@ -94,44 +126,6 @@ impl<'a> MasterListRepository<'a> {
 }
 
 type BoxedMasterListQuery = master_list::BoxedQuery<'static, DBType>;
-
-fn create_filtered_query(
-    filter: Option<MasterListFilter>,
-    connection: &StorageConnection,
-) -> Result<BoxedMasterListQuery, RepositoryError> {
-    let mut query = master_list_dsl::master_list.into_boxed();
-
-    if let Some(f) = filter {
-        apply_equal_filter!(query, f.id, master_list_dsl::id);
-        apply_simple_string_filter!(query, f.name, master_list_dsl::name);
-        apply_simple_string_filter!(query, f.code, master_list_dsl::code);
-        apply_simple_string_filter!(query, f.description, master_list_dsl::description);
-
-        // Result master list should be unique, which would need extra logic if we were to join
-        // name table through master_list_name_join, thus query separately and use resulting
-        // master_list_ids in 'any' filter
-        if f.exists_for_name.is_some()
-            || f.exists_for_name_id.is_some()
-            || f.exists_for_store_id.is_some()
-        {
-            let mut name_join_query = master_list_name_join_dsl::master_list_name_join
-                .select(master_list_name_join_dsl::master_list_id)
-                .left_join(name_dsl::name.left_join(store_dsl::store))
-                .into_boxed();
-
-            apply_simple_string_filter!(name_join_query, f.exists_for_name, name_dsl::name_);
-            apply_equal_filter!(name_join_query, f.exists_for_name_id, name_dsl::id);
-            apply_equal_filter!(name_join_query, f.exists_for_store_id, store_dsl::id);
-
-            let master_list_ids = name_join_query.load::<String>(&connection.connection)?;
-
-            let filter = Some(EqualFilter::equal_any(master_list_ids));
-            apply_equal_filter!(query, filter, master_list_dsl::id);
-        }
-    }
-
-    Ok(query)
-}
 
 impl MasterListFilter {
     pub fn new() -> MasterListFilter {

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -25,7 +25,7 @@ pub struct Name {
     pub store_row: Option<StoreRow>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Debug)]
 pub struct NameFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<SimpleStringFilter>,
@@ -69,7 +69,7 @@ impl<'a> NameRepository<'a> {
         store_id: &str,
         filter: Option<NameFilter>,
     ) -> Result<i64, RepositoryError> {
-        let query = create_filtered_query(store_id.to_string(), filter);
+        let query = Self::create_filtered_query(store_id.to_string(), filter);
 
         Ok(query.count().get_result(&self.connection.connection)?)
     }
@@ -97,7 +97,7 @@ impl<'a> NameRepository<'a> {
         filter: Option<NameFilter>,
         sort: Option<NameSort>,
     ) -> Result<Vec<Name>, RepositoryError> {
-        let mut query = create_filtered_query(store_id.to_string(), filter);
+        let mut query = Self::create_filtered_query(store_id.to_string(), filter);
 
         if let Some(sort) = sort {
             match sort.key {
@@ -124,15 +124,76 @@ impl<'a> NameRepository<'a> {
 
         let result = final_query.load::<NameAndNameStoreJoin>(&self.connection.connection)?;
 
-        Ok(result.into_iter().map(to_domain).collect())
+        Ok(result.into_iter().map(Name::from_join).collect())
+    }
+
+    pub fn create_filtered_query(store_id: String, filter: Option<NameFilter>) -> BoxedNameQuery {
+        let mut query = name_dsl::name
+            .left_join(
+                name_store_join_dsl::name_store_join.on(name_store_join_dsl::name_id
+                    .eq(name_dsl::id)
+                    .and(name_store_join_dsl::store_id.eq(store_id.clone()))),
+            )
+            .left_join(store_dsl::store)
+            .into_boxed();
+
+        if let Some(f) = filter {
+            let NameFilter {
+                id,
+                name,
+                code,
+                is_customer,
+                is_supplier,
+                is_store,
+                store_code,
+                is_visible,
+                is_system_name,
+                r#type,
+            } = f;
+
+            apply_equal_filter!(query, id, name_dsl::id);
+            apply_simple_string_filter!(query, code, name_dsl::code);
+            apply_simple_string_filter!(query, name, name_dsl::name_);
+            apply_simple_string_filter!(query, store_code, store_dsl::code);
+            apply_equal_filter!(query, r#type, name_dsl::type_);
+
+            if let Some(is_customer) = is_customer {
+                query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
+            }
+            if let Some(is_supplier) = is_supplier {
+                query = query.filter(name_store_join_dsl::name_is_supplier.eq(is_supplier));
+            }
+
+            query = match is_visible {
+                Some(true) => query.filter(name_store_join_dsl::id.is_not_null()),
+                Some(false) => query.filter(name_store_join_dsl::id.is_null()),
+                None => query,
+            };
+
+            query = match is_system_name {
+                Some(true) => query.filter(name_dsl::code.eq_any(SYSTEM_NAME_CODES)),
+                Some(false) => query.filter(name_dsl::code.ne_all(SYSTEM_NAME_CODES)),
+                None => query,
+            };
+
+            query = match is_store {
+                Some(true) => query.filter(store_dsl::id.is_not_null()),
+                Some(false) => query.filter(store_dsl::id.is_null()),
+                None => query,
+            };
+        };
+
+        query
     }
 }
 
-fn to_domain((name_row, name_store_join_row, store_row): NameAndNameStoreJoin) -> Name {
-    Name {
-        name_row,
-        name_store_join_row,
-        store_row,
+impl Name {
+    pub fn from_join((name_row, name_store_join_row, store_row): NameAndNameStoreJoin) -> Name {
+        Name {
+            name_row,
+            name_store_join_row,
+            store_row,
+        }
     }
 }
 
@@ -149,65 +210,6 @@ type BoxedNameQuery = IntoBoxed<
     LeftJoin<LeftJoin<name::table, OnNameStoreJoinToNameJoin>, store::table>,
     DBType,
 >;
-
-fn create_filtered_query(store_id: String, filter: Option<NameFilter>) -> BoxedNameQuery {
-    let mut query = name_dsl::name
-        .left_join(
-            name_store_join_dsl::name_store_join.on(name_store_join_dsl::name_id
-                .eq(name_dsl::id)
-                .and(name_store_join_dsl::store_id.eq(store_id.clone()))),
-        )
-        .left_join(store_dsl::store)
-        .into_boxed();
-
-    if let Some(f) = filter {
-        let NameFilter {
-            id,
-            name,
-            code,
-            is_customer,
-            is_supplier,
-            is_store,
-            store_code,
-            is_visible,
-            is_system_name,
-            r#type,
-        } = f;
-
-        apply_equal_filter!(query, id, name_dsl::id);
-        apply_simple_string_filter!(query, code, name_dsl::code);
-        apply_simple_string_filter!(query, name, name_dsl::name_);
-        apply_simple_string_filter!(query, store_code, store_dsl::code);
-        apply_equal_filter!(query, r#type, name_dsl::type_);
-
-        if let Some(is_customer) = is_customer {
-            query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
-        }
-        if let Some(is_supplier) = is_supplier {
-            query = query.filter(name_store_join_dsl::name_is_supplier.eq(is_supplier));
-        }
-
-        query = match is_visible {
-            Some(true) => query.filter(name_store_join_dsl::id.is_not_null()),
-            Some(false) => query.filter(name_store_join_dsl::id.is_null()),
-            None => query,
-        };
-
-        query = match is_system_name {
-            Some(true) => query.filter(name_dsl::code.eq_any(SYSTEM_NAME_CODES)),
-            Some(false) => query.filter(name_dsl::code.ne_all(SYSTEM_NAME_CODES)),
-            None => query,
-        };
-
-        query = match is_store {
-            Some(true) => query.filter(store_dsl::id.is_not_null()),
-            Some(false) => query.filter(store_dsl::id.is_null()),
-            None => query,
-        };
-    };
-
-    query
-}
 
 impl NameFilter {
     pub fn new() -> NameFilter {

--- a/server/repository/src/db_diesel/program_requisition/program_supplier.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_supplier.rs
@@ -1,0 +1,314 @@
+use diesel::prelude::*;
+
+use crate::{
+    db_diesel::{
+        master_list_name_join::master_list_name_join::dsl as master_list_name_join_dsl,
+        master_list_row::master_list::dsl as master_list_dsl, name_row::name::dsl as name_dsl,
+        name_store_join::name_store_join::dsl as name_store_join_dsl,
+        program_row::program::dsl as program_dsl, store_row::store::dsl as store_dsl,
+    },
+    diesel_macros::apply_equal_filter,
+    repository_error::RepositoryError,
+    EqualFilter, Name, NameFilter, NameRepository, NameRow, NameStoreJoinRow, ProgramRow,
+    StorageConnection, StoreRow,
+};
+
+pub type ProgramSupplierJoin = (NameRow, NameStoreJoinRow, StoreRow, ProgramRow);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ProgramSupplier {
+    pub supplier: Name,
+    pub program: ProgramRow,
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct ProgramSupplierFilter {
+    pub program_id: Option<EqualFilter<String>>,
+    pub name: Option<NameFilter>,
+}
+
+pub struct ProgramSupplierRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> ProgramSupplierRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        ProgramSupplierRepository { connection }
+    }
+
+    pub fn query(
+        &self,
+        store_id: &str,
+        ProgramSupplierFilter {
+            program_id: program_id_filter,
+            name: name_filter,
+        }: ProgramSupplierFilter,
+    ) -> Result<Vec<ProgramSupplier>, RepositoryError> {
+        let mut query = NameRepository::create_filtered_query(store_id.to_string(), name_filter)
+            .inner_join(
+                master_list_name_join_dsl::master_list_name_join
+                    .on(master_list_name_join_dsl::name_id.eq(name_dsl::id)),
+            )
+            .inner_join(
+                master_list_dsl::master_list
+                    .on(master_list_dsl::id.eq(master_list_name_join_dsl::master_list_id)),
+            )
+            .inner_join(
+                program_dsl::program.on(program_dsl::master_list_id.eq(master_list_dsl::id)),
+            );
+
+        apply_equal_filter!(query, program_id_filter, program_dsl::id);
+
+        //  Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
+
+        let query = query.select((
+            // Same as NameRepository
+            name_dsl::name::all_columns(),
+            name_store_join_dsl::name_store_join::all_columns(),
+            store_dsl::store::all_columns(),
+            program_dsl::program::all_columns(),
+        ));
+        let result = query.load::<ProgramSupplierJoin>(&self.connection.connection)?;
+
+        Ok(result
+            .into_iter()
+            .map(
+                |(name_row, name_store_join_row, store_row, program)| ProgramSupplier {
+                    supplier: Name::from_join((
+                        name_row,
+                        Some(name_store_join_row),
+                        Some(store_row),
+                    )),
+                    program,
+                },
+            )
+            .collect())
+    }
+}
+
+impl ProgramSupplierFilter {
+    pub fn new() -> ProgramSupplierFilter {
+        Default::default()
+    }
+
+    pub fn program_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.program_id = Some(filter);
+        self
+    }
+
+    pub fn name(mut self, filter: NameFilter) -> Self {
+        self.name = Some(filter);
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        mock::{MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        EqualFilter, MasterListNameJoinRepository, MasterListNameJoinRow, MasterListRow, Name,
+        NameFilter, NameRow, NameStoreJoinRepository, NameStoreJoinRow, ProgramRow,
+        ProgramSupplier, ProgramSupplierFilter, ProgramSupplierRepository, StoreRow,
+    };
+
+    #[actix_rt::test]
+    async fn program_requisition_settings_repository() {
+        let name1 = NameRow {
+            id: "name1".to_string(),
+            ..Default::default()
+        };
+
+        let store_name1 = NameRow {
+            id: "store_name1".to_string(),
+            ..Default::default()
+        };
+        let store1 = StoreRow {
+            id: "store1".to_string(),
+            name_id: store_name1.id.clone(),
+            ..Default::default()
+        };
+        let store_name2 = NameRow {
+            id: "store_name2".to_string(),
+            ..Default::default()
+        };
+
+        let store2 = StoreRow {
+            id: "store2".to_string(),
+            name_id: store_name2.id.clone(),
+            ..Default::default()
+        };
+
+        let store_name3 = NameRow {
+            id: "store_name3".to_string(),
+            ..Default::default()
+        };
+        let store3 = StoreRow {
+            id: "store3".to_string(),
+            name_id: store_name3.id.clone(),
+            ..Default::default()
+        };
+
+        let master_list1 = MasterListRow {
+            id: "master_list1".to_string(),
+            ..Default::default()
+        };
+        let program1 = ProgramRow {
+            id: "program1".to_string(),
+            master_list_id: master_list1.id.clone(),
+            ..Default::default()
+        };
+
+        let master_list2 = MasterListRow {
+            id: "master_list2".to_string(),
+            ..Default::default()
+        };
+
+        let program2 = ProgramRow {
+            id: "program2".to_string(),
+            master_list_id: master_list2.id.clone(),
+            ..Default::default()
+        };
+
+        let master_list_name_join1 = MasterListNameJoinRow {
+            id: "master_list_name_join1".to_string(),
+            name_id: name1.id.clone(),
+            master_list_id: master_list1.id.clone(),
+        };
+        let master_list_name_join2 = MasterListNameJoinRow {
+            id: "master_list_name_join2".to_string(),
+            name_id: store_name1.id.clone(),
+            master_list_id: master_list1.id.clone(),
+        };
+        let master_list_name_join3 = MasterListNameJoinRow {
+            id: "master_list_name_join3".to_string(),
+            name_id: store_name2.id.clone(),
+            master_list_id: master_list2.id.clone(),
+        };
+
+        let name_store_join1 = NameStoreJoinRow {
+            id: "name_store_join1".to_string(),
+            name_id: name1.id.clone(),
+            store_id: store3.id.clone(),
+            ..Default::default()
+        };
+        let name_store_join2 = NameStoreJoinRow {
+            id: "name_store_join2".to_string(),
+            name_id: store_name1.id.clone(),
+            store_id: store3.id.clone(),
+            ..Default::default()
+        };
+
+        let name_store_join3 = NameStoreJoinRow {
+            id: "name_store_join3".to_string(),
+            name_id: store_name2.id.clone(),
+            store_id: store3.id.clone(),
+            ..Default::default()
+        };
+
+        let (_, connection, _, _) = setup_all_with_data(
+            "program_supplier_repository",
+            MockDataInserts::none(),
+            MockData {
+                stores: vec![store1.clone(), store2.clone(), store3.clone()],
+                names: vec![
+                    name1,
+                    store_name1.clone(),
+                    store_name2.clone(),
+                    store_name3.clone(),
+                ],
+                master_lists: vec![master_list1, master_list2],
+                programs: vec![program1.clone(), program2.clone()],
+                master_list_name_joins: vec![master_list_name_join1, master_list_name_join3],
+                name_store_joins: vec![name_store_join1.clone(), name_store_join2.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // TEST 1 without master list join for store 1 and without name_store_join for store 2
+        // should result in nothing (since name1 is not store)
+        let repo = ProgramSupplierRepository::new(&connection);
+
+        let filter = ProgramSupplierFilter::new()
+            .program_id(EqualFilter::equal_any(vec![
+                program1.id.clone(),
+                program2.id.clone(),
+            ]))
+            .name(NameFilter::new().is_store(true).is_visible(true));
+
+        let result = repo.query(&store3.id, filter);
+
+        assert_eq!(result, Ok(Vec::new()));
+
+        // TEST 2 with master list join for store 1 and without name_store_join for store 2
+        // should result in one found, store_name1
+        let filter = ProgramSupplierFilter::new()
+            .program_id(EqualFilter::equal_any(vec![
+                program1.id.clone(),
+                program2.id.clone(),
+            ]))
+            .name(NameFilter::new().is_store(true).is_visible(true));
+
+        MasterListNameJoinRepository::new(&connection)
+            .upsert_one(&master_list_name_join2)
+            .unwrap();
+
+        let result = repo.query(&store3.id, filter);
+
+        assert_eq!(
+            result,
+            Ok(vec![ProgramSupplier {
+                supplier: Name {
+                    name_row: store_name1.clone(),
+                    name_store_join_row: Some(name_store_join2.clone()),
+                    store_row: Some(store1.clone()),
+                },
+                program: program1.clone()
+            }])
+        );
+
+        // TEST 3 with master list join for store 1 and with name_store_join for store 2
+        // should result in two found, store_name1 and store_name2
+        let filter = ProgramSupplierFilter::new()
+            .program_id(EqualFilter::equal_any(vec![
+                program1.id.clone(),
+                program2.id.clone(),
+            ]))
+            .name(NameFilter::new().is_store(true).is_visible(true));
+
+        NameStoreJoinRepository::new(&connection)
+            .upsert_one(&name_store_join3)
+            .unwrap();
+
+        let result = repo.query(&store3.id, filter);
+
+        assert_eq!(
+            result,
+            Ok(vec![
+                ProgramSupplier {
+                    supplier: Name {
+                        name_row: store_name1.clone(),
+                        name_store_join_row: Some(name_store_join2.clone()),
+                        store_row: Some(store1.clone()),
+                    },
+                    program: program1.clone()
+                },
+                ProgramSupplier {
+                    supplier: Name {
+                        name_row: store_name2.clone(),
+                        name_store_join_row: Some(name_store_join3.clone()),
+                        store_row: Some(store2.clone()),
+                    },
+                    program: program2.clone()
+                }
+            ])
+        );
+
+        //
+    }
+}

--- a/server/repository/src/db_diesel/program_requisition/program_supplier.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_supplier.rs
@@ -60,10 +60,10 @@ impl<'a> ProgramSupplierRepository<'a> {
         apply_equal_filter!(query, program_id_filter, program_dsl::id);
 
         //  Debug diesel query
-        // println!(
-        //     "{}",
-        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-        // );
+        println!(
+            "{}",
+            diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        );
 
         let query = query.select((
             // Same as NameRepository
@@ -308,7 +308,5 @@ mod test {
                 }
             ])
         );
-
-        //
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Links to #1508.3

Third of 5 stacked PR's, see latest PR for tests.

# 👩🏻‍💻 What does this PR do? 

Adds program supplier repository

* Add a view and a repository for requisition_in_period, this is required to know what periods are available for order type (based on order type max_order_per_period)
* Since this new repository uses master list create filtered query, this query is relocated to the repository struct, there is a small change to create filtered query here, that's easy to miss in review, it's the last few lines of that method (instead of querying ids first and using them in equal_any, do inner query)  -> oops, master list repository is not used here but in the next PR
* Name repository is used in this new repository, thus create filtered query is relocated to struct (no extra changes to that method)
* Program Supplier Repository, which was needed to get a combination of program and supplier, to be mapped in the program requisition settings service in first PR. Since we are constructing name node in graphql, we need the full Name not just name_row, thus using NameRepository::create_filtered_query and joining to it

# 🧪 How has/should this change been tested? 

In last PR

## 💌 Any notes for the reviewer?

Changes will be done here and merged to the last PR 
