### PR TITLE
restrict program master lists when creating internal orders

### DIFF
--- a/client/packages/common/src/hooks/useQueryParams/types.ts
+++ b/client/packages/common/src/hooks/useQueryParams/types.ts
@@ -13,6 +13,7 @@ type FilterRule = {
 };
 
 export type FilterBy = Record<string, FilterRule | null>;
+export type FilterByWithBoolean = Record<string, FilterRule | null | boolean>;
 
 export interface FilterController {
   filterBy: FilterBy | null;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1605,6 +1605,7 @@ export type MasterListFilterInput = {
   existsForNameId?: InputMaybe<EqualFilterStringInput>;
   existsForStoreId?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
+  isProgram?: InputMaybe<Scalars['Boolean']>;
   name?: InputMaybe<SimpleStringFilterInput>;
 };
 

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
@@ -24,6 +24,7 @@ export const AddFromMasterListButtonComponent = () => {
           modalController.toggleOff();
           addFromMasterList(masterList);
         }}
+        filterBy={{ isProgram: false }}
       />
       <ButtonWithIcon
         disabled={isDisabled || isProgram}

--- a/client/packages/system/src/MasterList/Components/MasterListSearchModal/MasterListSearchModal.tsx
+++ b/client/packages/system/src/MasterList/Components/MasterListSearchModal/MasterListSearchModal.tsx
@@ -1,13 +1,13 @@
 import React, { FC, useEffect } from 'react';
 import {
-  FilterBy,
+  FilterByWithBoolean,
   ListSearch,
   useTranslation,
 } from '@openmsupply-client/common';
 import { useMasterList, MasterListRowFragment } from '../../api';
 
 interface MasterListSearchProps {
-  filterBy?: FilterBy;
+  filterBy?: FilterByWithBoolean;
   open: boolean;
   onClose: () => void;
   onChange: (name: MasterListRowFragment) => void;

--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -2,6 +2,7 @@ import {
   SortBy,
   FilterBy,
   MasterListSortFieldInput,
+  FilterByWithBoolean,
 } from '@openmsupply-client/common';
 import { Sdk, MasterListRowFragment } from './operations.generated';
 
@@ -40,7 +41,7 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
       filterBy,
     }: {
       sortBy: SortBy<MasterListRowFragment>;
-      filterBy?: FilterBy;
+      filterBy?: FilterByWithBoolean;
     }) => {
       const key = masterListParser.toSort(sortBy);
       const desc = !!sortBy.isDesc;

--- a/client/packages/system/src/MasterList/api/hooks/document/useMasterListsAll.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/useMasterListsAll.ts
@@ -1,10 +1,14 @@
-import { FilterBy, SortBy, useMutation } from '@openmsupply-client/common';
+import {
+  FilterByWithBoolean,
+  SortBy,
+  useMutation,
+} from '@openmsupply-client/common';
 import { MasterListRowFragment } from '../../operations.generated';
 import { useMasterListApi } from '../utils/useMasterListApi';
 
 export const useMasterListsAll = (
   sortBy: SortBy<MasterListRowFragment>,
-  filterBy?: FilterBy
+  filterBy?: FilterByWithBoolean
 ) => {
   const api = useMasterListApi();
   const result = useMutation(api.keys.sortedList(sortBy, filterBy), () =>

--- a/client/packages/system/src/MasterList/api/hooks/utils/useMasterListApi.ts
+++ b/client/packages/system/src/MasterList/api/hooks/utils/useMasterListApi.ts
@@ -2,7 +2,7 @@ import {
   useGql,
   useAuthContext,
   SortBy,
-  FilterBy,
+  FilterByWithBoolean,
 } from '@openmsupply-client/common';
 import { getSdk, MasterListRowFragment } from '../../operations.generated';
 import { getMasterListQueries, ListParams } from '../../api';
@@ -14,8 +14,10 @@ export const useMasterListApi = () => {
     detail: (id: string) => [...keys.base(), storeId, id] as const,
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
-    sortedList: (sortBy: SortBy<MasterListRowFragment>, filterBy?: FilterBy) =>
-      [...keys.list(), sortBy, filterBy] as const,
+    sortedList: (
+      sortBy: SortBy<MasterListRowFragment>,
+      filterBy?: FilterByWithBoolean
+    ) => [...keys.list(), sortBy, filterBy] as const,
   };
   const { client } = useGql();
   const sdk = getSdk(client);

--- a/server/graphql/general/src/queries/master_list.rs
+++ b/server/graphql/general/src/queries/master_list.rs
@@ -49,6 +49,7 @@ pub struct MasterListFilterInput {
     pub exists_for_name: Option<SimpleStringFilterInput>,
     pub exists_for_name_id: Option<EqualFilterStringInput>,
     pub exists_for_store_id: Option<EqualFilterStringInput>,
+    pub is_program: Option<bool>,
 }
 
 impl MasterListFilterInput {
@@ -61,6 +62,7 @@ impl MasterListFilterInput {
             exists_for_name: self.exists_for_name.map(SimpleStringFilter::from),
             exists_for_name_id: self.exists_for_name_id.map(EqualFilter::from),
             exists_for_store_id: self.exists_for_store_id.map(EqualFilter::from),
+            is_program: self.is_program,
         }
     }
 }

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -213,6 +213,7 @@ mod graphql {
                         .exists_for_name(SimpleStringFilter::like("exists_for_name_filter"))
                         .exists_for_name_id(EqualFilter::not_equal_to("test_name_id_filter"))
                         .exists_for_store_id(EqualFilter::equal_to("store_a"))
+                        .is_program(SimpleFilter::equal_to(false))
                 )
             );
             Ok(ListResult::empty())
@@ -227,6 +228,7 @@ mod graphql {
             "existsForName": {"like": "exists_for_name_filter" },
             "existsForStoreId": {"equalTo": "store_a"},
             "existsForNameId": {"notEqualTo": "test_name_id_filter"}
+            "isProgram": {"equalTo": false}
           }
         });
 

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -213,7 +213,7 @@ mod graphql {
                         .exists_for_name(SimpleStringFilter::like("exists_for_name_filter"))
                         .exists_for_name_id(EqualFilter::not_equal_to("test_name_id_filter"))
                         .exists_for_store_id(EqualFilter::equal_to("store_a"))
-                        .is_program(SimpleFilter::equal_to(false))
+                        .is_program(false)
                 )
             );
             Ok(ListResult::empty())
