### PR TITLE
Prevent captured enclosure when updating placeholder

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -41,13 +41,17 @@ const TotalCell = styled(TableCell)({
 const PlaceholderRow = ({
   line,
   onChange,
+  allocatedQuantity,
 }: {
   line?: DraftOutboundLine;
   onChange: (key: string, value: number, packSize: number) => void;
+  allocatedQuantity: number;
 }) => {
   const t = useTranslation('distribution');
   const { status } = useOutbound.document.fields('status');
-  const debouncedOnChange = useDebounceCallback(onChange, []);
+  // adding allocatedQuantity to the deps to prevent a captured enclosure - the onChange function
+  // is capturing the draftLines and using them to allocate when the placeholder changes
+  const debouncedOnChange = useDebounceCallback(onChange, [allocatedQuantity]);
   const [placeholderBuffer, setPlaceholderBuffer] = useState(
     line?.numberOfPacks ?? 0
   );
@@ -150,6 +154,7 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
       line={placeholderRow}
       onChange={onChange}
       key="placeholder-row"
+      allocatedQuantity={allocatedQuantity}
     />,
     <tr key="divider-row">
       <td colSpan={10}>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1700

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The function which updates the draft outbound lines was capturing the array of lines when it is first rendered and wasn't being updated. This means that when the placeholder row is updated, the values allocated to each row are based on the values when the table is first rendered.

To prevent this - have added the `allocatedQuantity` to the dependencies of the callback which is used by the placeholder row. When any row is updated, the onChange used by the placeholder row is updated, to reflect the current values of the rows.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As per the issue: add a new item, add a value to the placeholder. edit any other row. edit the placeholder.
Previously - this would result in `0` for all non-placeholder rows.



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
