### PR TITLE
Make barcode sync finite

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -201,12 +201,12 @@ export type AuthTokenResponse = AuthToken | AuthTokenError;
 
 export type BarcodeNode = {
   __typename: 'BarcodeNode';
+  gtin: Scalars['String'];
   id: Scalars['String'];
   itemId: Scalars['String'];
   manufacturerId?: Maybe<Scalars['String']>;
   packSize?: Maybe<Scalars['Int']>;
   parentId?: Maybe<Scalars['String']>;
-  value: Scalars['String'];
 };
 
 export type BarcodeResponse = BarcodeNode | NodeError;
@@ -827,9 +827,9 @@ export enum InitialisationStatusType {
 export type InitialiseSiteResponse = SyncErrorNode | SyncSettingsNode;
 
 export type InsertBarcodeInput = {
+  gtin: Scalars['String'];
   itemId: Scalars['String'];
   packSize?: InputMaybe<Scalars['Int']>;
-  value: Scalars['String'];
 };
 
 export type InsertBarcodeResponse = BarcodeNode;
@@ -2300,7 +2300,7 @@ export type Queries = {
    * The refresh token is returned as a cookie
    */
   authToken: AuthTokenResponse;
-  barcodeByValue: BarcodeResponse;
+  barcodeByGtin: BarcodeResponse;
   displaySettings: DisplaySettingsNode;
   /** Available without authorisation in operational and initialisation states */
   initialisationStatus: InitialisationStatusNode;
@@ -2371,9 +2371,9 @@ export type QueriesAuthTokenArgs = {
 };
 
 
-export type QueriesBarcodeByValueArgs = {
+export type QueriesBarcodeByGtinArgs = {
+  gtin: Scalars['String'];
   storeId: Scalars['String'];
-  value: Scalars['String'];
 };
 
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
@@ -44,7 +44,7 @@ export const AddFromScannerButtonComponent = ({
 
       warning(t('error.no-matching-item'))();
 
-      onAddItem({ barcode: { value, batch } });
+      onAddItem({ barcode: { gtin: value, batch } });
     }
   };
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -111,7 +111,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
 
     const input = {
       input: {
-        value: barcode.value,
+        gtin: barcode.gtin,
         itemId: currentItem?.id,
         packSize,
       },

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -23,7 +23,7 @@ import {
   InsertOutboundShipmentMutationVariables,
   Sdk,
   OutboundLineFragment,
-  BarcodeByValueQuery,
+  BarcodeByGtinQuery,
 } from './operations.generated';
 
 export type ListParams = {
@@ -155,14 +155,14 @@ const outboundParsers = {
 
 export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
   get: {
-    barcodeByValue: async (
-      value: string
-    ): Promise<BarcodeByValueQuery['barcodeByValue']> => {
-      const result = await sdk.barcodeByValue({
-        value,
+    barcodeByGtin: async (
+      gtin: string
+    ): Promise<BarcodeByGtinQuery['barcodeByGtin']> => {
+      const result = await sdk.barcodeByGtin({
+        gtin,
         storeId,
       });
-      return result?.barcodeByValue;
+      return result?.barcodeByGtin;
     },
     list: async ({
       first,
@@ -237,7 +237,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
       input: {
         itemId: string;
         packSize?: number | null;
-        value: string;
+        gtin: string;
       };
     }): Promise<string> => {
       const result =

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useBarcode.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useBarcode.ts
@@ -4,5 +4,5 @@ import { useOutboundApi } from './../utils/useOutboundApi';
 export const useBarcode = () => {
   const api = useOutboundApi();
 
-  return useMutation(api.get.barcodeByValue);
+  return useMutation(api.get.barcodeByGtin);
 };

--- a/client/packages/invoices/src/OutboundShipment/api/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/index.ts
@@ -13,5 +13,5 @@ export type DraftItem = Pick<ItemRowFragment, 'id' | 'unitName'>;
 
 export type Draft = {
   item?: DraftItem;
-  barcode?: { id?: string; value: string; batch?: string };
+  barcode?: { id?: string; gtin: string; batch?: string };
 };

--- a/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
@@ -12,7 +12,7 @@ export type OutboundFragment = { __typename: 'InvoiceNode', id: string, comment?
 
 export type OutboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, transportReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, taxPercentage?: number | null, pricing: { __typename: 'PricingNode', totalAfterTax: number, taxPercentage?: number | null } };
 
-export type BarcodeFragment = { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, value: string };
+export type BarcodeFragment = { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, gtin: string };
 
 export type InvoicesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -50,13 +50,13 @@ export type InvoiceCountsQueryVariables = Types.Exact<{
 
 export type InvoiceCountsQuery = { __typename: 'Queries', invoiceCounts: { __typename: 'InvoiceCounts', outbound: { __typename: 'OutboundInvoiceCounts', notShipped: number, created: { __typename: 'InvoiceCountsSummary', today: number, thisWeek: number } } } };
 
-export type BarcodeByValueQueryVariables = Types.Exact<{
+export type BarcodeByGtinQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
-  value: Types.Scalars['String'];
+  gtin: Types.Scalars['String'];
 }>;
 
 
-export type BarcodeByValueQuery = { __typename: 'Queries', barcodeByValue: { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, value: string } | { __typename: 'NodeError' } };
+export type BarcodeByGtinQuery = { __typename: 'Queries', barcodeByGtin: { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, gtin: string } | { __typename: 'NodeError' } };
 
 export type InsertOutboundShipmentMutationVariables = Types.Exact<{
   id: Types.Scalars['String'];
@@ -122,7 +122,7 @@ export type InsertBarcodeMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertBarcodeMutation = { __typename: 'Mutations', insertBarcode: { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, value: string } };
+export type InsertBarcodeMutation = { __typename: 'Mutations', insertBarcode: { __typename: 'BarcodeNode', id: string, itemId: string, packSize?: number | null, gtin: string } };
 
 export const PartialStockLineFragmentDoc = gql`
     fragment PartialStockLine on StockLineNode {
@@ -284,7 +284,7 @@ export const BarcodeFragmentDoc = gql`
   id
   itemId
   packSize
-  value
+  gtin
 }
     `;
 export const InvoicesDocument = gql`
@@ -372,9 +372,9 @@ export const InvoiceCountsDocument = gql`
   }
 }
     `;
-export const BarcodeByValueDocument = gql`
-    query barcodeByValue($storeId: String!, $value: String!) {
-  barcodeByValue(storeId: $storeId, value: $value) {
+export const BarcodeByGtinDocument = gql`
+    query barcodeByGtin($storeId: String!, $gtin: String!) {
+  barcodeByGtin(storeId: $storeId, gtin: $gtin) {
     ... on BarcodeNode {
       __typename
       ...Barcode
@@ -967,8 +967,8 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     invoiceCounts(variables: InvoiceCountsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoiceCountsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<InvoiceCountsQuery>(InvoiceCountsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoiceCounts', 'query');
     },
-    barcodeByValue(variables: BarcodeByValueQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<BarcodeByValueQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<BarcodeByValueQuery>(BarcodeByValueDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'barcodeByValue', 'query');
+    barcodeByGtin(variables: BarcodeByGtinQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<BarcodeByGtinQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<BarcodeByGtinQuery>(BarcodeByGtinDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'barcodeByGtin', 'query');
     },
     insertOutboundShipment(variables: InsertOutboundShipmentMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InsertOutboundShipmentMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<InsertOutboundShipmentMutation>(InsertOutboundShipmentDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'insertOutboundShipment', 'mutation');
@@ -1070,16 +1070,16 @@ export const mockInvoiceCountsQuery = (resolver: ResponseResolver<GraphQLRequest
  * @param resolver a function that accepts a captured request and may return a mocked response.
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
- * mockBarcodeByValueQuery((req, res, ctx) => {
- *   const { storeId, value } = req.variables;
+ * mockBarcodeByGtinQuery((req, res, ctx) => {
+ *   const { storeId, gtin } = req.variables;
  *   return res(
- *     ctx.data({ barcodeByValue })
+ *     ctx.data({ barcodeByGtin })
  *   )
  * })
  */
-export const mockBarcodeByValueQuery = (resolver: ResponseResolver<GraphQLRequest<BarcodeByValueQueryVariables>, GraphQLContext<BarcodeByValueQuery>, any>) =>
-  graphql.query<BarcodeByValueQuery, BarcodeByValueQueryVariables>(
-    'barcodeByValue',
+export const mockBarcodeByGtinQuery = (resolver: ResponseResolver<GraphQLRequest<BarcodeByGtinQueryVariables>, GraphQLContext<BarcodeByGtinQuery>, any>) =>
+  graphql.query<BarcodeByGtinQuery, BarcodeByGtinQueryVariables>(
+    'barcodeByGtin',
     resolver
   )
 

--- a/client/packages/invoices/src/OutboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/OutboundShipment/api/operations.graphql
@@ -162,7 +162,7 @@ fragment Barcode on BarcodeNode {
   id
   itemId
   packSize
-  value
+  gtin
 }
 
 query invoices(
@@ -253,8 +253,8 @@ query invoiceCounts($storeId: String!, $timezoneOffset: Int) {
   }
 }
 
-query barcodeByValue($storeId: String!, $value: String!) {
-  barcodeByValue(storeId: $storeId, value: $value) {
+query barcodeByGtin($storeId: String!, $gtin: String!) {
+  barcodeByGtin(storeId: $storeId, gtin: $gtin) {
     ... on BarcodeNode {
       __typename
       ...Barcode

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -230,13 +230,13 @@ impl GeneralQueries {
         store_preferences(ctx, &store_id)
     }
 
-    pub async fn barcode_by_value(
+    pub async fn barcode_by_gtin(
         &self,
         ctx: &Context<'_>,
         store_id: String,
-        value: String,
+        gtin: String,
     ) -> Result<BarcodeResponse> {
-        barcode_by_value(ctx, store_id, value)
+        barcode_by_gtin(ctx, store_id, gtin)
     }
 
     pub async fn requisition_counts(

--- a/server/graphql/general/src/mutations/barcode.rs
+++ b/server/graphql/general/src/mutations/barcode.rs
@@ -13,7 +13,7 @@ use service::{
 #[derive(InputObject)]
 #[graphql(name = "InsertBarcodeInput")]
 pub struct BarcodeInput {
-    pub value: String,
+    pub gtin: String,
     pub item_id: String,
     pub pack_size: Option<i32>,
 }
@@ -32,7 +32,7 @@ pub struct InsertBarcodeError {
 impl BarcodeInput {
     pub fn to_domain(&self) -> service::barcode::BarcodeInput {
         service::barcode::BarcodeInput {
-            value: self.value.clone(),
+            gtin: self.gtin.clone(),
             item_id: self.item_id.clone(),
             pack_size: self.pack_size,
         }

--- a/server/graphql/general/src/queries/barcode.rs
+++ b/server/graphql/general/src/queries/barcode.rs
@@ -13,10 +13,10 @@ pub enum BarcodeResponse {
     Response(BarcodeNode),
 }
 
-pub fn barcode_by_value(
+pub fn barcode_by_gtin(
     ctx: &Context<'_>,
     store_id: String,
-    value: String,
+    gtin: String,
 ) -> Result<BarcodeResponse> {
     let user = validate_auth(
         ctx,
@@ -30,7 +30,7 @@ pub fn barcode_by_value(
     let service_context = service_provider.context(store_id.clone(), user.user_id)?;
     let barcode_option = service_provider
         .barcode_service
-        .get_barcode_by_value(&service_context, &value)
+        .get_barcode_by_gtin(&service_context, &gtin)
         .map_err(StandardGraphqlError::from_repository_error)?;
 
     let response = match barcode_option {

--- a/server/graphql/tests/report_default_queries.rs
+++ b/server/graphql/tests/report_default_queries.rs
@@ -45,25 +45,21 @@ mod tests {
         .await;
 
         // invoice
-
-        // TODO: fix this error
-        // "message": "\"UNKNOWN\" (\"\\\"\\\\\\\"no such column: barcode.gtin\\\\\\\"\\\"\")",
-
-        // let query = get_default_gql_query(DefaultQuery::Invoice).query;
-        // let mock_invoice = mock_outbound_shipment_a();
-        // let expected = json!({
-        //   "invoice": {
-        //     "id": mock_invoice.id
-        //   },
-        //   "store": {
-        //     "id": mock_invoice.store_id
-        //   }
-        // });
-        // let variables = Some(json!({
-        //     "storeId": mock_invoice.store_id,
-        //     "dataId": mock_invoice.id,
-        // }));
-        // assert_graphql_query!(&settings, &query, &variables, &expected, None);
+        let query = get_default_gql_query(DefaultQuery::Invoice).query;
+        let mock_invoice = mock_outbound_shipment_a();
+        let expected = json!({
+          "invoice": {
+            "id": mock_invoice.id
+          },
+          "store": {
+            "id": mock_invoice.store_id
+          }
+        });
+        let variables = Some(json!({
+            "storeId": mock_invoice.store_id,
+            "dataId": mock_invoice.id,
+        }));
+        assert_graphql_query!(&settings, &query, &variables, &expected, None);
 
         // stocktake
         let query = get_default_gql_query(DefaultQuery::Stocktake).query;

--- a/server/graphql/tests/report_default_queries.rs
+++ b/server/graphql/tests/report_default_queries.rs
@@ -45,21 +45,25 @@ mod tests {
         .await;
 
         // invoice
-        let query = get_default_gql_query(DefaultQuery::Invoice).query;
-        let mock_invoice = mock_outbound_shipment_a();
-        let expected = json!({
-          "invoice": {
-            "id": mock_invoice.id
-          },
-          "store": {
-            "id": mock_invoice.store_id
-          }
-        });
-        let variables = Some(json!({
-            "storeId": mock_invoice.store_id,
-            "dataId": mock_invoice.id,
-        }));
-        assert_graphql_query!(&settings, &query, &variables, &expected, None);
+
+        // TODO: fix this error
+        // "message": "\"UNKNOWN\" (\"\\\"\\\\\\\"no such column: barcode.gtin\\\\\\\"\\\"\")",
+
+        // let query = get_default_gql_query(DefaultQuery::Invoice).query;
+        // let mock_invoice = mock_outbound_shipment_a();
+        // let expected = json!({
+        //   "invoice": {
+        //     "id": mock_invoice.id
+        //   },
+        //   "store": {
+        //     "id": mock_invoice.store_id
+        //   }
+        // });
+        // let variables = Some(json!({
+        //     "storeId": mock_invoice.store_id,
+        //     "dataId": mock_invoice.id,
+        // }));
+        // assert_graphql_query!(&settings, &query, &variables, &expected, None);
 
         // stocktake
         let query = get_default_gql_query(DefaultQuery::Stocktake).query;

--- a/server/graphql/types/src/types/barcode.rs
+++ b/server/graphql/types/src/types/barcode.rs
@@ -20,8 +20,8 @@ impl BarcodeNode {
         &self.row().id
     }
 
-    pub async fn value(&self) -> &str {
-        &self.row().value
+    pub async fn gtin(&self) -> &str {
+        &self.row().gtin
     }
 
     pub async fn item_id(&self) -> &str {
@@ -111,7 +111,7 @@ mod test {
                         barcode_row: {
                             inline_init(|r: &mut BarcodeRow| {
                                 r.id = "CB81F6CD62C1476F9411362053D49E84".to_string();
-                                r.value = "0123456789".to_string();
+                                r.gtin = "0123456789".to_string();
                                 r.item_id = "AA460A207402434A89B1F6EEAC08DA43".to_string();
                                 r.pack_size = Some(1);
                             })
@@ -125,7 +125,7 @@ mod test {
             "testQuery": {
                 "__typename": "BarcodeNode",
                 "id": "CB81F6CD62C1476F9411362053D49E84",
-                "value": "0123456789",
+                "gtin": "0123456789",
                 "itemId": "AA460A207402434A89B1F6EEAC08DA43",
                 "packSize": 1
             }
@@ -137,7 +137,7 @@ mod test {
             testQuery {
                 __typename
                id
-               value
+               gtin
                itemId
                packSize
             }

--- a/server/repository/src/db_diesel/barcode.rs
+++ b/server/repository/src/db_diesel/barcode.rs
@@ -19,7 +19,7 @@ pub struct Barcode {
 #[derive(Clone, PartialEq, Debug)]
 pub struct BarcodeFilter {
     pub id: Option<EqualFilter<String>>,
-    pub value: Option<EqualFilter<String>>,
+    pub gtin: Option<EqualFilter<String>>,
     pub item_id: Option<EqualFilter<String>>,
     pub pack_size: Option<EqualFilter<i32>>,
 }
@@ -63,11 +63,11 @@ impl<'a> BarcodeRepository<'a> {
                     apply_sort_no_case!(query, sort, barcode_dsl::id)
                 }
                 BarcodeSortField::Barcode => {
-                    apply_sort_no_case!(query, sort, barcode_dsl::value)
+                    apply_sort_no_case!(query, sort, barcode_dsl::gtin)
                 }
             }
         } else {
-            query = query.order(barcode_dsl::value.asc())
+            query = query.order(barcode_dsl::gtin.asc())
         }
 
         let result = query
@@ -105,7 +105,7 @@ fn create_filtered_query(filter: Option<BarcodeFilter>) -> BoxedLogQuery {
 
     if let Some(filter) = filter {
         apply_equal_filter!(query, filter.id, barcode_dsl::id);
-        apply_equal_filter!(query, filter.value, barcode_dsl::value);
+        apply_equal_filter!(query, filter.gtin, barcode_dsl::gtin);
         apply_equal_filter!(query, filter.item_id, barcode_dsl::item_id);
         apply_equal_filter!(query, filter.pack_size, barcode_dsl::pack_size);
     }
@@ -121,7 +121,7 @@ impl BarcodeFilter {
     pub fn new() -> BarcodeFilter {
         BarcodeFilter {
             id: None,
-            value: None,
+            gtin: None,
             item_id: None,
             pack_size: None,
         }
@@ -132,8 +132,8 @@ impl BarcodeFilter {
         self
     }
 
-    pub fn value(mut self, filter: EqualFilter<String>) -> Self {
-        self.value = Some(filter);
+    pub fn gtin(mut self, filter: EqualFilter<String>) -> Self {
+        self.gtin = Some(filter);
         self
     }
 

--- a/server/repository/src/db_diesel/barcode_row.rs
+++ b/server/repository/src/db_diesel/barcode_row.rs
@@ -130,7 +130,7 @@ impl<'a> BarcodeRowRepository<'a> {
 
 #[cfg(test)]
 mod test {
-    use util::inline_init;
+    use util::{inline_init, uuid::uuid};
 
     use crate::{mock::MockDataInserts, test_db::setup_all, BarcodeRow, BarcodeRowRepository};
 

--- a/server/repository/src/db_diesel/requisition/requisition_row.rs
+++ b/server/repository/src/db_diesel/requisition/requisition_row.rs
@@ -43,7 +43,7 @@ table! {
 
 table! {
     #[sql_name = "requisition"]
-    requistion_is_sync_update (id) {
+    requisition_is_sync_update (id) {
         id -> Text,
         is_sync_update -> Bool,
     }
@@ -169,8 +169,8 @@ impl<'a> RequisitionRowRepository<'a> {
     }
 
     fn toggle_is_sync_update(&self, id: &str, is_sync_update: bool) -> Result<(), RepositoryError> {
-        diesel::update(requistion_is_sync_update::table.find(id))
-            .set(requistion_is_sync_update::dsl::is_sync_update.eq(is_sync_update))
+        diesel::update(requisition_is_sync_update::table.find(id))
+            .set(requisition_is_sync_update::dsl::is_sync_update.eq(is_sync_update))
             .execute(&self.connection.connection)?;
 
         Ok(())
@@ -221,9 +221,9 @@ impl<'a> RequisitionRowRepository<'a> {
 
     #[cfg(test)]
     fn find_is_sync_update_by_id(&self, id: &str) -> Result<Option<bool>, RepositoryError> {
-        let result = requistion_is_sync_update::table
+        let result = requisition_is_sync_update::table
             .find(id)
-            .select(requistion_is_sync_update::dsl::is_sync_update)
+            .select(requisition_is_sync_update::dsl::is_sync_update)
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
@@ -277,7 +277,7 @@ mod test {
         .await;
 
         let repo = RequisitionRowRepository::new(&connection);
-        // Two rows, to make sure is_sync_udpate update only affects one row
+        // Two rows, to make sure is_sync_update update only affects one row
         let row = mock_request_draft_requisition_all_fields().requisition;
         let row2 = mock_response_draft_requisition_all_fields().requisition;
         // First insert

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -310,7 +310,7 @@ impl StockLine {
     pub fn barcode(&self) -> Option<&str> {
         self.barcode_row
             .as_ref()
-            .map(|barcode_row| barcode_row.value.as_str())
+            .map(|barcode_row| barcode_row.gtin.as_str())
     }
 }
 

--- a/server/repository/src/migrations/v1_01_12/barcode_sync.rs
+++ b/server/repository/src/migrations/v1_01_12/barcode_sync.rs
@@ -5,7 +5,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         connection,
         r#"
         ALTER TABLE barcode ADD is_sync_update bool NOT NULL DEFAULT False;
-        ALTER TABLE public.barcode RENAME COLUMN value TO gtin;
+        ALTER TABLE barcode RENAME COLUMN value TO gtin;
         "#
     )?;
 

--- a/server/repository/src/migrations/v1_01_12/barcode_sync.rs
+++ b/server/repository/src/migrations/v1_01_12/barcode_sync.rs
@@ -1,0 +1,13 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        ALTER TABLE barcode ADD is_sync_update bool NOT NULL DEFAULT False;
+        ALTER TABLE public.barcode RENAME COLUMN value TO gtin;
+        "#
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_01_12/barcode_sync.rs
+++ b/server/repository/src/migrations/v1_01_12/barcode_sync.rs
@@ -9,5 +9,48 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         "#
     )?;
 
+    #[cfg(feature = "postgres")]
+    {
+        sql!(
+            connection,
+            r#"CREATE OR REPLACE FUNCTION upsert_barcode_changelog()
+        RETURNS trigger
+        LANGUAGE plpgsql
+       AS $function$
+         BEGIN
+           INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
+                 VALUES ('barcode', NEW.id, 'UPSERT', NEW.is_sync_update);
+           -- The return value is required, even though it is ignored for a row-level AFTER trigger
+           RETURN NULL;
+         END;
+       $function$
+       ;"#
+        )?;
+    }
+    #[cfg(not(feature = "postgres"))]
+    {
+        sql!(
+            connection,
+            r#"
+                DROP TRIGGER barcode_insert_trigger;
+                DROP TRIGGER barcode_update_trigger;
+                "#
+        )?;
+
+        for operation in vec!["insert", "update"] {
+            sql!(
+                connection,
+                r#"
+                    CREATE TRIGGER barcode_{operation}_trigger
+                    AFTER INSERT ON barcode
+                    BEGIN
+                        INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
+                        VALUES ("barcode", NEW.id, "UPSERT", NEW.is_sync_update);
+                    END;
+                "#
+            )?;
+        }
+    }
+
     Ok(())
 }

--- a/server/repository/src/migrations/v1_01_12/barcode_sync.rs
+++ b/server/repository/src/migrations/v1_01_12/barcode_sync.rs
@@ -42,7 +42,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                 connection,
                 r#"
                     CREATE TRIGGER barcode_{operation}_trigger
-                    AFTER INSERT ON barcode
+                    AFTER {operation} ON barcode
                     BEGIN
                         INSERT INTO changelog (table_name, record_id, row_action, is_sync_update)
                         VALUES ("barcode", NEW.id, "UPSERT", NEW.is_sync_update);

--- a/server/repository/src/migrations/v1_01_12/mod.rs
+++ b/server/repository/src/migrations/v1_01_12/mod.rs
@@ -1,5 +1,6 @@
 use super::{version::Version, Migration};
 
+mod barcode_sync;
 mod local_authorisation;
 mod location_movement_triggers;
 mod stock_line_barcode_id;
@@ -16,6 +17,7 @@ impl Migration for V1_01_12 {
         location_movement_triggers::migrate(connection)?;
         stock_line_barcode_id::migrate(connection)?;
         local_authorisation::migrate(connection)?;
+        barcode_sync::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/mock/barcode.rs
+++ b/server/repository/src/mock/barcode.rs
@@ -3,7 +3,7 @@ use crate::BarcodeRow;
 pub fn barcode_a() -> BarcodeRow {
     BarcodeRow {
         id: String::from("barcode_a"),
-        value: String::from("0123456789"),
+        gtin: String::from("0123456789"),
         item_id: String::from("item_a"),
         manufacturer_id: Some(String::from("manufacturer_a")),
         pack_size: Some(1),
@@ -14,7 +14,7 @@ pub fn barcode_a() -> BarcodeRow {
 pub fn barcode_b() -> BarcodeRow {
     BarcodeRow {
         id: String::from("barcode_b"),
-        value: String::from("9876543210"),
+        gtin: String::from("9876543210"),
         item_id: String::from("item_b"),
         manufacturer_id: Some(String::from("manufacturer_a")),
         pack_size: Some(1),

--- a/server/service/src/barcode.rs
+++ b/server/service/src/barcode.rs
@@ -13,13 +13,13 @@ pub const MIN_LIMIT: u32 = 1;
 
 pub struct InsertResult {
     pub id: String,
-    pub value: String,
+    pub gtin: String,
     pub item_id: String,
     pub pack_size: Option<i32>,
 }
 
 pub struct BarcodeInput {
-    pub value: String,
+    pub gtin: String,
     pub item_id: String,
     pub pack_size: Option<i32>,
 }
@@ -67,15 +67,15 @@ pub trait BarcodeServiceTrait: Sync + Send {
         })
     }
 
-    fn get_barcode_by_value(
+    fn get_barcode_by_gtin(
         &self,
         ctx: &ServiceContext,
-        value: &str,
+        gtin: &str,
     ) -> Result<Option<Barcode>, RepositoryError> {
         let repository = BarcodeRepository::new(&ctx.connection);
 
         Ok(repository
-            .query_by_filter(BarcodeFilter::new().value(EqualFilter::equal_to(value)))?
+            .query_by_filter(BarcodeFilter::new().gtin(EqualFilter::equal_to(gtin)))?
             .pop())
     }
 
@@ -91,7 +91,7 @@ pub trait BarcodeServiceTrait: Sync + Send {
                 let barcode_repository = BarcodeRepository::new(con);
                 let new_barcode = BarcodeRow {
                     id: uuid(),
-                    value: barcode.value.clone(),
+                    gtin: barcode.gtin.clone(),
                     item_id: barcode.item_id.clone(),
                     pack_size: barcode.pack_size,
                     manufacturer_id: None,
@@ -114,7 +114,7 @@ fn check_barcode_does_not_exist(
     connection: &StorageConnection,
     barcode: &BarcodeInput,
 ) -> Result<bool, RepositoryError> {
-    let mut filter = BarcodeFilter::new().value(EqualFilter::equal_to(&barcode.value));
+    let mut filter = BarcodeFilter::new().gtin(EqualFilter::equal_to(&barcode.gtin));
 
     if let Some(pack_size) = barcode.pack_size {
         filter = filter.pack_size(EqualFilter::equal_to_i32(pack_size))

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -197,10 +197,10 @@ fn generate_location_movement(
 fn generate_barcode_row(
     connection: &StorageConnection,
     existing: StockLineRow,
-    value: String,
+    gtin: String,
 ) -> Result<Option<BarcodeRow>, RepositoryError> {
     // for an empty string, simply unlink the barcode
-    if value.is_empty() {
+    if gtin.is_empty() {
         return Ok(None);
     }
 
@@ -210,16 +210,16 @@ fn generate_barcode_row(
 
     let barcode_rows = BarcodeRepository::new(connection).query_by_filter(filter)?;
     let barcode_row = match barcode_rows.first() {
-        // barcode already exists - persist the value change if there is one
+        // barcode already exists - persist the gtin change if there is one
         Some(row) => BarcodeRow {
-            value,
+            gtin,
             ..row.barcode_row.clone()
         },
         None => {
             // barcode does not exist - create a new one
             BarcodeRow {
                 id: uuid(),
-                value,
+                gtin,
                 item_id: existing.item_id,
                 pack_size: Some(existing.pack_size),
                 ..Default::default()

--- a/server/service/src/sync/test/test_data/barcode.rs
+++ b/server/service/src/sync/test/test_data/barcode.rs
@@ -35,7 +35,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
             BARCODE_1,
             PullUpsertRecord::Barcode(BarcodeRow {
                 id: BARCODE_1.0.to_string(),
-                value: "0123456789".to_string(),
+                gtin: "0123456789".to_string(),
                 item_id: "item_a".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),
@@ -47,7 +47,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
             BARCODE_2,
             PullUpsertRecord::Barcode(BarcodeRow {
                 id: BARCODE_2.0.to_string(),
-                value: "9876543210".to_string(),
+                gtin: "9876543210".to_string(),
                 item_id: "item_b".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),
@@ -64,7 +64,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
             table_name: LegacyTableName::BARCODE.to_string(),
             push_data: json!(LegacyBarcodeRow {
                 id: BARCODE_1.0.to_string(),
-                value: "0123456789".to_string(),
+                gtin: "0123456789".to_string(),
                 item_id: "item_a".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),
@@ -76,7 +76,7 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
             table_name: LegacyTableName::BARCODE.to_string(),
             push_data: json!(LegacyBarcodeRow {
                 id: BARCODE_2.0.to_string(),
-                value: "9876543210".to_string(),
+                gtin: "9876543210".to_string(),
                 item_id: "item_b".to_string(),
                 manufacturer_id: Some("manufacturer_a".to_string()),
                 pack_size: Some(1),

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -206,7 +206,7 @@ impl PullUpsertRecord {
                 InventoryAdjustmentReasonRowRepository::new(con).upsert_one(record)
             }
             StorePreference(record) => StorePreferenceRowRepository::new(con).upsert_one(record),
-            Barcode(record) => BarcodeRowRepository::new(con).upsert_one(record),
+            Barcode(record) => BarcodeRowRepository::new(con).sync_upsert_one(record),
         }
     }
 }

--- a/server/service/src/sync/translations/barcode.rs
+++ b/server/service/src/sync/translations/barcode.rs
@@ -23,7 +23,7 @@ pub struct LegacyBarcodeRow {
     #[serde(rename = "ID")]
     pub id: String,
     #[serde(rename = "barcode")]
-    pub value: String,
+    pub gtin: String,
     #[serde(rename = "itemID")]
     pub item_id: String,
     #[serde(rename = "manufacturerID")]
@@ -54,7 +54,7 @@ impl SyncTranslation for BarcodeTranslation {
         };
         let LegacyBarcodeRow {
             id,
-            value,
+            gtin,
             item_id,
             manufacturer_id,
             pack_size,
@@ -63,7 +63,7 @@ impl SyncTranslation for BarcodeTranslation {
 
         let result = BarcodeRow {
             id,
-            value,
+            gtin,
             item_id,
             manufacturer_id,
             pack_size,
@@ -86,7 +86,7 @@ impl SyncTranslation for BarcodeTranslation {
 
         let BarcodeRow {
             id,
-            value,
+            gtin,
             item_id,
             manufacturer_id,
             pack_size,
@@ -100,7 +100,7 @@ impl SyncTranslation for BarcodeTranslation {
 
         let legacy_row = LegacyBarcodeRow {
             id,
-            value,
+            gtin,
             item_id,
             manufacturer_id,
             pack_size,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1748 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Implement the `is_sync_update` for barcodes.
Also renames the `value` column to `gtin`

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As per the issue - running two sites from the same datafile. Create a barcode and sync it around.



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
