### PR TITLE
Invalidate program settings on delete

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useRequestApi.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useRequestApi.ts
@@ -11,7 +11,8 @@ export const useRequestApi = () => {
     sortedList: (sortBy: SortBy<RequestRowFragment>) =>
       [...keys.list(), sortBy] as const,
     chartData: (lineId: string) => [...keys.base(), storeId, lineId] as const,
-    programSettings: () => ['programSettings', storeId] as const,
+    programSettings: () =>
+      [...keys.base(), 'programSettings', storeId] as const,
   };
 
   const { client } = useGql();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1810 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Just changed the cache key for program settings, so that it depends on the internal order base key, which is invalidated on successful delete of an internal order.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
- Create an internal order using a program
- Delete it
- Create a new one using the same period


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
