### PR TITLE
Calculate the integration order from table dependencies

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4089,6 +4089,7 @@ dependencies = [
  "tera",
  "thiserror",
  "tokio",
+ "topological-sort",
  "url",
  "util",
 ]
@@ -4573,6 +4574,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde 1.0.137",
 ]
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower-service"

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -15,6 +15,7 @@ anymap = "0.12"
 anyhow = "1.0.56"
 async-trait = "0.1.57"
 thiserror = "1"
+topological-sort = "0.2.2"
 bcrypt = "0.12.0"
 chrono = { workspace = true }
 jsonwebtoken = "8.0.1"

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -1,4 +1,4 @@
-use super::translations::LegacyTableName;
+
 use chrono::Utc;
 use repository::{
     DatetimeFilter, EqualFilter, RepositoryError, StorageConnection, SyncBufferAction,
@@ -6,36 +6,7 @@ use repository::{
 };
 use util::inline_edit;
 
-// Ordered by referential constraints
-const TRANSLATION_AND_INTEGRATION_ORDER: &[&str] = &[
-    LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
-    LegacyTableName::NAME,
-    LegacyTableName::NAME_TAG,
-    LegacyTableName::NAME_TAG_JOIN,
-    LegacyTableName::UNIT,
-    LegacyTableName::ITEM,
-    LegacyTableName::STORE,
-    LegacyTableName::STORE_PREFERENCE,
-    LegacyTableName::PERIOD_SCHEDULE,
-    LegacyTableName::PERIOD,
-    LegacyTableName::LIST_MASTER,
-    LegacyTableName::LIST_MASTER_LINE,
-    LegacyTableName::LIST_MASTER_NAME_JOIN,
-    LegacyTableName::REPORT,
-    LegacyTableName::LOCATION,
     LegacyTableName::BARCODE,
-    LegacyTableName::ITEM_LINE,
-    LegacyTableName::LOCATION_MOVEMENT,
-    LegacyTableName::TRANSACT,
-    LegacyTableName::TRANS_LINE,
-    LegacyTableName::STOCKTAKE,
-    LegacyTableName::STOCKTAKE_LINE,
-    LegacyTableName::REQUISITION,
-    LegacyTableName::REQUISITION_LINE,
-    LegacyTableName::NAME_STORE_JOIN,
-    LegacyTableName::OM_ACTIVITY_LOG,
-];
-
 pub(crate) struct SyncBuffer<'a> {
     query_repository: SyncBufferRepository<'a>,
     row_repository: SyncBufferRowRepository<'a>,
@@ -75,10 +46,11 @@ impl<'a> SyncBuffer<'a> {
     pub(crate) fn get_ordered_sync_buffer_records(
         &self,
         action: SyncBufferAction,
+        ordered_table_names: &[&str],
     ) -> Result<Vec<SyncBufferRow>, RepositoryError> {
+        let ordered_table_names = ordered_table_names.into_iter().map(|r| *r);
         // Get ordered table names, for  upsert we sort in referential constraint order
         // and for delete in reverse of referential constraint order
-        let ordered_table_names = TRANSLATION_AND_INTEGRATION_ORDER.iter().map(|r| *r);
         let order: Vec<&str> = match action {
             SyncBufferAction::Upsert => ordered_table_names.collect(),
             SyncBufferAction::Delete => ordered_table_names.rev().collect(),
@@ -110,7 +82,7 @@ mod test {
     };
     use util::{inline_init, Defaults};
 
-    use crate::sync::translations::LegacyTableName;
+    use crate::sync::translations::{all_translators, pull_integration_order, LegacyTableName};
 
     use super::SyncBuffer;
 
@@ -166,6 +138,9 @@ mod test {
 
     #[actix_rt::test]
     async fn test_sync_buffer_service() {
+        let translations = all_translators();
+        let table_order = pull_integration_order(&translations);
+
         let (_, connection, _, _) = setup_all_with_data(
             "test_sync_buffer_service",
             MockDataInserts::none(),
@@ -179,7 +154,7 @@ mod test {
 
         // ORDER/ACTION
         let in_referencial_order = buffer
-            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert)
+            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert, &table_order)
             .unwrap();
 
         assert_eq!(
@@ -188,7 +163,7 @@ mod test {
         );
 
         let in_reverese_referencial_order = buffer
-            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Delete)
+            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Delete, &table_order)
             .unwrap();
 
         assert_eq!(in_reverese_referencial_order, vec![row_6(), row_5()]);
@@ -202,7 +177,7 @@ mod test {
             .unwrap();
 
         let result = buffer
-            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert)
+            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert, &table_order)
             .unwrap();
 
         assert_eq!(result, vec![row_4(), row_3()]);
@@ -218,7 +193,7 @@ mod test {
         buffer.record_successful_integration(&row_3()).unwrap();
 
         let result = buffer
-            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert)
+            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert, &table_order)
             .unwrap();
 
         assert_eq!(result, vec![row_4()]);
@@ -226,7 +201,7 @@ mod test {
         buffer.record_successful_integration(&row_4()).unwrap();
 
         let result = buffer
-            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert)
+            .get_ordered_sync_buffer_records(repository::SyncBufferAction::Upsert, &table_order)
             .unwrap();
 
         assert_eq!(result, vec![]);

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -1,4 +1,3 @@
-
 use chrono::Utc;
 use repository::{
     DatetimeFilter, EqualFilter, RepositoryError, StorageConnection, SyncBufferAction,
@@ -6,7 +5,6 @@ use repository::{
 };
 use util::inline_edit;
 
-    LegacyTableName::BARCODE,
 pub(crate) struct SyncBuffer<'a> {
     query_repository: SyncBufferRepository<'a>,
     row_repository: SyncBufferRowRepository<'a>,

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -3,7 +3,7 @@ use crate::sync::translations::PullDeleteRecordTable;
 use super::{
     sync_buffer::SyncBuffer,
     translations::{
-        all_translators, IntegrationRecords, PullDeleteRecord, PullUpsertRecord, SyncTranslators,
+        IntegrationRecords, PullDeleteRecord, PullUpsertRecord, SyncTranslation, SyncTranslators,
     },
 };
 use log::warn;
@@ -68,9 +68,9 @@ impl<'a> TranslationAndIntegration<'a> {
     pub(crate) fn translate_and_integrate_sync_records(
         &self,
         sync_records: Vec<SyncBufferRow>,
+        translators: &Vec<Box<dyn SyncTranslation>>,
     ) -> Result<TranslationAndIntegrationResults, RepositoryError> {
         let mut result = TranslationAndIntegrationResults::new();
-        let translators = all_translators();
 
         for sync_record in sync_records {
             // Try translate

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::sync::{api::RemoteSyncRecordV5, sync_serde::empty_str_as_option_string};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::OM_ACTIVITY_LOG;
 
@@ -38,6 +40,13 @@ pub struct LegacyActivityLogRow {
 
 pub(crate) struct ActivityLogTranslation {}
 impl SyncTranslation for ActivityLogTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::OM_ACTIVITY_LOG,
+            dependencies: vec![LegacyTableName::STORE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::sync::api::RemoteSyncRecordV5;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::BARCODE;
 
@@ -36,6 +38,13 @@ pub struct LegacyBarcodeRow {
 
 pub(crate) struct BarcodeTranslation {}
 impl SyncTranslation for BarcodeTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::BARCODE,
+            dependencies: vec![LegacyTableName::ITEM],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/inventory_adjustment_reason.rs
+++ b/server/service/src/sync/translations/inventory_adjustment_reason.rs
@@ -4,7 +4,8 @@ use repository::{
 use serde::{Deserialize, Serialize};
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::INVENTORY_ADJUSTMENT_REASON;
@@ -36,6 +37,13 @@ pub struct LegacyOptionsRow {
 
 pub(crate) struct InventoryAdjustmentReasonTranslation {}
 impl SyncTranslation for InventoryAdjustmentReasonTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/invoice.rs
+++ b/server/service/src/sync/translations/invoice.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::TRANSACT;
@@ -177,6 +178,13 @@ pub struct LegacyTransactRow {
 
 pub(crate) struct InvoiceTranslation {}
 impl SyncTranslation for InvoiceTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::TRANSACT,
+            dependencies: vec![LegacyTableName::NAME, LegacyTableName::STORE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,

--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     is_active_record_on_site, ActiveRecordCheck, IntegrationRecords, LegacyTableName,
-    PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    PullDeleteRecordTable, PullDependency, PullUpsertRecord, SyncTranslation,
 };
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::TRANS_LINE;
@@ -87,6 +87,19 @@ pub struct LegacyTransLineRow {
 
 pub(crate) struct InvoiceLineTranslation {}
 impl SyncTranslation for InvoiceLineTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::TRANS_LINE,
+            dependencies: vec![
+                LegacyTableName::TRANSACT,
+                LegacyTableName::ITEM,
+                LegacyTableName::ITEM_LINE,
+                LegacyTableName::LOCATION,
+                LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
+            ],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,

--- a/server/service/src/sync/translations/item.rs
+++ b/server/service/src/sync/translations/item.rs
@@ -2,7 +2,8 @@ use repository::{ItemRow, ItemRowType, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_camel_case_types)]
@@ -43,6 +44,13 @@ pub(crate) fn ordered_simple_json(text: &str) -> Result<String, serde_json::Erro
 
 pub(crate) struct ItemTranslation {}
 impl SyncTranslation for ItemTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::ITEM,
+            dependencies: vec![LegacyTableName::UNIT],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/location.rs
+++ b/server/service/src/sync/translations/location.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::sync::api::RemoteSyncRecordV5;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::LOCATION;
 
@@ -32,6 +34,13 @@ pub struct LegacyLocationRow {
 
 pub(crate) struct LocationTranslation {}
 impl SyncTranslation for LocationTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LOCATION,
+            dependencies: vec![LegacyTableName::STORE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/location_movement.rs
+++ b/server/service/src/sync/translations/location_movement.rs
@@ -12,7 +12,9 @@ use crate::sync::{
     },
 };
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::LOCATION_MOVEMENT;
 
@@ -50,6 +52,17 @@ pub struct LegacyLocationMovementRow {
 
 pub(crate) struct LocationMovementTranslation {}
 impl SyncTranslation for LocationMovementTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LOCATION_MOVEMENT,
+            dependencies: vec![
+                LegacyTableName::STORE,
+                LegacyTableName::LOCATION,
+                LegacyTableName::ITEM_LINE,
+            ],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/master_list.rs
+++ b/server/service/src/sync/translations/master_list.rs
@@ -2,7 +2,9 @@ use repository::{MasterListRow, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -19,6 +21,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 }
 pub(crate) struct MasterListTranslation {}
 impl SyncTranslation for MasterListTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LIST_MASTER,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/master_list_line.rs
+++ b/server/service/src/sync/translations/master_list_line.rs
@@ -2,7 +2,9 @@ use repository::{MasterListLineRow, StorageConnection, SyncBufferRow};
 
 use serde::Deserialize;
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
@@ -17,6 +19,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 }
 pub(crate) struct MasterListLineTranslation {}
 impl SyncTranslation for MasterListLineTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LIST_MASTER_LINE,
+            dependencies: vec![LegacyTableName::ITEM, LegacyTableName::LIST_MASTER],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/master_list_name_join.rs
+++ b/server/service/src/sync/translations/master_list_name_join.rs
@@ -3,7 +3,8 @@ use repository::{MasterListNameJoinRow, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -20,6 +21,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct MasterListNameJoinTranslation {}
 impl SyncTranslation for MasterListNameJoinTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LIST_MASTER_NAME_JOIN,
+            dependencies: vec![LegacyTableName::NAME, LegacyTableName::LIST_MASTER],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -77,8 +77,12 @@ pub(crate) fn pull_integration_order(translators: &SyncTranslators) -> Vec<&'sta
     let mut ts = TopologicalSort::<&str>::new();
     for translator in translators {
         let pull_dep = translator.pull_dependencies();
-        for dep in pull_dep.dependencies {
-            ts.add_dependency(dep, pull_dep.table);
+        if pull_dep.dependencies.len() == 0 {
+            ts.add_dependency("", pull_dep.table);
+        } else {
+            for dep in pull_dep.dependencies {
+                ts.add_dependency(dep, pull_dep.table);
+            }
         }
     }
     // fill output so that tables with the least dependencies come first

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -98,8 +98,8 @@ pub(crate) fn pull_integration_order(translators: &SyncTranslators) -> Vec<&'sta
 
         output.append(&mut next);
     }
-
-    output
+    // remove the empty helper dependency added earlier
+    output.into_iter().filter(|table| *table != "").collect()
 }
 
 #[allow(non_snake_case)]

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -260,7 +260,7 @@ impl IntegrationRecords {
 pub(crate) struct PullDependency {
     /// The legacy table name from where data is pulled for the SyncTranslation.
     pub table: &'static str,
-    /// List of legacy tables that need to be pulled first before the SyncTranslation can run.
+    /// List of legacy tables that need to be integrated first before the SyncTranslation can run.
     pub dependencies: Vec<&'static str>,
 }
 

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -260,11 +260,13 @@ impl IntegrationRecords {
 pub(crate) struct PullDependency {
     /// The legacy table name from where data is pulled for the SyncTranslation.
     pub table: &'static str,
-    /// List of legacy table names that need to be pulled first before the SyncTranslation can run.
+    /// List of legacy tables that need to be pulled first before the SyncTranslation can run.
     pub dependencies: Vec<&'static str>,
 }
 
 pub(crate) trait SyncTranslation {
+    /// Returns information about which legacy tables need to be integrated first before this
+    /// translation can run.
     fn pull_dependencies(&self) -> PullDependency;
 
     fn try_translate_pull_upsert(

--- a/server/service/src/sync/translations/mod.rs
+++ b/server/service/src/sync/translations/mod.rs
@@ -81,8 +81,7 @@ pub(crate) fn pull_integration_order(translators: &SyncTranslators) -> Vec<&'sta
     for translator in translators {
         let pull_dep = translator.pull_dependencies();
         if pull_dep.dependencies.len() == 0 {
-            // no dependencies; add it strait to the top of the output
-            output.push(pull_dep.table);
+            ts.insert(pull_dep.table);
             continue;
         }
         for dep in pull_dep.dependencies {

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -7,7 +7,8 @@ use repository::{Gender, NameRow, NameType, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -127,6 +128,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct NameTranslation {}
 impl SyncTranslation for NameTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::NAME,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -5,7 +5,8 @@ use repository::{
 use serde::{Deserialize, Serialize};
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -26,6 +27,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 }
 pub(crate) struct NameStoreJoinTranslation {}
 impl SyncTranslation for NameStoreJoinTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::NAME_STORE_JOIN,
+            dependencies: vec![LegacyTableName::NAME, LegacyTableName::STORE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,

--- a/server/service/src/sync/translations/name_tag.rs
+++ b/server/service/src/sync/translations/name_tag.rs
@@ -2,7 +2,9 @@ use repository::{NameTagRow, StorageConnection, SyncBufferRow};
 
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
@@ -17,6 +19,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct NameTagTranslation {}
 impl SyncTranslation for NameTagTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::NAME_TAG,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/name_tag_join.rs
+++ b/server/service/src/sync/translations/name_tag_join.rs
@@ -3,7 +3,8 @@ use repository::{NameTagJoinRow, StorageConnection, SyncBufferRow};
 use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -20,6 +21,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct NameTagJoinTranslation {}
 impl SyncTranslation for NameTagJoinTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::NAME_TAG_JOIN,
+            dependencies: vec![LegacyTableName::NAME, LegacyTableName::NAME_TAG],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/period.rs
+++ b/server/service/src/sync/translations/period.rs
@@ -2,7 +2,9 @@ use chrono::NaiveDate;
 use repository::{PeriodRow, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::PERIOD;
 
@@ -26,6 +28,13 @@ pub struct LegacyPeriodRow {
 
 pub(crate) struct PeriodTranslation {}
 impl SyncTranslation for PeriodTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::PERIOD,
+            dependencies: vec![LegacyTableName::PERIOD_SCHEDULE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/period_schedule.rs
+++ b/server/service/src/sync/translations/period_schedule.rs
@@ -1,7 +1,9 @@
 use repository::{PeriodScheduleRow, StorageConnection, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::PERIOD_SCHEDULE;
 
@@ -19,6 +21,13 @@ pub struct LegacyPeriodScheduleRow {
 
 pub(crate) struct PeriodScheduleTranslation {}
 impl SyncTranslation for PeriodScheduleTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::PERIOD_SCHEDULE,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/program_requisition_settings.rs
+++ b/server/service/src/sync/translations/program_requisition_settings.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecord, PullDeleteRecordTable, PullUpsertRecord,
-    SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecord, PullDeleteRecordTable, PullDependency,
+    PullUpsertRecord, SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -60,6 +60,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 }
 pub(crate) struct ProgramRequisitionSettingsTranslation {}
 impl SyncTranslation for ProgramRequisitionSettingsTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::LIST_MASTER,
+            dependencies: vec![LegacyTableName::NAME_TAG, LegacyTableName::PERIOD_SCHEDULE],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -4,7 +4,8 @@ use repository::{ReportContext, ReportRow, ReportType, StorageConnection, SyncBu
 use serde::{Deserialize, Serialize};
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -51,6 +52,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct ReportTranslation {}
 impl SyncTranslation for ReportTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::REPORT,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/requisition.rs
+++ b/server/service/src/sync/translations/requisition.rs
@@ -17,7 +17,8 @@ use crate::sync::{
 };
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::REQUISITION;
@@ -166,6 +167,18 @@ pub struct LegacyRequisitionRow {
 
 pub(crate) struct RequisitionTranslation {}
 impl SyncTranslation for RequisitionTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::REQUISITION,
+            dependencies: vec![
+                LegacyTableName::STORE,
+                LegacyTableName::NAME,
+                LegacyTableName::PERIOD,
+                LegacyTableName::LIST_MASTER,
+            ],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         conn: &StorageConnection,

--- a/server/service/src/sync/translations/requisition_line.rs
+++ b/server/service/src/sync/translations/requisition_line.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::REQUISITION_LINE;
@@ -59,6 +60,13 @@ pub struct LegacyRequisitionLineRow {
 
 pub(crate) struct RequisitionLineTranslation {}
 impl SyncTranslation for RequisitionLineTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::REQUISITION_LINE,
+            dependencies: vec![LegacyTableName::REQUISITION, LegacyTableName::ITEM],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/translations/special/name_to_name_store_join.rs
@@ -5,7 +5,7 @@ use repository::{
 use serde::Deserialize;
 
 use crate::sync::translations::{
-    IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -24,6 +24,13 @@ pub struct PartialLegacyNameRow {
 // NOTE Translator should be removed when central server configures these properties on name_store_join
 pub(crate) struct NameToNameStoreJoinTranslation {}
 impl SyncTranslation for NameToNameStoreJoinTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::NAME,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         connection: &StorageConnection,

--- a/server/service/src/sync/translations/stock_line.rs
+++ b/server/service/src/sync/translations/stock_line.rs
@@ -9,7 +9,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::ITEM_LINE;
 
@@ -50,6 +52,18 @@ pub struct LegacyStockLineRow {
 
 pub(crate) struct StockLineTranslation {}
 impl SyncTranslation for StockLineTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::ITEM_LINE,
+            dependencies: vec![
+                LegacyTableName::ITEM,
+                LegacyTableName::STORE,
+                LegacyTableName::LOCATION,
+                LegacyTableName::NAME,
+            ],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/stocktake.rs
+++ b/server/service/src/sync/translations/stocktake.rs
@@ -12,7 +12,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STOCKTAKE;
 
@@ -86,6 +88,13 @@ pub struct LegacyStocktakeRow {
 
 pub(crate) struct StocktakeTranslation {}
 impl SyncTranslation for StocktakeTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::STOCKTAKE,
+            dependencies: vec![LegacyTableName::STORE, LegacyTableName::TRANSACT],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/stocktake_line.rs
+++ b/server/service/src/sync/translations/stocktake_line.rs
@@ -9,7 +9,9 @@ use repository::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STOCKTAKE_LINE;
 
@@ -54,6 +56,19 @@ pub struct LegacyStocktakeLineRow {
 
 pub(crate) struct StocktakeLineTranslation {}
 impl SyncTranslation for StocktakeLineTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::STOCKTAKE_LINE,
+            dependencies: vec![
+                LegacyTableName::STOCKTAKE,
+                LegacyTableName::ITEM_LINE,
+                LegacyTableName::LOCATION,
+                LegacyTableName::ITEM,
+                LegacyTableName::INVENTORY_ADJUSTMENT_REASON,
+            ],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/store.rs
+++ b/server/service/src/sync/translations/store.rs
@@ -1,10 +1,11 @@
 use repository::{StorageConnection, StoreRow, SyncBufferRow};
 
-use serde::{Deserialize};
 use crate::sync::sync_serde::empty_str_as_option_string;
+use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -18,7 +19,7 @@ pub struct LegacyStoreRow {
     #[serde(rename = "sync_id_remote_site")]
     site_id: i32,
     #[serde(deserialize_with = "empty_str_as_option_string")]
-    logo: Option<String>
+    logo: Option<String>,
 }
 
 fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
@@ -26,6 +27,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 }
 pub(crate) struct StoreTranslation {}
 impl SyncTranslation for StoreTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::STORE,
+            dependencies: vec![LegacyTableName::NAME],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -1,7 +1,9 @@
 use repository::{StorageConnection, StorePreferenceRow, StorePreferenceType, SyncBufferRow};
 use serde::{Deserialize, Serialize};
 
-use super::{IntegrationRecords, LegacyTableName, PullUpsertRecord, SyncTranslation};
+use super::{
+    IntegrationRecords, LegacyTableName, PullDependency, PullUpsertRecord, SyncTranslation,
+};
 
 const LEGACY_TABLE_NAME: &'static str = LegacyTableName::STORE_PREFERENCE;
 
@@ -35,6 +37,13 @@ pub struct LegacyPrefData {
 
 pub(crate) struct StorePreferenceTranslation {}
 impl SyncTranslation for StorePreferenceTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::STORE_PREFERENCE,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,

--- a/server/service/src/sync/translations/unit.rs
+++ b/server/service/src/sync/translations/unit.rs
@@ -3,7 +3,8 @@ use repository::{StorageConnection, SyncBufferRow, UnitRow};
 use serde::Deserialize;
 
 use super::{
-    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullUpsertRecord, SyncTranslation,
+    IntegrationRecords, LegacyTableName, PullDeleteRecordTable, PullDependency, PullUpsertRecord,
+    SyncTranslation,
 };
 
 #[allow(non_snake_case)]
@@ -21,6 +22,13 @@ fn match_pull_table(sync_record: &SyncBufferRow) -> bool {
 
 pub(crate) struct UnitTranslation {}
 impl SyncTranslation for UnitTranslation {
+    fn pull_dependencies(&self) -> PullDependency {
+        PullDependency {
+            table: LegacyTableName::UNIT,
+            dependencies: vec![],
+        }
+    }
+
     fn try_translate_pull_upsert(
         &self,
         _: &StorageConnection,


### PR DESCRIPTION
I keep forgetting to add an entry to the translation order list `TRANSLATION_AND_INTEGRATION_ORDER`. This time I wrongfully blamed the central server for my failure (thanks @Chris-Petty for correcting me). @Chris-Petty and I had a brief chat how this could be enforced by the compiler, e.g. just implementing a `SyncTranslation` should be enough.

Here is one possible solution. I added a `pull_dependencies()` method to the `SyncTranslation` trait which returns information about which tables are required for the translation, i.e. which tables need to be integrated first. Based on this information the integration order is calculated.

Possible pitfall: when adding a new table / new dependency to a table and forgetting to add the dependency to the `PullDependency` the error might get unnoticed in the tests (if they are not updated properly). This is less likely with the old approach because you most likely would append a new table at the end of `TRANSLATION_AND_INTEGRATION_ORDER`(?)