@@ -227,8 +227,8 @@ mod graphql {
             "description": {"equalTo": "description_filter_1", "like": "description_filter_2" },
             "existsForName": {"like": "exists_for_name_filter" },
             "existsForStoreId": {"equalTo": "store_a"},
-            "existsForNameId": {"notEqualTo": "test_name_id_filter"}
-            "isProgram": {"equalTo": false}
+            "existsForNameId": {"notEqualTo": "test_name_id_filter"},
+            "isProgram": false
           }
         });
 

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -126,7 +126,8 @@ pub fn check_master_list_for_store(
     let mut rows = MasterListRepository::new(connection).query_by_filter(
         MasterListFilter::new()
             .id(EqualFilter::equal_to(master_list_id))
-            .exists_for_store_id(EqualFilter::equal_to(store_id)),
+            .exists_for_store_id(EqualFilter::equal_to(store_id))
+            .is_program(false),
     )?;
     Ok(rows.pop())
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1697 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Restricts the list of master lists which is shown when using a general internal order.
Adds a check to the 'addFromMasterList' mutation which also checks. This returns the 'master list not in this store' error, as I thought the event unlikely enough to warrant a new error variant. 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Configured multiple master lists for a store, with some program lists among them.
Check that you can create a program based internal order, and that you can add to a general order from master lists - but only lists which are not program lists.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Worth mentioning that you cannot use program lists when adding to internal orders
