### PR TITLE
1553 Add mac build for demo action

### DIFF
--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -1,0 +1,52 @@
+on: 
+  workflow_dispatch:
+    inputs:
+      architechture:
+        description: 'Architechture'
+        required: true
+        default: 'intel'
+        type: choice
+        options:
+          - intel
+          - arm
+      includeDemoData:
+        description: 'Includ demo data'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - false
+          - true
+
+name: Build mac demo
+
+jobs:
+  build_and_test:
+    name: Build mac demo
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          prefix-key: ${{ inputs.architechture }}
+      - name: Build
+        run: ./build/mac/build.sh ${{ inputs.architechture }} ${{ inputs.includeDemoData }}
+      # Upload artifact would remove +x (execute) permission and attributes from files when zipping
+      # thus need to manually zip (unfortunately it would be double zipped)
+      - name: Get Name and Zip
+        run: |
+          ARTIFACT_NAME=$(./build/mac/get_name.sh ${{ inputs.architechture }})
+          ZIPPED_ARTIFACT_NAME="${ARTIFACT_NAME}.zip"
+          # https://developer.apple.com/forums/thread/690457 (keep attributes)
+          ditto -c -k --keepParent --sequesterRsrc "${ARTIFACT_NAME}/" $ZIPPED_ARTIFACT_NAME
+          # Below would add it env.artifactName and env.zippedArtifactName, so it can be used in upload-artifact action
+          echo "artifactName=${ARTIFACT_NAME}" >> $GITHUB_ENV
+          echo "zippedArtifactName=${ZIPPED_ARTIFACT_NAME}" >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.artifactName }}
+          path: ${{ env.zippedArtifactName }}

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -1,8 +1,8 @@
 on: 
   workflow_dispatch:
     inputs:
-      architechture:
-        description: 'Architechture'
+      architecture:
+        description: 'Architecture'
         required: true
         default: 'intel'
         type: choice
@@ -32,14 +32,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
-          prefix-key: ${{ inputs.architechture }}
+          prefix-key: ${{ inputs.architecture }}
       - name: Build
-        run: ./build/mac/build.sh ${{ inputs.architechture }} ${{ inputs.includeDemoData }}
+        run: ./build/mac/build.sh ${{ inputs.architecture }} ${{ inputs.includeDemoData }}
       # Upload artifact would remove +x (execute) permission and attributes from files when zipping
       # thus need to manually zip (unfortunately it would be double zipped)
       - name: Get Name and Zip
         run: |
-          ARTIFACT_NAME=$(./build/mac/get_name.sh ${{ inputs.architechture }})
+          ARTIFACT_NAME=$(./build/mac/get_name.sh ${{ inputs.architecture }})
           ZIPPED_ARTIFACT_NAME="${ARTIFACT_NAME}.zip"
           # https://developer.apple.com/forums/thread/690457 (keep attributes)
           ditto -c -k --keepParent --sequesterRsrc "${ARTIFACT_NAME}/" $ZIPPED_ARTIFACT_NAME

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -10,7 +10,7 @@ on:
           - intel
           - arm
       includeDemoData:
-        description: 'Includ demo data'
+        description: 'Include demo data'
         required: true
         default: 'false'
         type: choice

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Build mac demo
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/build/mac/README.md
+++ b/build/mac/README.md
@@ -9,7 +9,7 @@
 ./build/mac/build.sh arm true
 ```
 
-Above will build and `bundle` files in `omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}`
+Above will build and `bundle` files in `omSupply_mac_{ARCHITECTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}`
 
 You can zip the contents of that folder now and share with testers or for demo purposes. (they would need to double click on open_msupply_server.sh, and allow it in their mac security settings)
 
@@ -27,4 +27,4 @@ Add 'true' as last argument (after intel or mac)
 * Log in with all of the users that will need access in the demo data
 * cmd + c out of terminal that was opened when `open_msupply_server.sh` was clicked
 
-Now zipping `omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}` should save the data as well
+Now zipping `omSupply_mac_{ARCHITECTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}` should save the data as well

--- a/build/mac/README.md
+++ b/build/mac/README.md
@@ -3,22 +3,23 @@
 `NOTE` -> this is for demo and testing purposes only, not to be used in production
 
 ```bash
