### PR TITLE
1622 Warning shown twice in Response Requisition

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -117,7 +117,6 @@ export const Toolbar: FC = () => {
                   Input={<Typography>{period?.name ?? ''}</Typography>}
                 />
               )}
-              {showInfo && <InfoPanel message={t('info.no-shipment')} />}
             </Box>
           </Box>
           {showInfo && (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1622

# 👩🏻‍💻 What does this PR do? 
Removes duplicate info panel in response requisition.

# 🧪 How has/should this change been tested? 
Go to a response requisition and you should only see one info panel. 

## 💌 Any notes for the reviewer?
Wasn't sure which one we wanted to remove, so I just kept the latest one..

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2