### PR TITLE
1523 wait for processor fix

### DIFF
--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -77,6 +77,7 @@ impl Processors {
                 // See test below for reasoning behind biased, even though there is no foreseen use case where
                 // requisition must be processed before shipment, it easy to reason about future use cases if
                 // order is guaranteed when requisition transfer is triggered before shipment transfer (like it is in synchroniser)
+                // The biased flag also makes sure that `await_process_queue` is only called after all other channels are empty.
                 let result = tokio::select! {
                     biased;
                     Some(_) = requisition_transfer.recv() => {

--- a/server/service/src/processors/test_helpers.rs
+++ b/server/service/src/processors/test_helpers.rs
@@ -7,26 +7,6 @@ pub(crate) async fn delay_for_processor() {
     tokio::time::sleep(Duration::from_millis(PROCESSOR_DELAY_MILLISECONDS)).await
 }
 
-/// Retries the input $check expression till the expression evaluates to true or till the number of
-/// max retries is reached.
-/// This is implemented as a macro to avoid thread problems if the $check expression is !Send
-macro_rules! delayed_with_retries {
-    ($check:expr, $err_message:expr) => {{
-        let mut success = false;
-        for _ in 1..=3 {
-            delay_for_processor().await;
-            if $check {
-                success = true;
-                break;
-            }
-        }
-        if !success {
-            panic!("Failed with retries: {}", $err_message);
-        }
-    }};
-}
-pub(crate) use delayed_with_retries;
-
 pub(crate) async fn exec_concurrent<C, T, Fut, F>(
     context: C,
     number_of_instances: u32,

--- a/server/service/src/processors/test_helpers.rs
+++ b/server/service/src/processors/test_helpers.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, time::Duration};
 use tokio::task::JoinSet;
 
-const PROCESSOR_DELAY_MILLISECONDS: u64 = 300;
+const PROCESSOR_DELAY_MILLISECONDS: u64 = 50;
 
 pub(crate) async fn delay_for_processor() {
     tokio::time::sleep(Duration::from_millis(PROCESSOR_DELAY_MILLISECONDS)).await
@@ -13,7 +13,7 @@ pub(crate) async fn delay_for_processor() {
 macro_rules! delayed_with_retries {
     ($check:expr, $err_message:expr) => {{
         let mut success = false;
-        for _ in 1..=3 {
+        for _ in 1..=50 {
             delay_for_processor().await;
             if $check {
                 success = true;

--- a/server/service/src/processors/test_helpers.rs
+++ b/server/service/src/processors/test_helpers.rs
@@ -7,7 +7,9 @@ pub(crate) async fn delay_for_processor() {
     tokio::time::sleep(Duration::from_millis(PROCESSOR_DELAY_MILLISECONDS)).await
 }
 
-// This is implemented as a macro to avoid thread problems if the $call expression is not Send
+/// Retries the input $check expression till the expression evaluates to true or till the number of
+/// max retries is reached.
+/// This is implemented as a macro to avoid thread problems if the $check expression is !Send
 macro_rules! delayed_with_retries {
     ($check:expr, $err_message:expr) => {{
         let mut success = false;

--- a/server/service/src/processors/test_helpers.rs
+++ b/server/service/src/processors/test_helpers.rs
@@ -1,11 +1,5 @@
-use std::{future::Future, time::Duration};
+use std::future::Future;
 use tokio::task::JoinSet;
-
-const PROCESSOR_DELAY_MILLISECONDS: u64 = 300;
-
-pub(crate) async fn delay_for_processor() {
-    tokio::time::sleep(Duration::from_millis(PROCESSOR_DELAY_MILLISECONDS)).await
-}
 
 pub(crate) async fn exec_concurrent<C, T, Fut, F>(
     context: C,

--- a/server/service/src/processors/test_helpers.rs
+++ b/server/service/src/processors/test_helpers.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, time::Duration};
 use tokio::task::JoinSet;
 
-const PROCESSOR_DELAY_MILLISECONDS: u64 = 50;
+const PROCESSOR_DELAY_MILLISECONDS: u64 = 300;
 
 pub(crate) async fn delay_for_processor() {
     tokio::time::sleep(Duration::from_millis(PROCESSOR_DELAY_MILLISECONDS)).await
@@ -13,7 +13,7 @@ pub(crate) async fn delay_for_processor() {
 macro_rules! delayed_with_retries {
     ($check:expr, $err_message:expr) => {{
         let mut success = false;
-        for _ in 1..=50 {
+        for _ in 1..=3 {
             delay_for_processor().await;
             if $check {
                 success = true;

--- a/server/service/src/processors/transfer/requisition/test.rs
+++ b/server/service/src/processors/transfer/requisition/test.rs
@@ -9,7 +9,7 @@ use repository::{
 use util::{inline_edit, inline_init, uuid::uuid};
 
 use crate::{
-    processors::test_helpers::{delay_for_processor, exec_concurrent},
+    processors::test_helpers::exec_concurrent,
     requisition::{
         request_requisition::{UpdateRequestRequisition, UpdateRequestRequisitionStatus},
         response_requisition::{UpdateResponseRequisition, UpdateResponseRequisitionStatus},
@@ -104,13 +104,11 @@ async fn requisition_transfer() {
                 .unwrap();
             ctx.processors_trigger.await_events_processed().await;
             tester.check_response_requisition_not_created(&ctx.connection);
-            delay_for_processor().await;
             tester.update_request_requisition_to_sent(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_response_requisition_created(&ctx.connection);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_request_requisition_was_linked(&ctx.connection);
-            delay_for_processor().await;
             tester.update_response_requisition_to_finalised(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_request_requisition_status_updated(&ctx.connection);

--- a/server/service/src/processors/transfer/requisition/test.rs
+++ b/server/service/src/processors/transfer/requisition/test.rs
@@ -20,7 +20,7 @@ use crate::{
     test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
 };
 
-fn requisition_processed(connection: &StorageConnection) -> bool {
+pub(crate) fn requisition_processed(connection: &StorageConnection) -> bool {
     let active_stores = ActiveStoresOnSite::get(connection).unwrap();
     let changelog_repo = ChangelogRepository::new(connection);
     let key_value_store_repo = KeyValueStoreRepository::new(connection);

--- a/server/service/src/processors/transfer/requisition/test.rs
+++ b/server/service/src/processors/transfer/requisition/test.rs
@@ -1,8 +1,7 @@
 use chrono::NaiveDate;
 use repository::{
     mock::{insert_extra_mock_data, MockData, MockDataInserts},
-    ChangelogFilter, ChangelogRepository, ChangelogTableName, EqualFilter, ItemRow,
-    KeyValueStoreRepository, KeyValueStoreRow, KeyValueType, NameRow, RequisitionFilter,
+    EqualFilter, ItemRow, KeyValueStoreRow, KeyValueType, NameRow, RequisitionFilter,
     RequisitionLineFilter, RequisitionLineRepository, RequisitionLineRow, RequisitionRepository,
     RequisitionRow, RequisitionRowRepository, RequisitionRowStatus, RequisitionRowType,
     StorageConnection, StoreRow,
@@ -10,36 +9,14 @@ use repository::{
 use util::{inline_edit, inline_init, uuid::uuid};
 
 use crate::{
-    processors::test_helpers::{delay_for_processor, delayed_with_retries, exec_concurrent},
+    processors::test_helpers::{delay_for_processor, exec_concurrent},
     requisition::{
         request_requisition::{UpdateRequestRequisition, UpdateRequestRequisitionStatus},
         response_requisition::{UpdateResponseRequisition, UpdateResponseRequisitionStatus},
     },
     service_provider::ServiceProvider,
-    sync::ActiveStoresOnSite,
     test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
 };
-
-pub(crate) fn requisition_processed(connection: &StorageConnection) -> bool {
-    let active_stores = ActiveStoresOnSite::get(connection).unwrap();
-    let changelog_repo = ChangelogRepository::new(connection);
-    let key_value_store_repo = KeyValueStoreRepository::new(connection);
-
-    let cursor = key_value_store_repo
-        .get_i64(KeyValueType::RequisitionTransferProcessorCursor)
-        .unwrap()
-        .unwrap_or(0) as u64;
-
-    // For transfers, changelog MUST be filtered by records where name_id is active store on this site
-    // this is the contract obligation for try_process_record in ProcessorTrait
-    let filter = ChangelogFilter::new()
-        .table_name(ChangelogTableName::Requisition.equal_to())
-        .name_id(EqualFilter::equal_any(active_stores.name_ids()));
-    let logs = changelog_repo
-        .changelogs(cursor, 1, Some(filter.clone()))
-        .unwrap();
-    logs.is_empty()
-}
 
 /// This test is for requesting and responding store on the same site
 /// See same site transfer diagram in README.md for example of how
@@ -125,17 +102,17 @@ async fn requisition_transfer() {
                 .requisition_transfer
                 .try_send(())
                 .unwrap();
-            delayed_with_retries!(requisition_processed(&ctx.connection), "wait for processor");
+            ctx.processors_trigger.await_events_processed().await;
             tester.check_response_requisition_not_created(&ctx.connection);
             delay_for_processor().await;
             tester.update_request_requisition_to_sent(&service_provider);
-            delayed_with_retries!(requisition_processed(&ctx.connection), "wait for processor");
+            ctx.processors_trigger.await_events_processed().await;
             tester.check_response_requisition_created(&ctx.connection);
-            delayed_with_retries!(requisition_processed(&ctx.connection), "wait for processor");
+            ctx.processors_trigger.await_events_processed().await;
             tester.check_request_requisition_was_linked(&ctx.connection);
             delay_for_processor().await;
             tester.update_response_requisition_to_finalised(&service_provider);
-            delayed_with_retries!(requisition_processed(&ctx.connection), "wait for processor");
+            ctx.processors_trigger.await_events_processed().await;
             tester.check_request_requisition_status_updated(&ctx.connection);
         },
     );

--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -1,12 +1,12 @@
 use chrono::NaiveDate;
 use repository::{
     mock::{insert_extra_mock_data, MockData, MockDataInserts},
-    EqualFilter, InvoiceFilter, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow,
-    InvoiceLineRowRepository, InvoiceLineRowType, InvoiceRepository, InvoiceRow,
-    InvoiceRowRepository, InvoiceRowStatus, InvoiceRowType, ItemRow, KeyValueStoreRow,
-    KeyValueType, LocationRow, NameRow, RequisitionFilter, RequisitionRepository, RequisitionRow,
-    RequisitionRowRepository, RequisitionRowStatus, RequisitionRowType, StockLineRow,
-    StorageConnection, StoreRow,
+    ChangelogFilter, ChangelogRepository, ChangelogTableName, EqualFilter, InvoiceFilter,
+    InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow, InvoiceLineRowRepository,
+    InvoiceLineRowType, InvoiceRepository, InvoiceRow, InvoiceRowRepository, InvoiceRowStatus,
+    InvoiceRowType, ItemRow, KeyValueStoreRepository, KeyValueStoreRow, KeyValueType, LocationRow,
+    NameRow, RequisitionFilter, RequisitionRepository, RequisitionRow, RequisitionRowRepository,
+    RequisitionRowStatus, RequisitionRowType, StockLineRow, StorageConnection, StoreRow,
 };
 use util::{inline_edit, inline_init, uuid::uuid};
 
@@ -16,12 +16,34 @@ use crate::{
         outbound_shipment::{UpdateOutboundShipment, UpdateOutboundShipmentStatus},
     },
     invoice_line::outbound_shipment_line::UpdateOutboundShipmentLine,
-    processors::test_helpers::{delay_for_processor, exec_concurrent},
+    processors::test_helpers::{delay_for_processor, delayed_with_retries, exec_concurrent},
     requisition::request_requisition::{UpdateRequestRequisition, UpdateRequestRequisitionStatus},
     service_provider::ServiceProvider,
+    sync::ActiveStoresOnSite,
     test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
 };
 
+fn shipments_processed(connection: &StorageConnection) -> bool {
+    let active_stores = ActiveStoresOnSite::get(connection).unwrap();
+    let changelog_repo = ChangelogRepository::new(connection);
+    let key_value_store_repo = KeyValueStoreRepository::new(connection);
+
+    let cursor = key_value_store_repo
+        .get_i64(KeyValueType::RequisitionTransferProcessorCursor)
+        .unwrap()
+        .unwrap_or(0) as u64;
+
+    // For transfers, changelog MUST be filtered by records where name_id is active store on this site
+    // this is the contract obligation for try_process_record in ProcessorTrait
+    let filter = ChangelogFilter::new()
+        .table_name(ChangelogTableName::Requisition.equal_to())
+        .name_id(EqualFilter::equal_any(active_stores.name_ids()));
+    let logs = changelog_repo
+        .changelogs(cursor, 1, Some(filter.clone()))
+        .unwrap();
+
+    logs.is_empty()
+}
 /// This test is for requesting and responding store on the same site
 /// See same site transfer diagram in requisition README.md for example of how
 /// changelog is upserted and processed by the same instance of triggered processor
@@ -102,30 +124,30 @@ async fn invoice_transfers() {
                 ShipmentTransferTester::new(&inbound_store, &outbound_store, &item1, &item2);
 
             tester.insert_request_requisition(&service_provider).await;
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_response_requisition_created(&ctx.connection);
             tester.insert_outbound_shipment(&ctx.connection);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_inbound_shipment_not_created(&ctx.connection);
             delay_for_processor().await;
             tester.update_outbound_shipment_to_picked(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_inbound_shipment_created(&ctx.connection);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_outbound_shipment_was_linked(&ctx.connection);
             delay_for_processor().await;
             tester.update_outbound_shipment_lines(&service_provider);
             delay_for_processor().await;
             tester.update_outbound_shipment_to_shipped(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_inbound_shipment_was_updated(&ctx.connection);
             delay_for_processor().await;
             tester.update_inbound_shipment_to_delivered(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_outbound_shipment_status_matches_inbound_shipment(&ctx.connection);
             delay_for_processor().await;
             tester.update_inbound_shipment_to_verified(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_outbound_shipment_status_matches_inbound_shipment(&ctx.connection);
             delay_for_processor().await;
 

--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -156,16 +156,16 @@ async fn invoice_transfers() {
                 ShipmentTransferTester::new(&inbound_store, &outbound_store, &item1, &item2);
 
             tester.insert_request_requisition(&service_provider).await;
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_response_requisition_created(&ctx.connection);
             tester.insert_outbound_shipment(&ctx.connection);
             delay_for_processor().await;
             tester.update_outbound_shipment_to_picked(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_inbound_shipment_created(&ctx.connection);
             delay_for_processor().await;
             tester.delete_outbound_shipment(&service_provider);
-            delay_for_processor().await;
+            delayed_with_retries!(shipments_processed(&ctx.connection), "wait for processor");
             tester.check_inbound_shipment_deleted(&ctx.connection);
         },
     );

--- a/server/service/src/processors/transfer/shipment/test.rs
+++ b/server/service/src/processors/transfer/shipment/test.rs
@@ -16,7 +16,7 @@ use crate::{
         outbound_shipment::{UpdateOutboundShipment, UpdateOutboundShipmentStatus},
     },
     invoice_line::outbound_shipment_line::UpdateOutboundShipmentLine,
-    processors::test_helpers::{delay_for_processor, exec_concurrent},
+    processors::test_helpers::exec_concurrent,
     requisition::request_requisition::{UpdateRequestRequisition, UpdateRequestRequisitionStatus},
     service_provider::ServiceProvider,
     test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
@@ -112,27 +112,21 @@ async fn invoice_transfers() {
                 .unwrap();
             ctx.processors_trigger.await_events_processed().await;
             tester.check_inbound_shipment_not_created(&ctx.connection);
-            delay_for_processor().await;
             tester.update_outbound_shipment_to_picked(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_inbound_shipment_created(&ctx.connection);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_outbound_shipment_was_linked(&ctx.connection);
-            delay_for_processor().await;
             tester.update_outbound_shipment_lines(&service_provider);
-            delay_for_processor().await;
             tester.update_outbound_shipment_to_shipped(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_inbound_shipment_was_updated(&ctx.connection);
-            delay_for_processor().await;
             tester.update_inbound_shipment_to_delivered(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_outbound_shipment_status_matches_inbound_shipment(&ctx.connection);
-            delay_for_processor().await;
             tester.update_inbound_shipment_to_verified(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_outbound_shipment_status_matches_inbound_shipment(&ctx.connection);
-            delay_for_processor().await;
 
             // With delete
             let mut tester =
@@ -142,11 +136,9 @@ async fn invoice_transfers() {
             ctx.processors_trigger.await_events_processed().await;
             tester.check_response_requisition_created(&ctx.connection);
             tester.insert_outbound_shipment(&ctx.connection);
-            delay_for_processor().await;
             tester.update_outbound_shipment_to_picked(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_inbound_shipment_created(&ctx.connection);
-            delay_for_processor().await;
             tester.delete_outbound_shipment(&service_provider);
             ctx.processors_trigger.await_events_processed().await;
             tester.check_inbound_shipment_deleted(&ctx.connection);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1523

I was running into this quite consistency now... I first tried to just retry the `check_{*} ` methods in the tests. This worked, but it required to change the semantics of the check methods, e.g. they needed to return a bool to indicated that they should be retried (unwinding the panic didn't work because a mut reference to the Tester was used).

In this PR I just look at the processor queue and wait till the processor handled everything. I used some code from the processor but the usecase is slightly different for which reason I copied the code rather than refactor the processor to have something like an "is_done()" method.