-./build/mac/build.sh
+# for Intel mac
+./build/mac/build.sh intel 
+# or for Arm mac (with demo data)
+./build/mac/build.sh arm true
 ```
 
-Above will build and `bundle` files in `{..}_mac_sqlite` folder where `{..}` is replaced with architecture of the build
+Above will build and `bundle` files in `omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}`
 
-In finder, right click on `{..}_mac_sqlite/open_msupply_server.sh`, then
-* `Open With`
-* `Other`
-* Select `All Appliations` for `Enable` drop down
-* Select `terminal` from `Utilities
-
-You can zip the contents of `{..}_mac_sqlite` folder now and share with testers or for demo purposes.
+You can zip the contents of that folder now and share with testers or for demo purposes. (they would need to double click on open_msupply_server.sh, and allow it in their mac security settings)
 
 To include some data:
 
-## Add data
+## Add demo data
+
+Add 'true' as last argument (after intel or mac)
+
+## Add other data
 
 * Click on open_msupply_server.sh from finder
 * After 3 seconds initialisation screen should open in browser
@@ -26,4 +27,4 @@ To include some data:
 * Log in with all of the users that will need access in the demo data
 * cmd + c out of terminal that was opened when `open_msupply_server.sh` was clicked
 
-You can zip the contents of `{..}_mac_sqlite` folder now and share with testers or for demo purposes.
+Now zipping `omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}` should save the data as well

--- a/build/mac/build.sh
+++ b/build/mac/build.sh
@@ -62,4 +62,4 @@ chmod +x $DESTINATION/open_msupply_server.sh
 # Copy instructions
 cp build/mac/instructions.txt $DESTINATION/
 # Write hash
-echo echo $(git log -1) > $DESTINATION/sha.txt
+echo $(git log -1) > $DESTINATION/sha.txt

--- a/build/mac/build.sh
+++ b/build/mac/build.sh
@@ -1,16 +1,65 @@
 #!/bin/bash
 
-# On M1 mac below would be DESTINATION="arm64_mac_sqlite"
-DESTINATION="$(uname -m)_mac_sqlite"
+# Current directory
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# intel or arm
+ARCHITECHTURE=$1
+SHOULD_INCLUDE_DEMO_DATA=$2
+DESTINATION=$("${DIR}"/get_name.sh $ARCHITECHTURE)
+
+echo "destination: ${DESTINATION}"
+
+# Select target
+if [ "$ARCHITECHTURE" == "intel" ]; then
+    TARGET="x86_64-apple-darwin"
+elif [ "$ARCHITECHTURE" == "arm" ]; then
+    TARGET="aarch64-apple-darwin"
+else
+    echo "Error: first argument must be 'intel' or 'arm'"
+    exit 1
+fi
+
+# Add target
+rustup target add $TARGET
 
 # Buid (on Mac)
-cd client && yarn install && yarn build && cd ../server && cargo clean && cargo build --release --bin remote_server && cd ../
+cd client
+yarn install
+yarn build
+
+cd ../server
+cargo build --release --bin remote_server --bin remote_server_cli --target $TARGET
+cd ../
+
 # Copy binaries to $DESTINATION
-rm -rf $DESTINATION && mkdir $DESTINATION&& mkdir $DESTINATION/bin && mv server/target/release/remote_server $DESTINATION/bin 
+rm -rf $DESTINATION
+mkdir $DESTINATION
+mkdir $DESTINATION/bin
+cp "server/target/${TARGET}/release/remote_server" $DESTINATION/bin 
+cp "server/target/${TARGET}/release/remote_server_cli" $DESTINATION/bin 
+
 # Copy configurations
-mkdir $DESTINATION/configuration && cp -R server/configuration/base.yaml $DESTINATION/configuration/
+mkdir $DESTINATION/configuration
+cp -R server/configuration/base.yaml $DESTINATION/configuration/
 # Local file should be present
 touch $DESTINATION/configuration/local.yaml
 
+# Initialise demo data
+if [ "$SHOULD_INCLUDE_DEMO_DATA" == "true" ]; then
+    cp -R server/data $DESTINATION
+    cd $DESTINATION
+    ./bin/remote_server_cli initialise-from-export -n reference1
+    cd ../
+fi
+
 # Copy launch script
 cp build/mac/open_msupply_server.sh $DESTINATION/
