### PR TITLE
1612 encounter store

### DIFF
--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -37,11 +37,12 @@ interface Encounter {
   startDatetime?: string;
   endDatetime?: string;
   clinician?: Clinician;
+  location?: { storeId?: string };
 }
 
 export const CreateEncounterModal: FC = () => {
   const patientId = usePatient.utils.id();
-  const { user } = useAuthContext();
+  const { user, storeId } = useAuthContext();
   const t = useTranslation('patients');
   const { getLocalisedFullName } = useIntlUtils();
   const { current, setModal: selectModal } = usePatientModalStore();
@@ -78,27 +79,36 @@ export const CreateEncounterModal: FC = () => {
     setEncounterRegistry(entry);
   };
 
+  const currentOrNewDraft = (): Encounter => {
+    return (
+      draft ?? {
+        createdDatetime,
+        createdBy: { id: user?.id ?? '', username: user?.name ?? '' },
+        status: EncounterNodeStatus.Pending,
+        location: {
+          storeId,
+        },
+      }
+    );
+  };
   const setStartDatetime = (date: Date | null): void => {
     const startDatetime = DateUtils.formatRFC3339(
       DateUtils.addCurrentTime(date)
     );
     setDraft({
-      createdDatetime,
-      ...draft,
+      ...currentOrNewDraft(),
       startDatetime,
-      createdBy: { id: user?.id ?? '', username: user?.name ?? '' },
-      status: EncounterNodeStatus.Pending,
     });
     setStartDateTimeError(false);
   };
 
   const setClinician = (option: ClinicianAutocompleteOption | null): void => {
     if (option === null) {
-      setDraft({ createdDatetime, ...draft, clinician: undefined });
+      setDraft({ ...currentOrNewDraft(), clinician: undefined });
       return;
     }
     const clinician = option.value;
-    setDraft({ createdDatetime, ...draft, clinician });
+    setDraft({ ...currentOrNewDraft(), clinician });
   };
 
   const canSubmit = () =>

--- a/server/repository/migrations/postgres/2022-06-07T17-00_create_encounter_table/up.sql
+++ b/server/repository/migrations/postgres/2022-06-07T17-00_create_encounter_table/up.sql
@@ -14,5 +14,7 @@ CREATE TABLE encounter (
     start_datetime TIMESTAMP NOT NULL,
     end_datetime TIMESTAMP,
     status encounter_status,
-    clinician_id TEXT REFERENCES clinician(id)
+    clinician_id TEXT REFERENCES clinician(id),
+    -- The encounter's location (if the location is a store)
+    store_id TEXT
 )

--- a/server/repository/migrations/sqlite/2022-06-07T17-00_create_encounter_table/up.sql
+++ b/server/repository/migrations/sqlite/2022-06-07T17-00_create_encounter_table/up.sql
@@ -8,5 +8,6 @@ CREATE TABLE encounter (
     start_datetime TIMESTAMP NOT NULL,
     end_datetime TIMESTAMP,
     status TEXT,
-    clinician_id TEXT REFERENCES clinician(id)
+    clinician_id TEXT REFERENCES clinician(id),
+    store_id TEXT
 )

--- a/server/repository/src/db_diesel/encounter_row.rs
+++ b/server/repository/src/db_diesel/encounter_row.rs
@@ -29,6 +29,7 @@ table! {
         end_datetime -> Nullable<Timestamp>,
         status -> Nullable<crate::db_diesel::encounter_row::EncounterStatusMapping>,
         clinician_id -> Nullable<Text>,
+        store_id -> Nullable<Text>,
     }
 }
 
@@ -49,6 +50,8 @@ pub struct EncounterRow {
     pub end_datetime: Option<NaiveDateTime>,
     pub status: Option<EncounterStatus>,
     pub clinician_id: Option<String>,
+    ///  The encounter's location (if the location is a store)
+    pub store_id: Option<String>,
 }
 
 pub struct EncounterRowRepository<'a> {

--- a/server/service/src/programs/encounter/encounter_schema.rs
+++ b/server/service/src/programs/encounter/encounter_schema.rs
@@ -18,6 +18,7 @@ impl Default for SchemaEncounter {
             clinician: Default::default(),
             notes: Default::default(),
             created_by: Default::default(),
+            location: Default::default(),
         }
     }
 }

--- a/server/service/src/programs/encounter/encounter_updated.rs
+++ b/server/service/src/programs/encounter/encounter_updated.rs
@@ -44,6 +44,10 @@ pub(crate) fn update_encounter_row(
         end_datetime: validated_encounter.end_datetime,
         status,
         clinician_id,
+        store_id: validated_encounter
+            .encounter
+            .location
+            .and_then(|l| l.store_id),
     };
     EncounterRowRepository::new(con).upsert_one(&row)?;
 

--- a/server/service/src/programs/schemas/encounter.json
+++ b/server/service/src/programs/schemas/encounter.json
@@ -34,6 +34,10 @@
           "format": "date-time",
           "type": "string"
         },
+        "location": {
+          "$ref": "#/definitions/EncounterLocation",
+          "description": "The store/clinic/location of the encounter"
+        },
         "notes": {
           "description": "An overall note for additional comments about the encounter",
           "items": {
@@ -51,6 +55,14 @@
         }
       },
       "required": ["createdDatetime", "startDatetime"],
+      "type": "object"
+    },
+    "EncounterLocation": {
+      "properties": {
+        "storeId": {
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "EncounterStatus": {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1612

Set an encounter location (the store id) when creating an encounter. This information is needed, e.g. for the central encounters report where encounters from multiple stores are reported.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- [ ] Create an encounter and check in the history that the location has been set in the data