### PR TITLE
#1708 - Customer ref entering is slow on response order

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar.tsx
@@ -3,7 +3,6 @@ import {
   AppBarContentPortal,
   Box,
   InputWithLabelRow,
-  BasicTextInput,
   Grid,
   DropdownMenu,
   DropdownMenuItem,
@@ -12,6 +11,8 @@ import {
   SearchBar,
   InfoPanel,
   Typography,
+  BufferedTextInput,
+  
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 
@@ -76,7 +77,7 @@ export const Toolbar: FC = () => {
               <InputWithLabelRow
                 label={t('label.customer-ref')}
                 Input={
-                  <BasicTextInput
+                  <BufferedTextInput
                     disabled={isDisabled}
                     size="small"
                     sx={{ width: 250 }}


### PR DESCRIPTION
Fixes #1708 

# 👩🏻‍💻 What does this PR do? 

Fixes the slowness on editing or adding Customer ref on response order

## 💌 Any notes for the reviewer?

Don't understand what would be the difference between using BasicTextInput and BufferedTextInput, but using `BufferedTextInput` solved the issue. 