+
+# This would set openWith = terminal for mac (you can manually set openWith = terminal then do 'xattr -px com.apple.LaunchServices.OpenWith open_msupply_server.sh' to see this hash)
+xattr -wx com.apple.LaunchServices.OpenWith 62706C6973743030D30102030405065776657273696F6E54706174685F101062756E646C656964656E74696669657210005F102B2F53797374656D2F4170706C69636174696F6E732F5574696C69746965732F5465726D696E616C2E6170705F1012636F6D2E6170706C652E5465726D696E616C080F171C2F315F0000000000000101000000000000000700000000000000000000000000000074 $DESTINATION/open_msupply_server.sh
+chmod +x $DESTINATION/open_msupply_server.sh
+
+# Copy instructions
+cp build/mac/instructions.txt $DESTINATION/
+# Write hash
+echo echo $(git log -1) > $DESTINATION/sha.txt

--- a/build/mac/build.sh
+++ b/build/mac/build.sh
@@ -3,16 +3,16 @@
 # Current directory
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # intel or arm
-ARCHITECHTURE=$1
+ARCHITECTURE=$1
 SHOULD_INCLUDE_DEMO_DATA=$2
-DESTINATION=$("${DIR}"/get_name.sh $ARCHITECHTURE)
+DESTINATION=$("${DIR}"/get_name.sh $ARCHITECTURE)
 
 echo "destination: ${DESTINATION}"
 
 # Select target
-if [ "$ARCHITECHTURE" == "intel" ]; then
+if [ "$ARCHITECTURE" == "intel" ]; then
     TARGET="x86_64-apple-darwin"
-elif [ "$ARCHITECHTURE" == "arm" ]; then
+elif [ "$ARCHITECTURE" == "arm" ]; then
     TARGET="aarch64-apple-darwin"
 else
     echo "Error: first argument must be 'intel' or 'arm'"
@@ -60,6 +60,7 @@ xattr -wx com.apple.LaunchServices.OpenWith 62706C6973743030D3010203040506577665
 chmod +x $DESTINATION/open_msupply_server.sh
 
 # Copy instructions
+
 cp build/mac/instructions.txt $DESTINATION/
 # Write hash
 echo $(git log -1) > $DESTINATION/sha.txt

--- a/build/mac/get_name.sh
+++ b/build/mac/get_name.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # intel or arm
-ARCHITECHTURE=$1
+ARCHITECTURE=$1
 # Get version from package.json, get line with version on it, then remove everything but version
 # and replace . with _
 VERSION=$(cat package.json | grep 'version":' | sed 's/[^0-9.]//g' | sed 's/[.]/_/g')
 # Commit {DAY}{MONTH}_{HOUR}{SECOND}
 HASH=$(git log -1 --format=%cd --date=format:%d%m_%H%M)
-echo "omSupply_mac_${ARCHITECHTURE}_v${VERSION}_${HASH}"
+echo "omSupply_mac_${ARCHITECTURE}_v${VERSION}_${HASH}"
 

--- a/build/mac/get_name.sh
+++ b/build/mac/get_name.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# intel or arm
+ARCHITECHTURE=$1
+# Get version from package.json, get line with version on it, then remove everything but version
+# and replace . with _
+VERSION=$(cat package.json | grep 'version":' | sed 's/[^0-9.]//g' | sed 's/[.]/_/g')
+# Commit {DAY}{MONTH}_{HOUR}{SECOND}
+HASH=$(git log -1 --format=%cd --date=format:%d%m_%H%M)
+echo "omSupply_mac_${ARCHITECHTURE}_v${VERSION}_${HASH}"
+

--- a/build/mac/instructions.txt
+++ b/build/mac/instructions.txt
@@ -1,0 +1,16 @@
+This is unofficial MacOS sqlite built of omSupply intended for demonstration, testing and other internal purposes.
+
+Double click on open_msupply.sh to run the app, you will need to allow this app to run in System Settings -> Privacy & Security -> Security. Successfull start should launch omSupply in browser window.
+
+The folder name is written in this format: omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}. Even though version is included in the build, intermediary builds can be created, thus the need for differentiation via commit date and time. There is also a file call sha.txt, which can be usefull to developers when reporting a bug (to narrow on on exact version).
+
+Configuration files are located in configurations folder, they can be used to adjust settings, like port, database name etc.. App needs to be restarted after configurations have changed.
+
+Some builds come with bundled data, please contact devs or project managers if you unsure what the user credentials are.
+
+If you want to re-initialise omSupply from mSupply central server after it's already been initialised (either manually or through bundled demo data) you can either remove omsupply-database file, or change database_name in configurations/base.yaml
+
+Common Problems:
+
+'Error: Os { code: 48, kind: AddrInUse, message: "Address already in use" }' -> omSupply is likely already running, close all terminals and try again, or launch in a different port, see configurations above
+

