### PR TITLE
1761 [User Training Feedback] Internal Order list view: new column for authorised quantity in packs (same as requested packs) 

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -181,6 +181,7 @@
   "label.remaining-to-supply": "Remaining",
   "label.requested-quantity": "Requested",
   "label.requested-packs": "Requested packs",
+  "label.approved-packs": "Approved packs",
   "label.requested-number-packs": "Requested number of packs (approx)",
   "label.requisition": "Requisition",
   "label.requisition-general": "General",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -60,6 +60,7 @@
   "heading.expiring-stock": "Expiration des stocks",
   "heading.select-items": "Choisir articles",
   "heading.settings": "Réglages",
+  "label.approved-packs": "Quantité Autorisée (emb.)",
   "label.actions": "Actions",
   "label.address": "Adresse",
   "label.allocated": "Alloué(e)",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -136,6 +136,18 @@ export const useRequestColumns = () => {
         rowData.linkedRequisitionLine?.approvedQuantity,
     });
     columnDefinitions.push({
+      key: 'approvedNumPacks',
+      label: 'label.approved-packs',
+      align: ColumnAlign.Right,
+      accessor: ({ rowData }) =>
+        formatNumber.round(
+          rowData.linkedRequisitionLine?.approvedQuantity ??
+            0 / rowData.item.defaultPackSize,
+          2
+        ),
+      sortable: false,
+    });
+    columnDefinitions.push({
       key: 'approvalComment',
       label: 'label.approval-comment',
       sortable: false,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1761

# 👩🏻‍💻 What does this PR do? 
Add approved quantity of packs to Internal Order detail view
