### PR TITLE
1653 Sort and paginate periods for program internal order

### DIFF
--- a/server/service/src/requisition/program_settings/map.rs
+++ b/server/service/src/requisition/program_settings/map.rs
@@ -5,6 +5,7 @@ use util::date_now;
 
 use super::{prepare::PrepareProgramSettings, OrderType, ProgramSettings};
 
+// History = historic and current
 const MAX_NUMBER_OF_HISTORIC_PERIODS: usize = 3;
 const MAX_NUMBER_OF_FUTURE_PERIODS: usize = 3;
 
@@ -105,6 +106,7 @@ fn period_is_available(
 /// and sort in ascending order
 fn reduce_and_sort_periods(periods: Vec<PeriodRow>) -> Vec<PeriodRow> {
     let now = date_now();
+    // History = historic and current, thus p.start_date < now
     let (mut historic, mut future): (Vec<PeriodRow>, Vec<PeriodRow>) =
         periods.into_iter().partition(|p| p.start_date < now);
     // Sort them

--- a/server/service/src/requisition/program_settings/map.rs
+++ b/server/service/src/requisition/program_settings/map.rs
@@ -1,8 +1,12 @@
 use repository::{
     PeriodRow, ProgramRequisitionOrderTypeRow, ProgramRequisitionSettings, RequisitionsInPeriod,
 };
+use util::date_now;
 
 use super::{prepare::PrepareProgramSettings, OrderType, ProgramSettings};
+
+const MAX_NUMBER_OF_HISTORIC_PERIODS: usize = 3;
+const MAX_NUMBER_OF_FUTURE_PERIODS: usize = 3;
 
 /// Map prepared program_settings, order_types, periods and requisitions_in_periods to ProgramSettings
 /// order types are mapped to program settings by program setting id
@@ -43,7 +47,7 @@ pub(super) fn map(
 
                     // Order type for program settings
                     OrderType {
-                        available_periods,
+                        available_periods: reduce_and_sort_periods(available_periods),
                         order_type: order_type.clone(),
                     }
                 })
@@ -95,4 +99,53 @@ fn period_is_available(
         this_period_requisitions.map(|r| r.count).unwrap_or(0);
 
     number_of_requisitions_in_this_period < order_type.max_order_per_period as i64
+}
+
+/// Reduce periods by MAX_NUMBER_OF_HISTORIC_PERIODS and MAX_NUMBER_OF_FUTURE_PERIODS
+/// and sort in ascending order
+fn reduce_and_sort_periods(periods: Vec<PeriodRow>) -> Vec<PeriodRow> {
+    let now = date_now();
+    let (mut historic, mut future): (Vec<PeriodRow>, Vec<PeriodRow>) =
+        periods.into_iter().partition(|p| p.start_date < now);
+    // Sort them
+
+    future.sort_by(|a, b| a.start_date.cmp(&b.start_date));
+    historic.sort_by(|a, b| a.start_date.cmp(&b.start_date));
+
+    // Take first MAX_NUMBER_OF_FUTURE_PERIODS (sorted in ASC order)
+
+    let future_iter = future.into_iter().take(MAX_NUMBER_OF_FUTURE_PERIODS);
+
+    // Take last MAX_NUMBER_OF_HISTORIC_PERIODS (sorted in ASC order)
+    // there is not 'take' method for last X elements
+    historic
+        .into_iter()
+        // Reverse once to get last X
+        .rev()
+        .take(MAX_NUMBER_OF_HISTORIC_PERIODS)
+        // Reverse second time to retain order
+        .rev()
+        // Add future periods
+        .chain(future_iter)
+        .collect()
+}
+
+#[test]
+fn test_reduce_and_sort_periods() {
+    fn make_date(offset: &i32) -> PeriodRow {
+        PeriodRow {
+            id: offset.to_string(),
+            start_date: util::date_now_with_offset(chrono::Duration::days(*offset as i64)),
+            ..PeriodRow::default()
+        }
+    }
+
+    let periods: Vec<PeriodRow> = [3, -10, -2, -5, 10, 11, 2, 4, -4, -10, 20, 21]
+        .iter()
+        .map(make_date)
+        .collect();
+
+    let result: Vec<PeriodRow> = [-5, -4, -2, 2, 3, 4].iter().map(make_date).collect();
+
+    assert_eq!(reduce_and_sort_periods(periods), result)
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1653

# 👩🏻‍💻 What does this PR do? 

Periods are paginated and sorted in program settings API

# 🧪 How has/should this change been tested? 

Configure program requisitions, create lots of periods before and after current date, should only see 3 available periods before now and 3 available periods after now.

Can use this data file: https://drive.google.com/drive/u/1/folders/1-5JlYyYA5jArUl6LbSAvH3qsWE--nO2I

You can adjust existing periods down and create new periods, try test site test store and emergency or normal order (see how it affects the periods shown, should only see max 6 periods (and they should be `centered` around current date and sorted in ASC order)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