--- a/build/mac/instructions.txt
+++ b/build/mac/instructions.txt
@@ -1,4 +1,4 @@
-This is an unofficial MacOS sqlite built of omSupply intended for demonstration, testing and other internal purposes.
+This is an unofficial MacOS sqlite build of omSupply intended for demonstration, testing and other internal purposes.
 
 Double click on open_msupply.sh to run the app, you will need to allow this app to run in System Settings -> Privacy & Security -> Security. Successful start should launch omSupply in the browser window.
 

--- a/build/mac/instructions.txt
+++ b/build/mac/instructions.txt
@@ -2,7 +2,7 @@ This is unofficial MacOS sqlite built of omSupply intended for demonstration, te
 
 Double click on open_msupply.sh to run the app, you will need to allow this app to run in System Settings -> Privacy & Security -> Security. Successfull start should launch omSupply in browser window.
 
-The folder name is written in this format: omSupply_mac_{ARCHITECHTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}. Even though version is included in the build, intermediary builds can be created, thus the need for differentiation via commit date and time. There is also a file call sha.txt, which can be usefull to developers when reporting a bug (to narrow on on exact version).
+The folder name is written in this format: omSupply_mac_{ARCHITECTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}. Even though version is included in the build, intermediary builds can be created, thus the need for differentiation via commit date and time. There is also a file call sha.txt, which can be usefull to developers when reporting a bug (to narrow on on exact version).
 
 Configuration files are located in configurations folder, they can be used to adjust settings, like port, database name etc.. App needs to be restarted after configurations have changed.
 

--- a/build/mac/instructions.txt
+++ b/build/mac/instructions.txt
@@ -1,12 +1,12 @@
-This is unofficial MacOS sqlite built of omSupply intended for demonstration, testing and other internal purposes.
+This is an unofficial MacOS sqlite built of omSupply intended for demonstration, testing and other internal purposes.
 
-Double click on open_msupply.sh to run the app, you will need to allow this app to run in System Settings -> Privacy & Security -> Security. Successfull start should launch omSupply in browser window.
+Double click on open_msupply.sh to run the app, you will need to allow this app to run in System Settings -> Privacy & Security -> Security. Successful start should launch omSupply in the browser window.
 
-The folder name is written in this format: omSupply_mac_{ARCHITECTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}. Even though version is included in the build, intermediary builds can be created, thus the need for differentiation via commit date and time. There is also a file call sha.txt, which can be usefull to developers when reporting a bug (to narrow on on exact version).
+The folder name is written in this format: omSupply_mac_{ARCHITECTURE}_{VERSION}_{COMMIT_DAY_MONTH}_{COMMIT_HOUR_AND_SECOND}. Even though version is included in the build, intermediary builds can be created, thus the need for differentiation via commit date and time. There is also a file call sha.txt, which can be useful to developers when reporting a bug (to narrow down on exact version).
 
-Configuration files are located in configurations folder, they can be used to adjust settings, like port, database name etc.. App needs to be restarted after configurations have changed.
+Configuration files are located in the configuration folder, they can be used to adjust settings, like port, database name etc.. App needs to be restarted after configurations have changed.
 
-Some builds come with bundled data, please contact devs or project managers if you unsure what the user credentials are.
+Some builds come with bundled data, please contact devs or project managers if you are unsure what the user credentials are.
 
 If you want to re-initialise omSupply from mSupply central server after it's already been initialised (either manually or through bundled demo data) you can either remove omsupply-database file, or change database_name in configurations/base.yaml
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1553

PRd to main, will need to be merged to main and then to develop and be in any branch that is being built with this method

I've been playing around with this here: https://github.com/andreievg/open-msupply-actions-test/actions, it's made to run manually, branch can be selected (also can select `intel` or `arm` architecture, and if demo data file should be included or not) 

# 👩🏻‍💻 What does this PR do? 

* Added action and modified build script, see self review comments

# 🧪 How has/should this change been tested? 

Can create your own fork, with these changes and try running action (it takes quite awhile). You should see artefact, can download it, double click on `open_msupply_server.sh` and allow to run in security settings, and server should launch and open a browser (it would run on default port, so may open browser but the server may fail to start)

## 💌 Any notes for the reviewer?


## 📃 Documentation
 
I think README.md and instructions.txt may be enough ?

## Carry Over

Same thing for windows ? 
When address is in use, don't open browser ?
Cache properly ! 