### PR TITLE
#1758 Stocktake items filter

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   DatePickerInput,
   Formatter,
   InfoPanel,
+  SearchBar,
 } from '@openmsupply-client/common';
 import { useStocktake } from '../api';
 
@@ -21,6 +22,7 @@ export const Toolbar: FC = () => {
   const { isLocked, stocktakeDate, description, update } =
     useStocktake.document.fields(['isLocked', 'description', 'stocktakeDate']);
   const onDelete = useStocktake.line.deleteSelected();
+  const { itemFilter, setItemFilter } = useStocktake.line.rows();
   const [descriptionBuffer, setDescriptionBuffer] = useBufferState(description);
   const infoMessage = isLocked
     ? t('messages.on-hold-stock-take')
@@ -66,7 +68,15 @@ export const Toolbar: FC = () => {
           {isDisabled && <InfoPanel message={infoMessage} />}
         </Grid>
 
-        <Grid item>
+        <Grid item display="flex" gap={1} justifyContent="flex-end">
+          <SearchBar
+            placeholder={t('placeholder.filter-items')}
+            value={itemFilter}
+            onChange={newValue => {
+              setItemFilter(newValue);
+            }}
+            debounceTime={0}
+          />
           <DropdownMenu disabled={isDisabled} label={t('label.actions')}>
             <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
               {t('button.delete-lines')}

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -1,8 +1,31 @@
 import { useMemo } from 'react';
-import { SortUtils, useUrlQueryParams } from '@openmsupply-client/common';
+import {
+  ItemNode,
+  RegexUtils,
+  SortUtils,
+  useUrlQuery,
+  useUrlQueryParams,
+} from '@openmsupply-client/common';
 import { useStocktakeColumns } from '../../../DetailView';
 import { useStocktakeLines } from './useStocktakeLines';
 import { useStocktakeItems } from './useStocktakeItems';
+
+const useItemFilter = () => {
+  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['codeOrName'] });
+  return {
+    itemFilter: urlQuery.codeOrName ?? '',
+    setItemFilter: (itemFilter: string) =>
+      updateQuery({ codeOrName: itemFilter }),
+  };
+};
+
+const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+  const filter = RegexUtils.escapeChars(itemFilter);
+  return (
+    RegexUtils.includes(filter, name ?? '') ||
+    RegexUtils.includes(filter, code ?? '')
+  );
+};
 
 export const useStocktakeRows = (isGrouped = true) => {
   const {
@@ -11,6 +34,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'desc' } });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
+  const { itemFilter, setItemFilter } = useItemFilter();
   const columns = useStocktakeColumns({
     onChangeSortBy: updateSortQuery,
     sortBy,
@@ -23,8 +47,12 @@ export const useStocktakeRows = (isGrouped = true) => {
       currentColumn?.getSortValue,
       !!sortBy.isDesc
     );
-    return items?.sort(sorter);
-  }, [items, sortBy.key, sortBy.isDesc]);
+    return items
+      ?.filter(item => {
+        return matchItem(itemFilter, item.item as ItemNode);
+      })
+      ?.sort(sorter);
+  }, [items, sortBy.key, sortBy.isDesc, itemFilter]);
 
   const sortedLines = useMemo(() => {
     const currentColumn = columns.find(({ key }) => key === sortBy.key);
@@ -33,8 +61,12 @@ export const useStocktakeRows = (isGrouped = true) => {
       currentColumn?.getSortValue,
       !!sortBy.isDesc
     );
-    return lines?.sort(sorter);
-  }, [lines, sortBy.key, sortBy.isDesc]);
+    return lines
+      ?.filter(line => {
+        return matchItem(itemFilter, line.item);
+      })
+      ?.sort(sorter);
+  }, [lines, sortBy.key, sortBy.isDesc, itemFilter]);
 
   const rows = isGrouped ? sortedItems : sortedLines;
 
@@ -44,5 +76,7 @@ export const useStocktakeRows = (isGrouped = true) => {
     items: sortedItems,
     onChangeSortBy: updateSortQuery,
     sortBy,
+    itemFilter,
+    setItemFilter,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1758

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Adds filter to Stocktake items/lines. Have basically just copied it exactly from the Internal Order item filter. As with that one, it doesn't change the database query, it just filters the full list of results (since line queries aren't paginated).

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Go to a Stocktake detail view. Check the filter works.