### PR TITLE
1655 Program requisition creation to restrict supplier on hold

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
@@ -53,7 +53,7 @@ const useProgramRequisitionOptions = (
     setPeriod(null);
   }, [orderType]);
 
-  let allOptions: {
+  const allOptions: {
     programs: Common<ProgramSetting>;
     orderTypes: Common<OrderType>;
     suppliers: Common<Supplier>;

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
@@ -119,11 +119,7 @@ const LabelAndOptions = <T,>({
   renderOption,
   getOptionDisabled,
 }: Pick<AutocompleteProps<T>, 'optionKey' | 'autoFocus'> &
-  Common<T> & {
-    label: string;
-    set: (value: T | null) => void;
-    labelNoOptions?: string;
-  }) => {
+  Common<T>) => {
   const noOptionsDisplay = options.length == 0 &&
     !disabled &&
     !!labelNoOptions && <Typography>{labelNoOptions}</Typography>;

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ProgramRequisitionOptions.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   useTranslation,
 } from '@openmsupply-client/common';
+import { getNameOptionRenderer } from '@openmsupply-client/system';
 
 import { ProgramSettingsFragment } from '../api';
 import { NewRequisitionType } from './types';
@@ -18,6 +19,15 @@ export interface NewProgramRequisition {
   otherPartyId: string;
   periodId: string;
 }
+
+type Common<T> = Pick<
+  AutocompleteProps<T>,
+  'options' | 'value' | 'disabled' | 'renderOption' | 'getOptionDisabled'
+> & {
+  label: string;
+  set: (value: T | null) => void;
+  labelNoOptions?: string;
+};
 
 const useProgramRequisitionOptions = (
   programSettings: ProgramSettingsFragment[]
@@ -43,7 +53,12 @@ const useProgramRequisitionOptions = (
     setPeriod(null);
   }, [orderType]);
 
-  return {
+  let allOptions: {
+    programs: Common<ProgramSetting>;
+    orderTypes: Common<OrderType>;
+    suppliers: Common<Supplier>;
+    periods: Common<Period>;
+  } = {
     programs: {
       options: programSettings,
       value: program,
@@ -65,8 +80,9 @@ const useProgramRequisitionOptions = (
       set: setSupplier,
       disabled: program === null,
       labelNoOptions: t('messages.not-configured'),
-      // TODO supplier on hold ?
       label: t('label.supplier-name'),
+      renderOption: getNameOptionRenderer(t('label.on-hold')),
+      getOptionDisabled: (supplier: Supplier) => supplier.isOnHold,
     },
     periods: {
       options: orderType?.availablePeriods || [],
@@ -76,6 +92,10 @@ const useProgramRequisitionOptions = (
       labelNoOptions: t('messages.period-not-available'),
       label: t('label.period'),
     },
+  };
+
+  return {
+    ...allOptions,
     createOptions:
       !!program && !!orderType && !!supplier && !!period
         ? {
@@ -96,14 +116,14 @@ const LabelAndOptions = <T,>({
   value,
   autoFocus,
   optionKey,
-}: Pick<
-  AutocompleteProps<T>,
-  'options' | 'value' | 'optionKey' | 'autoFocus' | 'disabled'
-> & {
-  label: string;
-  set: (value: T | null) => void;
-  labelNoOptions?: string;
-}) => {
+  renderOption,
+  getOptionDisabled,
+}: Pick<AutocompleteProps<T>, 'optionKey' | 'autoFocus'> &
+  Common<T> & {
+    label: string;
+    set: (value: T | null) => void;
+    labelNoOptions?: string;
+  }) => {
   const noOptionsDisplay = options.length == 0 &&
     !disabled &&
     !!labelNoOptions && <Typography>{labelNoOptions}</Typography>;
@@ -117,6 +137,8 @@ const LabelAndOptions = <T,>({
         {noOptionsDisplay || (
           <Autocomplete
             width="300"
+            renderOption={renderOption}
+            getOptionDisabled={getOptionDisabled}
             autoFocus={autoFocus}
             options={options}
             optionKey={optionKey}

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '@openmsupply-client/common';
 import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
+import { NameRowFragmentDoc } from '../../../../system/src/Name/api/operations.generated';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
 export type ItemWithStatsFragment = { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand?: number | null } };
 
@@ -111,14 +112,14 @@ export type DeleteRequestMutationVariables = Types.Exact<{
 
 export type DeleteRequestMutation = { __typename: 'Mutations', batchRequestRequisition: { __typename: 'BatchRequestRequisitionResponse', deleteRequestRequisitions?: Array<{ __typename: 'DeleteRequestRequisitionResponseWithId', id: string, response: { __typename: 'DeleteRequestRequisitionError', error: { __typename: 'CannotDeleteRequisitionWithLines', description: string } | { __typename: 'CannotEditRequisition', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'DeleteResponse', id: string } }> | null } };
 
-export type ProgramSettingsFragment = { __typename: 'ProgramRequisitionSettingNode', programName: string, programId: string, suppliers: Array<{ __typename: 'NameNode', id: string, name: string }>, orderTypes: Array<{ __typename: 'ProgramRequisitionOrderTypeNode', id: string, name: string, availablePeriods: Array<{ __typename: 'PeriodNode', id: string, name: string }> }> };
+export type ProgramSettingsFragment = { __typename: 'ProgramRequisitionSettingNode', programName: string, programId: string, suppliers: Array<{ __typename: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, isOnHold: boolean, name: string, store?: { __typename: 'StoreNode', id: string, code: string } | null }>, orderTypes: Array<{ __typename: 'ProgramRequisitionOrderTypeNode', id: string, name: string, availablePeriods: Array<{ __typename: 'PeriodNode', id: string, name: string }> }> };
 
 export type ProgramSettingsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
 }>;
 
 
-export type ProgramSettingsQuery = { __typename: 'Queries', programRequisitionSettings: Array<{ __typename: 'ProgramRequisitionSettingNode', programName: string, programId: string, suppliers: Array<{ __typename: 'NameNode', id: string, name: string }>, orderTypes: Array<{ __typename: 'ProgramRequisitionOrderTypeNode', id: string, name: string, availablePeriods: Array<{ __typename: 'PeriodNode', id: string, name: string }> }> }> };
+export type ProgramSettingsQuery = { __typename: 'Queries', programRequisitionSettings: Array<{ __typename: 'ProgramRequisitionSettingNode', programName: string, programId: string, suppliers: Array<{ __typename: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, isOnHold: boolean, name: string, store?: { __typename: 'StoreNode', id: string, code: string } | null }>, orderTypes: Array<{ __typename: 'ProgramRequisitionOrderTypeNode', id: string, name: string, availablePeriods: Array<{ __typename: 'PeriodNode', id: string, name: string }> }> }> };
 
 export const RequestRowFragmentDoc = gql`
     fragment RequestRow on RequisitionNode {
@@ -256,8 +257,7 @@ export const ProgramSettingsFragmentDoc = gql`
   programName
   programId
   suppliers {
-    id
-    name
+    ...NameRow
   }
   orderTypes {
     id
@@ -268,7 +268,7 @@ export const ProgramSettingsFragmentDoc = gql`
     }
   }
 }
-    `;
+    ${NameRowFragmentDoc}`;
 export const RequestByNumberDocument = gql`
     query requestByNumber($storeId: String!, $requisitionNumber: Int!) {
   requisitionByNumber(

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.graphql
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.graphql
@@ -487,8 +487,7 @@ fragment ProgramSettings on ProgramRequisitionSettingNode {
   programName
   programId
   suppliers {
-    id
-    name
+    ...NameRow
   }
   orderTypes {
     id

--- a/client/packages/system/src/Name/Components/index.ts
+++ b/client/packages/system/src/Name/Components/index.ts
@@ -4,3 +4,4 @@ export * from './CustomerSearchInput';
 export * from './CustomerSearchModal';
 export * from './InternalSupplierSearchInput';
 export * from './InternalSupplierSearchModal';
+export { getNameOptionRenderer } from './NameOptionRenderer';

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -263,6 +263,7 @@ impl NameFilter {
         self.is_customer = Some(value);
         self
     }
+    
 
     pub fn r#type(mut self, filter: EqualFilter<NameType>) -> Self {
         self.r#type = Some(filter);

--- a/server/repository/src/db_diesel/program_requisition/program_supplier.rs
+++ b/server/repository/src/db_diesel/program_requisition/program_supplier.rs
@@ -44,7 +44,10 @@ impl<'a> ProgramSupplierRepository<'a> {
     ) -> Result<Vec<ProgramSupplier>, RepositoryError> {
         // If this filter is lifter to service layer, we may have an issue this after `query.select` below, name_store_join_row and store_row
         // becomes not null, but can be if this fitler is not exposed, causing diesel deserialisation error TODO add issue with diesel
-        let name_filter = NameFilter::new().is_store(true).is_visible(true);
+        let name_filter = NameFilter::new()
+            .is_store(true)
+            .is_visible(true)
+            .match_is_supplier(true);
 
         let mut query =
             NameRepository::create_filtered_query(store_id.to_string(), Some(name_filter))
@@ -192,12 +195,14 @@ mod test {
             id: "name_store_join1".to_string(),
             name_id: name1.id.clone(),
             store_id: store3.id.clone(),
+            name_is_supplier: true,
             ..Default::default()
         };
         let name_store_join2 = NameStoreJoinRow {
             id: "name_store_join2".to_string(),
             name_id: store_name1.id.clone(),
             store_id: store3.id.clone(),
+            name_is_supplier: true,
             ..Default::default()
         };
 
@@ -205,6 +210,7 @@ mod test {
             id: "name_store_join3".to_string(),
             name_id: store_name2.id.clone(),
             store_id: store3.id.clone(),
+            name_is_supplier: true,
             ..Default::default()
         };
 

--- a/server/service/src/requisition/program_settings/mod.rs
+++ b/server/service/src/requisition/program_settings/mod.rs
@@ -213,12 +213,14 @@ mod test {
             id: "name_store_join1".to_string(),
             name_id: mock_name_store_b().id.clone(),
             store_id: mock_store_a().id,
+            name_is_supplier: true,
             ..Default::default()
         };
         let name_store_join2 = NameStoreJoinRow {
             id: "name_store_join2".to_string(),
             name_id: mock_name_store_c().id.clone(),
             store_id: mock_store_a().id,
+            name_is_supplier: true,
             ..Default::default()
         };
         let ServiceTestContext {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1655 

# 👩🏻‍💻 What does this PR do? 

When creating program requisition, supplier input is the same style as when creating general input and stores/names are enforced.

Also make sure we are filtering suppliers (for program requisitions) that are is_supplier.

# 🧪 How has/should this change been tested? 

Setup program requisitions, make sure more then one supplier is configured for a program and as suppliers for a store, toggled `hold` on one, see it being disabled in input when creating program internal order.

Can use data file here: https://drive.google.com/drive/u/1/folders/1-5JlYyYA5jArUl6LbSAvH3qsWE--nO2I, would need to sync test site and make test2 is supplier. Check when creating test store program requisition with supplier on hold.

## 💌 Any notes for the reviewer?


## 📃 Documentation
