### PR TITLE
1743 Restrict master list visibility by store in internal order

### DIFF
--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -48,7 +48,7 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
       const result = await sdk.masterLists({
         key,
         desc,
-        filter: filterBy ?? { existsForStoreId: { equalTo: storeId } },
+        filter: { ...filterBy, existsForStoreId: { equalTo: storeId } },
         storeId,
       });
       return result?.masterLists;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1743 

# 👩🏻‍💻 What does this PR do? 
- Only loads master list that belong to the store in `Internal Order -> Add from Master List`

# 🧪 How has/should this change been tested? 
- Have multiple master lists: some belonging to the store and some not.
- Create an Internal Order from Master List
- Should only see the master lists that belong to that store