### PR TITLE
1508.4 program requisition settings repository

### DIFF
--- a/server/repository/src/db_diesel/name_tag.rs
+++ b/server/repository/src/db_diesel/name_tag.rs
@@ -1,0 +1,75 @@
+use diesel::prelude::*;
+
+use crate::{
+    db_diesel::{
+        name_row::name::dsl as name_dsl,
+        name_tag_join::name_tag_join::dsl as name_tag_join_dsl,
+        name_tag_row::{name_tag, name_tag::dsl as name_tag_dsl},
+        store_row::store::dsl as store_dsl,
+    },
+    diesel_macros::apply_equal_filter,
+    repository_error::RepositoryError,
+    DBType, NameTagRow, StorageConnection,
+};
+
+use crate::EqualFilter;
+
+pub type NameTag = NameTagRow;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct NameTagFilter {
+    pub store_id: Option<EqualFilter<String>>,
+}
+
+pub struct NameTagRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+pub type BoxedNameTagQuery = name_tag::BoxedQuery<'static, DBType>;
+
+impl<'a> NameTagRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        NameTagRepository { connection }
+    }
+
+    pub fn query(&self, filter: Option<NameTagFilter>) -> Result<Vec<NameTag>, RepositoryError> {
+        let query = Self::create_filtered_query(filter);
+
+        let result = query.load::<NameTag>(&self.connection.connection)?;
+
+        Ok(result)
+    }
+
+    pub fn create_filtered_query(filter: Option<NameTagFilter>) -> BoxedNameTagQuery {
+        let mut query = name_tag::table.into_boxed();
+
+        let Some(NameTagFilter { store_id }) = filter else {
+            return query;
+        };
+
+        if store_id.is_some() {
+            let mut name_tag_query = name_tag_join_dsl::name_tag_join
+                .left_join(name_dsl::name.left_join(store_dsl::store))
+                .into_boxed();
+
+            apply_equal_filter!(name_tag_query, store_id, store_dsl::id);
+
+            query = query.filter(
+                name_tag_dsl::id.eq_any(name_tag_query.select(name_tag_join_dsl::name_tag_id)),
+            );
+        }
+
+        query
+    }
+}
+
+impl NameTagFilter {
+    pub fn new() -> NameTagFilter {
+        NameTagFilter { store_id: None }
+    }
+
+    pub fn store_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.store_id = Some(filter);
+        self
+    }
+}

--- a/server/repository/src/db_diesel/name_tag_join.rs
+++ b/server/repository/src/db_diesel/name_tag_join.rs
@@ -1,6 +1,5 @@
 use super::{name_tag_join::name_tag_join::dsl as name_tag_join_dsl, StorageConnection};
-
-use crate::repository_error::RepositoryError;
+use crate::{db_diesel::name_row::name, repository_error::RepositoryError};
 
 use diesel::prelude::*;
 
@@ -19,6 +18,8 @@ pub struct NameTagJoinRow {
     pub name_id: String,
     pub name_tag_id: String,
 }
+
+joinable!(name_tag_join -> name (name_id));
 
 pub struct NameTagJoinRepository<'a> {
     connection: &'a StorageConnection,

