### PR TITLE
1664 Remove pagination from stock line loader

### DIFF
--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -84,7 +84,7 @@ impl<'a> StockLineRepository<'a> {
         filter: StockLineFilter,
         store_id: Option<String>,
     ) -> Result<Vec<StockLine>, RepositoryError> {
-        self.query(Pagination::new(), Some(filter), None, store_id)
+        self.query(Pagination::all(), Some(filter), None, store_id)
     }
 
     pub fn query(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1664 

# 👩🏻‍💻 What does this PR do? 

Remove pagination from stock line loader (since stocktake line was getting stock line info)

# 🧪 How has/should this change been tested? 

If you change this limit to 3

https://github.com/openmsupply/open-msupply/blob/a88030a2e156a5b149958edb2be07d3f48338bb7/server/repository/src/db_diesel/filter_sort_pagination.rs#L211

Create stocktake with more then 3 stock lines, without this change stocktake will freeze

## 💌 Any notes for the reviewer?


## 📃 Documentation


TODO: Create an issue to check all other loaders for this (and remove pagination from service): https://github.com/openmsupply/open-msupply/issues/1687