### PR TITLE
Return master lists for outbound shipments

### DIFF
--- a/client/packages/inventory/src/Stocktake/ListView/CreateStocktakeButton.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/CreateStocktakeButton.tsx
@@ -40,11 +40,18 @@ export const CreateStocktakeButton: React.FC<{
 }> = ({ modalController }) => {
   const t = useTranslation('inventory');
   const { mutateAsync, isLoading: isSaving } = useStocktake.document.insert();
+  const { user, storeId } = useAuthContext();
   const {
     data: masterListData,
     isLoading: isLoadingMasterLists,
     mutate: fetchMasterLists,
-  } = useMasterList.document.listAll({ key: 'name', direction: 'asc' });
+  } = useMasterList.document.listAll(
+    {
+      key: 'name',
+      direction: 'asc',
+    },
+    { existsForStoreId: { equalTo: storeId } }
+  );
   const {
     data: locationData,
     isLoading: isLoadingLocations,
@@ -54,7 +61,6 @@ export const CreateStocktakeButton: React.FC<{
     key: 'expiryDate',
     direction: 'asc',
   });
-  const { user } = useAuthContext();
   const { localisedDate } = useFormatDateTime();
   const [createStocktakeArgs, setCreateStocktakeArgs] =
     useState<CreateStocktakeArgs>(DEFAULT_ARGS);

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AddFromMasterListButton.tsx
@@ -4,6 +4,7 @@ import {
   useTranslation,
   useToggle,
   PlusCircleIcon,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { MasterListSearchModal } from '@openmsupply-client/system';
 import { useRequest } from '../../api';
@@ -14,6 +15,7 @@ export const AddFromMasterListButtonComponent = () => {
   const isProgram = useRequest.utils.isProgram();
   const { addFromMasterList } = useRequest.utils.addFromMasterList();
   const modalController = useToggle();
+  const { storeId } = useAuthContext();
 
   return (
     <>
@@ -24,7 +26,7 @@ export const AddFromMasterListButtonComponent = () => {
           modalController.toggleOff();
           addFromMasterList(masterList);
         }}
-        filterBy={{ isProgram: false }}
+        filterBy={{ isProgram: false, existsForStoreId: { equalTo: storeId } }}
       />
       <ButtonWithIcon
         disabled={isDisabled || isProgram}

--- a/client/packages/system/src/MasterList/api/api.ts
+++ b/client/packages/system/src/MasterList/api/api.ts
@@ -38,17 +38,17 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
     },
     listAll: async ({
       sortBy,
-      filterBy,
+      filter,
     }: {
       sortBy: SortBy<MasterListRowFragment>;
-      filterBy?: FilterByWithBoolean;
+      filter?: FilterByWithBoolean;
     }) => {
       const key = masterListParser.toSort(sortBy);
       const desc = !!sortBy.isDesc;
       const result = await sdk.masterLists({
         key,
         desc,
-        filter: { ...filterBy, existsForStoreId: { equalTo: storeId } },
+        filter,
         storeId,
       });
       return result?.masterLists;

--- a/client/packages/system/src/MasterList/api/hooks/document/useMasterListsAll.ts
+++ b/client/packages/system/src/MasterList/api/hooks/document/useMasterListsAll.ts
@@ -12,7 +12,7 @@ export const useMasterListsAll = (
 ) => {
   const api = useMasterListApi();
   const result = useMutation(api.keys.sortedList(sortBy, filterBy), () =>
-    api.get.listAll({ sortBy, filterBy })
+    api.get.listAll({ sortBy, filter: filterBy })
   );
   return {
     ...result,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1780 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The outbound shipment master list query was using a filter that had `existsForName` with the customer name, and `existsForStore` for the current store. These two things cannot exist together, and no lists are returned.

The change came in because the internal order filter was incorrect.
Have updated internal orders and outbound shipments and tested.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Outbound shipments should show all lists which are valid in the customer store.
Internal orders show all lists which are valid in the current store and are not programs.
Stocktakes show all lists which are valid in the current store.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
