### PR TITLE
1745 Doc is linked to wrong page 

### DIFF
--- a/client/packages/common/src/utils/environment/EnvUtils.ts
+++ b/client/packages/common/src/utils/environment/EnvUtils.ts
@@ -16,7 +16,7 @@ const mapRoute = (route: string): RouteMapping => {
   const inRoute = (sub: string) => new RegExp(`/${sub}/|/${sub}\$`).test(route);
   switch (true) {
     case inRoute('dashboard'):
-      return { title: 'dashboard', docs: '/dashboard/' };
+      return { title: 'dashboard', docs: '/introduction/dashboard/' };
     case inRoute('outbound-shipment'):
       return {
         title: 'outbound-shipments',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1745

# 👩🏻‍💻 What does this PR do? 
- Use the correct route for dashboards and add back the location doc https://docs.msupply.foundation/docs/inventory/locations/

# 🧪 How has/should this change been tested? 
- Dashboard -> Docs
