### PR TITLE
Barcode scanning: detect invalid lines in outbound line edit

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useOutboundLineEditRows.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useOutboundLineEditRows.ts
@@ -80,7 +80,7 @@ export const useOutboundLineEditRows = (
       scannedBatchMismatchRows,
       placeholderRow,
     };
-  }, [rows, packSizeController]);
+  }, [rows, packSizeController.selected?.value]);
 
   const orderedRows = useMemo(() => {
     return [


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1694 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The function which checks to see if a scanned barcode line exists is only checking existence, and needs to also check validity.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
The issue which Richard encountered was that the scanned stock line was unable to be used. When you scan, the matching line is highlighted and all other lines are disabled. The problem here is that the scanned line is disabled ( due, in his case, to a different pack size ). This results in all lines being disabled.

To test: 
Run the desktop version using `yarn electron:start-local`
Using a stocktake, add stock for an item and two batch lines with different pack sizes.
Add a barcode for that item, for the second batches' pack size. Use the GTIN value of `0109501101530003` and batch of `B090`.

Create an outbound shipment, add that item. Allocate some stock of batch 1.
Scan the below QR code. this will open the edit item modal with one stock line enabled.

![image](https://github.com/openmsupply/open-msupply/assets/9192912/77a41fec-f473-48bb-80fc-ed5b8c0d5b81)

Note: I have created a barcode with this string `01095011015300031722040110B090`
This has 
- GTIN: `0109501101530003`
- expiry: `01/02/2022`
- batch: `B090`




## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

