### PR TITLE
Add firewall rules

### DIFF
--- a/build/windows/omsupply_desktop.suf
+++ b/build/windows/omsupply_desktop.suf
@@ -2906,6 +2906,12 @@ end
 <Script>Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 if Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop") then
 	Registry.DeleteKey(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop");
+end
+
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
 end</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3125,6 +3131,21 @@ SessionVar.Set("%window_title%", sWindowTitle);</Script>
 	Shell.CreateShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop", omSupplyDesktopPath, "", "", "", 0, SW_SHOWNORMAL, nil, "", START_OPTION_DEFAULT);
 end
 
+-- Add a firewall rule to allow the omSupply Desktop to communicate with the server
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+
+	-- The firewall service requires restarting to detect the new rule
+	local firewallServiceName = "Windows Firewall";
+	queryResult = Service.Query(firewallServiceName, "");
+	if (queryResult == SERVICE_RUNNING) then
+		Service.Stop(firewallServiceName, "", 5);
+		Service.Start(firewallServiceName, "", nil);
+	end
+end
 </Script>
 <BookMarks count="0">
 </BookMarks>

--- a/build/windows/omsupply_desktop.suf
+++ b/build/windows/omsupply_desktop.suf
@@ -2906,12 +2906,6 @@ end
 <Script>Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 if Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop") then
 	Registry.DeleteKey(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop");
-end
-
-local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
-if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
-	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
-	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
 end</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3131,21 +3125,6 @@ SessionVar.Set("%window_title%", sWindowTitle);</Script>
 	Shell.CreateShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop", omSupplyDesktopPath, "", "", "", 0, SW_SHOWNORMAL, nil, "", START_OPTION_DEFAULT);
 end
 
--- Add a firewall rule to allow the omSupply Desktop to communicate with the server
-local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
-if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
-
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
-
-	-- The firewall service requires restarting to detect the new rule
-	local firewallServiceName = "Windows Firewall";
-	queryResult = Service.Query(firewallServiceName, "");
-	if (queryResult == SERVICE_RUNNING) then
-		Service.Stop(firewallServiceName, "", 5);
-		Service.Start(firewallServiceName, "", nil);
-	end
-end
 </Script>
 <BookMarks count="0">
 </BookMarks>

--- a/build/windows/omsupply_desktop.suf
+++ b/build/windows/omsupply_desktop.suf
@@ -2906,6 +2906,12 @@ end
 <Script>Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 if Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop") then
 	Registry.DeleteKey(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop");
+end
+
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
 end</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3123,6 +3129,22 @@ SessionVar.Set("%window_title%", sWindowTitle);</Script>
 	Registry.SetValue(HKEY_LOCAL_MACHINE, "Software\\omSupply Desktop", "Path", omSupplyDesktopPath, REG_SZ);
 
 	Shell.CreateShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop", omSupplyDesktopPath, "", "", "", 0, SW_SHOWNORMAL, nil, "", START_OPTION_DEFAULT);
+end
+
+-- Add a firewall rule to allow the omSupply Desktop to communicate with the server
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+
+	-- The firewall service requires restarting to detect the new rule
+	local firewallServiceName = "Windows Firewall";
+	queryResult = Service.Query(firewallServiceName, "");
+	if (queryResult == SERVICE_RUNNING) then
+		Service.Stop(firewallServiceName, "", 5);
+		Service.Start(firewallServiceName, "", nil);
+	end
 end
 </Script>
 <BookMarks count="0">

--- a/build/windows/omsupply_server.suf
+++ b/build/windows/omsupply_server.suf
@@ -4283,7 +4283,7 @@ File.Delete(sFileToBeDeletePath); -- Delete unchoosen app file (.exe) by a user
 local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=omSupply Server|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=".. SessionVar.Get("%ProductName%") .. "|", REG_SZ);
 	
 	-- The firewall service requires restarting to detect the new rule
 	local firewallServiceName = "Windows Firewall";

--- a/build/windows/omsupply_server.suf
+++ b/build/windows/omsupply_server.suf
@@ -3882,7 +3882,10 @@ end</Script>
 <Event>
 <Name>On Post Uninstall</Name>
 <Args/>
-<Script/>
+<Script>local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN");
+end</Script>
 <BookMarks count="0">
 </BookMarks>
 </Event>
@@ -4275,6 +4278,21 @@ else
 end
 
 File.Delete(sFileToBeDeletePath); -- Delete unchoosen app file (.exe) by a user
+
+-- Add a firewall rule to allow incoming requests
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=omSupply Server|", REG_SZ);
+	
+	-- The firewall service requires restarting to detect the new rule
+	local firewallServiceName = "Windows Firewall";
+	queryResult = Service.Query(firewallServiceName, "");
+	if (queryResult == SERVICE_RUNNING) then
+		Service.Stop(firewallServiceName, "", 5);
+		Service.Start(firewallServiceName, "", nil);
+	end
+end
 
 Service.Start("Open mSupply Server", "omsupply-server", nil);
 </Script>

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3076,6 +3076,8 @@ Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 <Script>local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
 end</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3377,7 +3379,9 @@ local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Para
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 
 	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=".. SessionVar.Get("%ProductName%") .. "|", REG_SZ);
-	
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
+
 	-- The firewall service requires restarting to detect the new rule
 	local firewallServiceName = "Windows Firewall";
 	queryResult = Service.Query(firewallServiceName, "");

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3073,7 +3073,12 @@ Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 <Event>
 <Name>On Post Uninstall</Name>
 <Args/>
-<Script/>
+<Script>local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
+	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
+end</Script>
 <BookMarks count="0">
 </BookMarks>
 </Event>
@@ -3369,6 +3374,23 @@ else
 	Registry.SetValue(HKEY_LOCAL_MACHINE, "Software\\omSupply Standalone", "Database", "sqlite", REG_SZ);
 end 
 
+-- Add a firewall rule to allow incoming requests
+local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
+if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
+
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=omSupply Server|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+
+	-- The firewall service requires restarting to detect the new rule
+	local firewallServiceName = "Windows Firewall";
+	queryResult = Service.Query(firewallServiceName, "");
+	if (queryResult == SERVICE_RUNNING) then
+		Service.Stop(firewallServiceName, "", 5);
+		Service.Start(firewallServiceName, "", nil);
+	end
+end
+
 Service.Create(SessionVar.Expand("%AppFolder%\\server\\omSupply-sqlite.exe"), "Open mSupply Server", "omsupply-server", SERVICE_WIN32_OWN_PROCESS, false, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, "", nil, nil, "", "");
 
 Service.Start("Open mSupply Server", "omsupply-server", nil);
@@ -3379,7 +3401,8 @@ if not hasOmsupplyStandaloneInstalled then
 	Registry.SetValue(HKEY_LOCAL_MACHINE, "Software\\omSupply Standalone", "Path", omSupplyDesktopPath, REG_SZ);
 
 	Shell.CreateShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop", omSupplyDesktopPath, "", "", "", 0, SW_SHOWNORMAL, nil, "", START_OPTION_DEFAULT);
-end</Script>
+end
+</Script>
 <BookMarks count="0">
 </BookMarks>
 </Event>

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3378,9 +3378,9 @@ end
 local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=omSupply Server|", REG_SZ);
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=open mSupply|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=".. SessionVar.Get("%ProductName%") .. "|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
+	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
 
 	-- The firewall service requires restarting to detect the new rule
 	local firewallServiceName = "Windows Firewall";

--- a/build/windows/omsupply_standalone.suf
+++ b/build/windows/omsupply_standalone.suf
@@ -3076,8 +3076,6 @@ Shell.DeleteShortcut(Shell.GetFolder(SHF_DESKTOP), "omSupply Desktop");
 <Script>local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules";
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN");
-	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe");
-	Registry.DeleteValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe");
 end</Script>
 <BookMarks count="0">
 </BookMarks>
@@ -3379,9 +3377,7 @@ local firewallRuleKey = "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Para
 if (Registry.DoesKeyExist(HKEY_LOCAL_MACHINE, firewallRuleKey)) then
 
 	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "open-mSupply-Server-TCP-IN", "v2.28|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort=" .. SessionVar.Get("%omsupply_port%") .. "|Name=".. SessionVar.Get("%ProductName%") .. "|", REG_SZ);
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "TCP Query User{F9DC9425-4A13-4FFE-9682-84C57917A6A1}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
-	Registry.SetValue(HKEY_LOCAL_MACHINE, firewallRuleKey, "UDP Query User{0B61B8B0-9AF9-47AA-9A17-404C68DC8AF6}open msupply.exe", "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=17|Profile=Private|App="..omSupplyDesktopPath.."|Name=".. SessionVar.Get("%ProductName%") .. "|Desc=open mSupply|Defer=User|", REG_SZ);
-
+	
 	-- The firewall service requires restarting to detect the new rule
 	local firewallServiceName = "Windows Firewall";
 	queryResult = Service.Query(firewallServiceName, "");


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1723 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds an incoming firewall rule for the server port to both the server and standalone installers.
For the rule to be applied, the firewall service requires restarting, so that happens too.
On uninstall, the rules are removed.

For the standalone and desktop installers I've added the rules which were added when the app was first run - I thought that if we add the rules, then the user won't get prompted.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Have created installers and tested on a couple of different machines. 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