--- a/server/repository/src/db_diesel/program_requisition/program_requisition_settings.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_requisition_settings.rs
@@ -1,0 +1,202 @@
+use diesel::prelude::*;
+
+use crate::{
+    db_diesel::{
+        master_list_row::master_list::dsl as master_list_dsl,
+        name_tag_row::name_tag::dsl as name_tag_dsl,
+    },
+    program::dsl as program_dsl,
+    program_requisition_settings_row::program_requisition_settings::dsl as program_requisition_settings_dsl,
+    repository_error::RepositoryError,
+    MasterListFilter, MasterListRepository, MasterListRow, NameTagFilter, NameTagRepository,
+    ProgramRequisitionSettingsRow, ProgramRow, StorageConnection,
+};
+
+pub type ProgramRequisitionSettingsJoin =
+    (ProgramRequisitionSettingsRow, ProgramRow, MasterListRow);
+
+#[derive(Debug, PartialEq)]
+pub struct ProgramRequisitionSettings {
+    pub program_settings_row: ProgramRequisitionSettingsRow,
+    pub program_row: ProgramRow,
+    pub master_list: MasterListRow,
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct ProgramRequisitionSettingsFilter {
+    pub name_tag: Option<NameTagFilter>,
+    pub master_list: Option<MasterListFilter>,
+}
+
+pub struct ProgramRequisitionSettingsRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl<'a> ProgramRequisitionSettingsRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        ProgramRequisitionSettingsRepository { connection }
+    }
+
+    pub fn query(
+        &self,
+        filter: Option<ProgramRequisitionSettingsFilter>,
+    ) -> Result<Vec<ProgramRequisitionSettings>, RepositoryError> {
+        let mut query = program_requisition_settings_dsl::program_requisition_settings
+            .inner_join(program_dsl::program)
+            .inner_join(
+                master_list_dsl::master_list
+                    .on(master_list_dsl::id.eq(program_dsl::master_list_id)),
+            )
+            .into_boxed();
+
+        if let Some(ProgramRequisitionSettingsFilter {
+            name_tag,
+            master_list,
+        }) = filter
+        {
+            if name_tag.is_some() {
+                let name_tag_ids =
+                    NameTagRepository::create_filtered_query(name_tag).select(name_tag_dsl::id);
+                query = query
+                    .filter(program_requisition_settings_dsl::name_tag_id.eq_any(name_tag_ids));
+            }
+
+            if master_list.is_some() {
+                let master_list_ids = MasterListRepository::create_filtered_query(master_list)
+                    .select(master_list_dsl::id);
+                query = query.filter(program_dsl::master_list_id.eq_any(master_list_ids));
+            }
+        }
+
+        //  Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
+
+        let result = query.load::<ProgramRequisitionSettingsJoin>(&self.connection.connection)?;
+
+        Ok(result
+            .into_iter()
+            .map(
+                |(program_settings_row, program_row, master_list)| ProgramRequisitionSettings {
+                    program_settings_row,
+                    program_row,
+                    master_list,
+                },
+            )
+            .collect())
+    }
+}
+
+impl ProgramRequisitionSettingsFilter {
+    pub fn new() -> ProgramRequisitionSettingsFilter {
+        Default::default()
+    }
+
+    pub fn name_tag(mut self, filter: NameTagFilter) -> Self {
+        self.name_tag = Some(filter);
+        self
+    }
+
+    pub fn master_list(mut self, filter: MasterListFilter) -> Self {
+        self.master_list = Some(filter);
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        mock::{
+            mock_name_store_a, mock_period_schedule_1, mock_store_a, MockData, MockDataInserts,
+        },
+        test_db::setup_all_with_data,
+        EqualFilter, MasterListFilter, MasterListNameJoinRow, MasterListRow, NameTagFilter,
+        NameTagJoinRow, NameTagRow, ProgramRequisitionSettings, ProgramRequisitionSettingsFilter,
+        ProgramRequisitionSettingsRepository, ProgramRequisitionSettingsRow, ProgramRow,
+    };
+
+    #[actix_rt::test]
+    async fn program_requisition_settings_repository() {
+        let name_tag1 = NameTagRow {
+            id: "name_tag1".to_string(),
+            name: "tag1".to_string(),
+            ..Default::default()
+        };
+        let name_tag_join1 = NameTagJoinRow {
+            id: "name_tag_join1".to_string(),
+            name_tag_id: name_tag1.id.clone(),
+            name_id: mock_name_store_a().id,
+            ..Default::default()
+        };
+        let master_list = MasterListRow {
+            id: "master_list1".to_string(),
+            ..Default::default()
+        };
+        let master_list_name_join = MasterListNameJoinRow {
+            id: "master_list_name_join".to_string(),
+            name_id: mock_name_store_a().id,
+            master_list_id: master_list.id.clone(),
+        };
+        let program = ProgramRow {
+            id: "program1".to_string(),
+            master_list_id: master_list.id.clone(),
+            ..Default::default()
+        };
+        let program_requisition_setting = ProgramRequisitionSettingsRow {
+            id: "program_setting1".to_string(),
+            program_id: program.id.clone(),
+            name_tag_id: name_tag1.id.clone(),
+            period_schedule_id: mock_period_schedule_1().id,
+            ..Default::default()
+        };
+        let (_, connection, _, _) = setup_all_with_data(
+            "program_requisition_settings_repository",
+            MockDataInserts::none()
+                .names()
+                .stores()
+                .periods()
+                .period_schedules(),
+            MockData {
+                name_tag_rows: vec![name_tag1],
+                name_tag_join_rows: vec![name_tag_join1],
+                master_lists: vec![master_list.clone()],
+                programs: vec![program.clone()],
+                master_list_name_joins: vec![master_list_name_join],
+                program_requisition_settings: vec![program_requisition_setting.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let repo = ProgramRequisitionSettingsRepository::new(&connection);
+
+        // TEST that program_requisition_settings can be queried by name_tag belonging to a store
+        let result = repo.query(Some(ProgramRequisitionSettingsFilter::new().name_tag(
+            NameTagFilter::new().store_id(EqualFilter::equal_to(&mock_store_a().id)),
+        )));
+
+        assert_eq!(
+            result,
+            Ok(vec![ProgramRequisitionSettings {
+                program_settings_row: program_requisition_setting.clone(),
+                program_row: program.clone(),
+                master_list: master_list.clone()
+            }])
+        );
+        // TEST that program_requisition_settings can be queried by master list linked to a store
+        let result = repo.query(Some(ProgramRequisitionSettingsFilter::new().master_list(
+            MasterListFilter::new().exists_for_store_id(EqualFilter::equal_to(&mock_store_a().id)),
+        )));
+
+        assert_eq!(
+            result,
+            Ok(vec![ProgramRequisitionSettings {
+                program_settings_row: program_requisition_setting.clone(),
+                program_row: program.clone(),
+                master_list: master_list.clone()
+            }])
+        );
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Links to #1508.4

4 of 5 stacked PR's, see latest PR for tests.

# 👩🏻‍💻 What does this PR do? 

Adds program settings repository

* Even though this repository uses master list repository and needs to return master list (for to avoid using loader in graphql), i couldnt' quite start with that repository boxed record and join to it, there is something different to a single boxed table vs joined ¯\_(ツ)_/¯, instead i used what i started with create_filtere_query and select to do inner statement (i really like this pattern)
* NameTag repository is created and use in program settings repository query
* Program Settings Repository, which can be used to search settings by NameTag and MasterList (current store must have both NameTag and MasterList linked to program and program settings to be considered as 'having' that program and settings)

# 🧪 How has/should this change been tested? 

In last PR

## 💌 Any notes for the reviewer?

Changes will be done here and merged to the last PR 
