### PR TITLE
1676 - Fix cors for local ip connection

### DIFF
--- a/server/server/src/cors.rs
+++ b/server/server/src/cors.rs
@@ -26,9 +26,12 @@ pub fn cors_policy(config_settings: &Settings) -> Cors {
             });
 
             match sec_fetch_site_header {
-                Some(b"cross-site") => true,
+                Some(b"same-site") => true,
                 Some(b"same-origin") => true,
+                // Both 'none' and None value indicates browser considers to be the same origin
+                // found this in an edge case when connecting by IP in Chrome sec-fetch-site headers are missing
                 Some(b"none") => true,
+                None => true,
                 _ => false,
             }
         });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

OOPS this was committed to develop by accident, making a PR to show the changes, will close if ok, otherwise will make changes and re-base to develop

Fixes #1676

# 👩🏻‍💻 What does this PR do? 

Allow cors if sec-fetch-site header is missing (this happens in chrome when connecting by IP)

Fix cross-site cors 😱 , i don't know how this happened, in this PR: https://github.com/openmsupply/open-msupply/pull/802, i made a mistake and then [Clemens caught it,](https://github.com/openmsupply/open-msupply/pull/802#discussion_r1025875304) and i made a commit, but somehow it was reverted (didn't investigate, glad we caught it now thought)

# 🧪 How has/should this change been tested? 
With Chrome

Run release remote server or comment out is_debug statment in cors.rs. (either way make sure front end is pre-built)

Try opening localhost:8000 in browser (should work).
Try opening {your ip address}:8000 in browser (should not work without this change)

Now to validate that cross site is still forbidden, start web app with yarn start-local, and try opening {your ip address}:3003 (should work without this change and shouldn't work with this change)

`should not work` above means, login page is opened, but font styles are wrong and API requests are returned with 400

## 💌 Any notes for the reviewer?


## 📃 Documentation
