### PR TITLE
Fix unhandled switch case

### DIFF
--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -84,6 +84,7 @@ const extractAt = (
 
   if (options?.at?.type === 'encounter') {
     switch (options.at.encounterStartDatetime) {
+      case undefined: // fallthrough to the default 'before' value
       case 'before':
         const before = new Date(
           new Date(encounter?.startDatetime ?? date).getTime() - 1
@@ -92,10 +93,11 @@ const extractAt = (
       case 'after':
         return new Date(encounter?.startDatetime ?? date);
       default:
-        ((_: never) => {})(options.at.encounterStartDatetime as never);
+        ((_: never) => {})(options.at.encounterStartDatetime);
     }
   } else if (options?.at?.type === 'programEnrolment') {
     switch (options.at.programEnrolmentDatetime) {
+      case undefined: // fallthrough to the default 'before' value
       case 'before':
         const before = new Date(
           new Date(program?.enrolmentDatetime ?? date).getTime() - 1
@@ -104,7 +106,7 @@ const extractAt = (
       case 'after':
         return new Date(program?.enrolmentDatetime ?? date);
       default:
-        ((_: never) => {})(options.at.programEnrolmentDatetime as never);
+        ((_: never) => {})(options.at.programEnrolmentDatetime);
     }
   }
 

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -4,6 +4,7 @@ import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
   DetailInputWithLabelRow,
   NumericTextInput,
+  noOtherVariants,
 } from '@openmsupply-client/common';
 import {
   DefaultFormRowSx,
@@ -93,7 +94,7 @@ const extractAt = (
       case 'after':
         return new Date(encounter?.startDatetime ?? date);
       default:
-        ((_: never) => {})(options.at.encounterStartDatetime);
+        noOtherVariants(options.at.encounterStartDatetime);
     }
   } else if (options?.at?.type === 'programEnrolment') {
     switch (options.at.programEnrolmentDatetime) {
@@ -106,7 +107,7 @@ const extractAt = (
       case 'after':
         return new Date(program?.enrolmentDatetime ?? date);
       default:
-        ((_: never) => {})(options.at.programEnrolmentDatetime);
+        noOtherVariants(options.at.programEnrolmentDatetime);
     }
   }
 

--- a/client/packages/system/src/Encounter/utils.ts
+++ b/client/packages/system/src/Encounter/utils.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
 import { EncounterNodeStatus } from '@common/types';
 import { EncounterRowFragment } from '@openmsupply-client/programs';
+import { noOtherVariants } from '@openmsupply-client/common';
 
 export const encounterStatusTranslation = (
   status: EncounterNodeStatus,
@@ -15,7 +16,7 @@ export const encounterStatusTranslation = (
     case EncounterNodeStatus.Visited:
       return t('label.encounter-status-visited');
     default:
-      return ((_: never) => '')(status);
+      return noOtherVariants(status);
   }
 };
 

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -4,6 +4,7 @@ import {
   DataTable,
   GenderInput,
   Typography,
+  noOtherVariants,
   useColumns,
   useFormatDateTime,
   useNavigate,
@@ -15,9 +16,6 @@ import { Gender, usePatientCreateStore } from '@openmsupply-client/programs';
 import { PatientFragment } from '../api/operations.generated';
 
 const genderToGenderInput = (gender: Gender): GenderInput => {
-  const exhaustiveCheck = (_: never): GenderInput => {
-    return GenderInput.Male; // never returned
-  };
   switch (gender) {
     case Gender.MALE:
       return GenderInput.Male;
@@ -32,7 +30,7 @@ const genderToGenderInput = (gender: Gender): GenderInput => {
     case Gender.NON_BINARY:
       return GenderInput.NonBinary;
     default:
-      return exhaustiveCheck(gender);
+      return noOtherVariants(gender);
   }
 };
 


### PR DESCRIPTION
The exhaustive check at the end of the switch statement was effectively disabled by the type cast `as never`. Removing this revealed a bug, i.e. the default case was not handled. When TypeScript complains it's usually right; don't silence it :)