### PR TITLE
1702 When editing stock, the location field doesn't retain the new location choice when there is already an assigned location

### DIFF
--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import {
   Checkbox,
   Grid,
@@ -20,6 +20,7 @@ import {
 } from '@openmsupply-client/common';
 import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
+import { LocationRowFragment } from '../../Location';
 
 const StyledInputRow = ({ label, Input }: InputWithLabelRowProps) => (
   <InputWithLabelRow
@@ -49,6 +50,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({ draft, onUpdate }) => {
   const supplierName = draft.supplierName
     ? draft.supplierName
     : t('message.no-supplier');
+  const [location, setLocation] = useState<LocationRowFragment | null>();
 
   const scanBarcode = async () => {
     try {
@@ -163,9 +165,12 @@ export const StockLineForm: FC<StockLineFormProps> = ({ draft, onUpdate }) => {
             <LocationSearchInput
               autoFocus={false}
               disabled={false}
-              value={draft.location ?? null}
+              value={location ?? draft.location ?? null}
               width={160}
-              onChange={location => onUpdate({ locationId: location?.id })}
+              onChange={(location) => {
+                onUpdate({ locationId: location?.id });
+                setLocation(location);
+              }}
             />
           }
         />

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import {
   Checkbox,
   Grid,
@@ -20,7 +20,6 @@ import {
 } from '@openmsupply-client/common';
 import { StockLineRowFragment } from '../api';
 import { LocationSearchInput } from '../../Location/Components/LocationSearchInput';
-import { LocationRowFragment } from '../../Location';
 
 const StyledInputRow = ({ label, Input }: InputWithLabelRowProps) => (
   <InputWithLabelRow
@@ -50,7 +49,7 @@ export const StockLineForm: FC<StockLineFormProps> = ({ draft, onUpdate }) => {
   const supplierName = draft.supplierName
     ? draft.supplierName
     : t('message.no-supplier');
-  const [location, setLocation] = useState<LocationRowFragment | null>();
+  const location = draft?.location ?? null;
 
   const scanBarcode = async () => {
     try {
@@ -165,11 +164,10 @@ export const StockLineForm: FC<StockLineFormProps> = ({ draft, onUpdate }) => {
             <LocationSearchInput
               autoFocus={false}
               disabled={false}
-              value={location ?? draft.location ?? null}
+              value={location}
               width={160}
               onChange={(location) => {
-                onUpdate({ locationId: location?.id });
-                setLocation(location);
+                onUpdate({ location, locationId: location?.id });
               }}
             />
           }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1702 

# 👩🏻‍💻 What does this PR do? 
Sets stock location to state, so that it changes on UI when user changes locations

# 🧪 How has/should this change been tested? 
- Have stock line with location already saved 
- Go to edit stock
- Change location and see it reflected in UI
