### PR TITLE
Ask user about fingerprint change

### DIFF
--- a/client/packages/electron/src/electron.ts
+++ b/client/packages/electron/src/electron.ts
@@ -275,8 +275,6 @@ app.addListener(
       // Update stored fingerprint
       storedFingerprint = certificate.fingerprint;
       store.set(identifier, storedFingerprint);
-
-      return callback(false);
     }
 
     // storedFingerprint did not exist or it matched certificate fingerprint


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1783 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Prompts the user if there is a fingerprint change and asks them to accept it. This is how it looks in development mode on a mac:

<img width="581" alt="Screenshot 2023-05-16 at 3 26 00 PM" src="https://github.com/openmsupply/open-msupply/assets/9192912/2b6b10d1-60b7-418f-8250-35168f7314bd">

Windows version is being built.

For reference - the [message box options](https://www.electronjs.org/docs/latest/api/dialog#dialogshowmessageboxbrowserwindow-options)


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Just tested on mac, with a windows server. 
Connected, then stopped the server, changed the cert and started the server again.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Should mention this somewhere. not public docs but.
