### PR TITLE
Remove path from the server url

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
@@ -199,8 +199,7 @@ class CertWebViewClient extends ExtendedWebViewClient {
         // will not only reload, but will open the URL in a browser tab
         // for local URLs we don't want this to happen!
         Uri url = request.getUrl();
-        if(url.toString().startsWith("https://127.0.0.1:" + nativeApi.DEFAULT_PORT)
-            || url.toString().startsWith("https://localhost:" + nativeApi.DEFAULT_PORT)) {
+        if (url.toString().startsWith(nativeApi.getServerUrl())) {
             return false;
         }
 

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
@@ -199,7 +199,8 @@ class CertWebViewClient extends ExtendedWebViewClient {
         // will not only reload, but will open the URL in a browser tab
         // for local URLs we don't want this to happen!
         Uri url = request.getUrl();
-        if(url.toString().startsWith(this.nativeApi.getServerUrl())) {
+        if(url.toString().startsWith("https://127.0.0.1:" + nativeApi.DEFAULT_PORT)
+            || url.toString().startsWith("https://localhost:" + nativeApi.DEFAULT_PORT)) {
             return false;
         }
 

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.security.MessageDigest;
-import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -119,7 +118,7 @@ class CertWebViewClient extends ExtendedWebViewClient {
      * It needs to be checked that we know/trust the server before performing the
      * certificate validation.
      */
-    private boolean validateNonLocalCertificate(SslCertificate targetCert, NativeApi.omSupplyServer connectedServer) {
+    private boolean validateNonLocalCertificate(SslCertificate targetCert, NativeApi.FrontEndHost connectedServer) {
         // Calculate SSL fingerprint
         MessageDigest md = null;
         try {
@@ -164,7 +163,7 @@ class CertWebViewClient extends ExtendedWebViewClient {
 
         String url = error.getUrl();
         Boolean isDiscovery = url.startsWith(nativeApi.getLocalUrl());
-        NativeApi.omSupplyServer connectedServer = nativeApi.getConnectedServer();
+        NativeApi.FrontEndHost connectedServer = nativeApi.getConnectedServer();
         Boolean isConnectedToServer = connectedServer != null && url.startsWith(connectedServer.getUrl());
 
         // Default behaviour if not connected to a server or not discovery

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -417,12 +417,12 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
             this.data = data;
         }
 
+        /**
+         * @return the servers url string including protocol, ip and port,
+         * e.g. https://127.0.0.1:8000
+         */
         public String getUrl() {
-            String path = "";
-            if (data.getString("path") != null) {
-                path = "/" + data.getString("path");
-            }
-            return data.getString("protocol") + "://" + data.getString("ip") + ":" + data.getString("port") + path;
+            return data.getString("protocol") + "://" + data.getString("ip") + ":" + data.getString("port");
         }
 
         public boolean isLocal() {

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -33,7 +33,8 @@ import javax.net.ssl.SSLHandshakeException;
 public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     private static final String LOG_FILE_NAME = "remote_server.log";
     public static final String OM_SUPPLY = "omSupply";
-    private static final String DEFAULT_URL = "https://localhost:8000/";
+    public static final Integer DEFAULT_PORT = DiscoveryConstants.PORT;
+    private static final String DEFAULT_URL = "https://localhost:" + DEFAULT_PORT + "/";
     private static final String CONFIGURATION_GROUP = "omSupply_preferences";
     DiscoveryConstants discoveryConstants;
     JSArray discoveredServers;

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -33,7 +33,7 @@ import javax.net.ssl.SSLHandshakeException;
 public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     private static final String LOG_FILE_NAME = "remote_server.log";
     public static final String OM_SUPPLY = "omSupply";
-    public static final Integer DEFAULT_PORT = DiscoveryConstants.PORT;
+    private static final Integer DEFAULT_PORT = DiscoveryConstants.PORT;
     private static final String DEFAULT_URL = "https://localhost:" + DEFAULT_PORT + "/";
     private static final String CONFIGURATION_GROUP = "omSupply_preferences";
     DiscoveryConstants discoveryConstants;

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -38,7 +38,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
     DiscoveryConstants discoveryConstants;
     JSArray discoveredServers;
     Deque<NsdServiceInfo> serversToResolve;
-    omSupplyServer connectedServer;
+    FrontEndHost connectedServer;
     NsdManager discoveryManager;
     boolean isDebug;
     boolean isAdvertising;
@@ -73,7 +73,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         return isDebug;
     }
 
-    public omSupplyServer getConnectedServer() {
+    public FrontEndHost getConnectedServer() {
         return connectedServer;
     }
 
@@ -245,7 +245,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
 
     @PluginMethod()
     public void connectToServer(PluginCall call) {
-        omSupplyServer server = new omSupplyServer(call.getData());
+        FrontEndHost server = new FrontEndHost(call.getData());
 
         stopServerDiscovery();
         connectedServer = server;
@@ -410,10 +410,11 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         call.resolve(response);
     }
 
-    public class omSupplyServer {
+    /** Helper class to get access to the JS FrontEndHost data */
+    public class FrontEndHost {
         JSObject data;
         
-        public omSupplyServer(JSObject data) {
+        public FrontEndHost(JSObject data) {
             this.data = data;
         }
 

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -257,7 +257,7 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         WebView webView = bridge.getWebView();
         this.serverUrl = url;
         // .post to run on UI thread
-        webView.post(() -> webView.loadUrl(url));
+        webView.post(() -> webView.loadUrl(server.getConnectionUrl()));
     }
 
     // NsdManager.DiscoveryListener
@@ -419,11 +419,23 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         }
 
         /**
-         * @return the servers url string including protocol, ip and port,
+         * Constructs the server's base url string including protocol, ip and port,
          * e.g. https://127.0.0.1:8000
          */
         public String getUrl() {
             return data.getString("protocol") + "://" + data.getString("ip") + ":" + data.getString("port");
+        }
+
+        /**
+         * Constructs the url to be used when connecting to a server,
+         * e.g. https://127.0.0.1:8000/login
+         */
+        public String getConnectionUrl() {
+            String path = "";
+            if (data.getString("path") != null) {
+                path = "/" + data.getString("path");
+            }
+            return getUrl()  + path;
         }
 
         public boolean isLocal() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1704

Remove the path that was introduced in:

https://github.com/openmsupply/open-msupply/pull/1452

@mark-prins I couldn't figure out why it was added, and it doesn't seem to be used anywhere (?)

In `packages/android/app/src/main/java/org/openmsupply/client/CertWebViewClient.java` there is the code:

```java
@Override
    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
        // reloading a page ( javascript: navigate(0) or window.location.reload() )
        // will not only reload, but will open the URL in a browser tab
        // for local URLs we don't want this to happen!
        Uri url = request.getUrl();
        if(url.toString().startsWith(this.nativeApi.getServerUrl())) {
            return false;
        }

        return bridge.launchIntent(url);
    }
```
and `this.nativeApi.getServerUrl()` returned `https://127.0.0.1:8000/login` for me.

Note, if there is a debugUrl the url is done like `localUrl = isDebug ? debugUrl : "https://localhost:" + discoveryConstants.PORT;` This potentially wouldn't work in the comparison... Can fix/investigate after the initial review, i.e. if there wasn't a reason to have the path on the url...

