### PR TITLE
27(internal) Add itemName when pushing requisition line

### DIFF
--- a/server/service/src/sync/test/test_data/requisition_line.rs
+++ b/server/service/src/sync/test/test_data/requisition_line.rs
@@ -83,6 +83,7 @@ fn requisition_line_request_push_record() -> TestSyncPushRecord {
             snapshot_datetime: None,
             approved_quantity: 0,
             approval_comment: None,
+            item_name: "Item A".to_string()
         }),
     }
 }
@@ -165,6 +166,7 @@ fn requisition_line_om_fields_push_record() -> TestSyncPushRecord {
             approved_quantity: 0,
             approval_comment: Some("approval comment".to_string()),
             comment: Some("Some comment".to_string()),
+            item_name: "Item A".to_string(),
             snapshot_datetime: Some(
                 NaiveDate::from_ymd_opt(2022, 04, 04)
                     .unwrap()

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -4,8 +4,8 @@ use crate::sync::{
 };
 use chrono::NaiveDateTime;
 use repository::{
-    ChangelogRow, ChangelogTableName, RequisitionLineRow, RequisitionLineRowRepository,
-    StorageConnection, SyncBufferRow,
+    ChangelogRow, ChangelogTableName, ItemRowRepository, RequisitionLineRow,
+    RequisitionLineRowRepository, StorageConnection, SyncBufferRow,
 };
 use serde::{Deserialize, Serialize};
 use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
@@ -52,6 +52,9 @@ pub struct LegacyRequisitionLineRow {
     #[serde(rename = "om_snapshot_datetime")]
     #[serde(deserialize_with = "empty_str_as_option")]
     pub snapshot_datetime: Option<NaiveDateTime>,
+
+    #[serde(rename = "itemName")]
+    pub item_name: String,
 }
 
 pub(crate) struct RequisitionLineTranslation {}
@@ -135,6 +138,14 @@ impl SyncTranslation for RequisitionLineTranslation {
                 changelog.record_id
             )))?;
 
+        // Required for backward compatibility (authorisation web app uses this to display item name)
+        let item_name = ItemRowRepository::new(connection)
+            .find_one_by_id(&item_id)?
+            .ok_or(anyhow::anyhow!(
+                "Item ({item_id}) not found in requisition line ({id})"
+            ))?
+            .name;
+
         let legacy_row = LegacyRequisitionLineRow {
             ID: id.clone(),
             requisition_ID: requisition_id,
@@ -148,6 +159,7 @@ impl SyncTranslation for RequisitionLineTranslation {
             snapshot_datetime,
             approved_quantity,
             approval_comment,
+            item_name,
         };
 
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes https://github.com/openmsupply/open-msupply-internal/issues/27

# 👩🏻‍💻 What does this PR do? 

item name is added when pushing requisition line to central

# 🧪 How has/should this change been tested? 

Setup remote authorisation, see item name for requisition line in remote authorisation web app shows correctly.

You can use this data file (or instructions), https://drive.google.com/drive/u/1/folders/1-5JlYyYA5jArUl6LbSAvH3qsWE--nO2I, probably easier to change program supplier store to test site, initialise test site, create program requisition from test store to program supplier store

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
