### PR TITLE
1805 and 1811 barcode sync and foreign key issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/general/src/mutations/barcode.rs
+++ b/server/graphql/general/src/mutations/barcode.rs
@@ -57,7 +57,7 @@ pub fn insert_barcode(
     map_response(
         service_provider
             .barcode_service
-            .insert_barcode(&service_context, &input.to_domain()),
+            .upsert_barcode(&service_context, input.to_domain()),
     )
 }
 
@@ -69,7 +69,6 @@ pub fn map_response(from: Result<Barcode, ServiceError>) -> Result<InsertRespons
             let formatted_error = format!("{:#?}", error);
 
             let graphql_error = match error {
-                ServiceError::BarcodeAlreadyExists => BadUserInput(formatted_error),
                 ServiceError::InternalError(err) => InternalError(err),
                 ServiceError::DatabaseError(_) => InternalError(formatted_error),
                 ServiceError::InvalidItem => BadUserInput(formatted_error),

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateInput {
     pub expiry_date: Option<NaiveDate>,
     pub batch: Option<String>,
     pub on_hold: Option<bool>,
-    pub barcode: Option<String>,
+    pub barcode_gtin: Option<String>,
 }
 
 #[derive(Interface)]
@@ -87,7 +87,7 @@ impl UpdateInput {
             expiry_date,
             batch,
             on_hold,
-            barcode,
+            barcode_gtin,
         } = self;
 
         ServiceInput {
@@ -98,7 +98,7 @@ impl UpdateInput {
             expiry_date,
             batch,
             on_hold,
-            barcode,
+            barcode_gtin,
         }
     }
 }
@@ -264,7 +264,7 @@ mod test {
                     expiry_date: None,
                     batch: None,
                     on_hold: None,
-                    barcode: None,
+                    barcode_gtin: None,
                 }
             );
             Ok(StockLine {

--- a/server/repository/src/db_diesel/barcode.rs
+++ b/server/repository/src/db_diesel/barcode.rs
@@ -77,25 +77,6 @@ impl<'a> BarcodeRepository<'a> {
 
         Ok(result.into_iter().map(to_domain).collect())
     }
-
-    #[cfg(feature = "postgres")]
-    pub fn upsert_one(&self, row: &BarcodeRow) -> Result<(), RepositoryError> {
-        diesel::insert_into(barcode_dsl::barcode)
-            .values(row)
-            .on_conflict(barcode_dsl::id)
-            .do_update()
-            .set(row)
-            .execute(&self.connection.connection)?;
-        Ok(())
-    }
-
-    #[cfg(not(feature = "postgres"))]
-    pub fn upsert_one(&self, row: &BarcodeRow) -> Result<(), RepositoryError> {
-        diesel::replace_into(barcode_dsl::barcode)
-            .values(row)
-            .execute(&self.connection.connection)?;
-        Ok(())
-    }
 }
 
 type BoxedLogQuery = barcode::BoxedQuery<'static, DBType>;

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -7,6 +7,7 @@ mod v1_01_05;
 mod v1_01_11;
 mod v1_01_12;
 mod v1_01_13;
+mod v1_01_14;
 mod version;
 pub(crate) use self::types::*;
 use self::v1_00_04::V1_00_04;
@@ -70,6 +71,7 @@ pub fn migrate(
         Box::new(v1_01_11::V1_01_11),
         Box::new(v1_01_12::V1_01_12),
         Box::new(v1_01_13::V1_01_13),
+        Box::new(v1_01_14::V1_01_14),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_01_14/barcode_changelog.rs
+++ b/server/repository/src/migrations/v1_01_14/barcode_changelog.rs
@@ -1,0 +1,187 @@
+use crate::StorageConnection;
+use diesel::prelude::*;
+
+#[cfg(feature = "postgres")]
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    Ok(())
+}
+
+table! {
+    changelog (id) {
+        id -> Text,
+        record_id -> Text,
+        table_name -> Text,
+        row_action -> Text,
+    }
+}
+
+table! {
+    barcode (id) {
+        id -> Text,
+        gtin -> Text,
+        item_id -> Text,
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    // Update changelogs for barcodes
+    use self::barcode::dsl as barcode_dsl;
+    use self::changelog::dsl as changelog_dsl;
+
+    let barcode_ids = barcode_dsl::barcode
+        .select(barcode::id)
+        .load::<String>(&connection.connection)?;
+
+    // Delete all changelogs for able barcode where record_id is not found
+    // in barcode table and changelog is of upsert type
+    diesel::delete(changelog_dsl::changelog)
+        .filter(
+            changelog_dsl::table_name
+                .eq("barcode")
+                .and(changelog_dsl::row_action.eq("UPSERT"))
+                .and(changelog_dsl::record_id.ne_all(barcode_ids)),
+        )
+        .execute(&connection.connection)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_01_14() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+    use diesel::RunQueryDsl;
+    // For data migrations we want to insert data then do the migration, thus setup with version - 1
+    // Then insert data and upgrade to this version
+
+    let previous_version = v1_01_13::V1_01_13.version();
+    let version = super::V1_01_14.version();
+
+    // Migrate to version - 1
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(previous_version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    use barcode::dsl as barcode_dsl;
+    use changelog::dsl as changelog_dsl;
+
+    sql!(
+        &connection,
+        r#"
+        INSERT INTO item 
+        (id, name, code, default_pack_size, type, legacy_record) 
+        VALUES 
+        ('item', 'item', 'item', 1, 'STOCK', '');
+    "#
+    )
+    .unwrap();
+
+    sql!(
+        &connection,
+        r#"
+        INSERT INTO barcode 
+        (id, gtin, item_id) 
+        VALUES 
+        ('barcode_1', 'gtin_1', 'item');
+    "#
+    )
+    .unwrap();
+
+    sql!(
+        &connection,
+        r#"
+        INSERT INTO barcode 
+        (id, gtin, item_id) 
+        VALUES 
+        ('barcode_2', 'gtin_2', 'item');
+    "#
+    )
+    .unwrap();
+
+    sql!(
+        &connection,
+        r#"
+        INSERT INTO barcode 
+        (id, gtin, item_id) 
+        VALUES 
+        ('barcode_3', 'gtin_3', 'item');
+    "#
+    )
+    .unwrap();
+
+    sql!(
+        &connection,
+        r#"
+        INSERT INTO barcode 
+        (id, gtin, item_id) 
+        VALUES 
+        ('barcode_4', 'gtin_4', 'item');
+    "#
+    )
+    .unwrap();
+
+    // This one should remove barcode_3, as per: https://www.db-fiddle.com/f/izBry7rdXHZ2S37DNpAuZ9/1
+    // this replicates upsert_one logic
+    diesel::replace_into(barcode_dsl::barcode)
+        .values((
+            barcode_dsl::id.eq("barcode_5"),
+            barcode_dsl::gtin.eq("gtin_3"),
+            barcode_dsl::item_id.eq("item"),
+        ))
+        .execute(&connection.connection)
+        .unwrap();
+
+    let barcode_ids = barcode_dsl::barcode
+        .select(barcode_dsl::id)
+        .order_by(barcode_dsl::id.asc())
+        .load::<String>(&connection.connection)
+        .unwrap();
+
+    assert_eq!(
+        barcode_ids,
+        vec!["barcode_1", "barcode_2", "barcode_4", "barcode_5"]
+    );
+    // But barcode_3 would be kept in changelog
+    // Check data
+    let changelog_record_ids = changelog_dsl::changelog
+        .select(changelog_dsl::record_id)
+        .distinct()
+        .filter(changelog_dsl::table_name.eq("barcode"))
+        .order_by(changelog_dsl::record_id.asc())
+        .load::<String>(&connection.connection)
+        .unwrap();
+
+    assert_eq!(
+        changelog_record_ids,
+        vec![
+            "barcode_1",
+            "barcode_2",
+            "barcode_3",
+            "barcode_4",
+            "barcode_5"
+        ]
+    );
+
+    // Migrate to this version
+    migrate(&connection, Some(version.clone())).unwrap();
+    assert_eq!(get_database_version(&connection), version);
+
+    // Check data, barcode_3 should be removed from changelog
+    let changelog_record_ids = changelog_dsl::changelog
+        .select(changelog_dsl::record_id)
+        .distinct()
+        .filter(changelog_dsl::table_name.eq("barcode"))
+        .order_by(changelog_dsl::record_id.asc())
+        .load::<String>(&connection.connection)
+        .unwrap();
+
+    assert_eq!(
+        changelog_record_ids,
+        vec!["barcode_1", "barcode_2", "barcode_4", "barcode_5"]
+    )
+}

--- a/server/repository/src/migrations/v1_01_14/mod.rs
+++ b/server/repository/src/migrations/v1_01_14/mod.rs
@@ -1,0 +1,36 @@
+use super::{version::Version, Migration};
+
+mod barcode_changelog;
+
+use crate::StorageConnection;
+pub(crate) struct V1_01_14;
+
+impl Migration for V1_01_14 {
+    fn version(&self) -> Version {
+        Version::from_str("1.1.14")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        barcode_changelog::migrate(connection)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_01_14() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_01_14.version();
+
+    // This test allows checking sql syntax
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/service/src/barcode.rs
+++ b/server/service/src/barcode.rs
@@ -1,6 +1,6 @@
 use repository::{
-    Barcode, BarcodeFilter, BarcodeRepository, BarcodeRow, BarcodeSort, EqualFilter,
-    PaginationOption, RepositoryError, StorageConnection, StorageConnectionManager,
+    Barcode, BarcodeFilter, BarcodeRepository, BarcodeRow, BarcodeRowRepository, BarcodeSort,
+    EqualFilter, PaginationOption, RepositoryError, StorageConnection, StorageConnectionManager,
 };
 use util::uuid::uuid;
 
@@ -28,7 +28,6 @@ pub struct BarcodeInput {
 pub enum InsertBarcodeError {
     DatabaseError(RepositoryError),
     InternalError(String),
-    BarcodeAlreadyExists,
     InvalidItem,
 }
 impl From<RepositoryError> for InsertBarcodeError {
@@ -79,61 +78,60 @@ pub trait BarcodeServiceTrait: Sync + Send {
             .pop())
     }
 
-    fn insert_barcode(
+    fn upsert_barcode(
         &self,
         ctx: &ServiceContext,
-        barcode: &BarcodeInput,
+        input: BarcodeInput,
     ) -> Result<Barcode, InsertBarcodeError> {
         let result = ctx
             .connection
             .transaction_sync(|con| {
-                validate(con, &ctx.store_id, &barcode)?;
-                let barcode_repository = BarcodeRepository::new(con);
-                let new_barcode = BarcodeRow {
-                    id: uuid(),
-                    gtin: barcode.gtin.clone(),
-                    item_id: barcode.item_id.clone(),
-                    pack_size: barcode.pack_size,
-                    manufacturer_id: None,
-                    parent_id: None,
-                };
-                barcode_repository.upsert_one(&new_barcode)?;
+                validate(con, &ctx.store_id, &input)?;
+
+                let new_barcode = generate(con, input)?;
+
+                BarcodeRowRepository::new(con).upsert_one(&new_barcode)?;
                 let barcode = self.get_barcode(ctx, new_barcode.id)?;
                 barcode.ok_or(InsertBarcodeError::InternalError(
-                    "Failed to read the just inserted barcode".to_string(),
+                    "Failed to read the just upserted barcode".to_string(),
                 ))
             })
             .map_err(|err| err.to_inner_error())?;
         Ok(result)
     }
 }
+
+// Barcode is upserted by gtin
+pub(crate) fn generate(
+    connection: &StorageConnection,
+    input: BarcodeInput,
+) -> Result<BarcodeRow, RepositoryError> {
+    let existing_barcode = BarcodeRepository::new(connection)
+        .query_by_filter(BarcodeFilter::new().gtin(EqualFilter::equal_to(&input.gtin)))?
+        .pop()
+        .map(|r| r.barcode_row);
+
+    let new_barcode = existing_barcode.unwrap_or(BarcodeRow {
+        id: uuid(),
+        gtin: input.gtin,
+        ..Default::default()
+    });
+
+    Ok(BarcodeRow {
+        item_id: input.item_id,
+        pack_size: input.pack_size.or(new_barcode.pack_size.clone()),
+        ..new_barcode
+    })
+}
+
 pub struct BarcodeService {}
 impl BarcodeServiceTrait for BarcodeService {}
-
-fn check_barcode_does_not_exist(
-    connection: &StorageConnection,
-    barcode: &BarcodeInput,
-) -> Result<bool, RepositoryError> {
-    let mut filter = BarcodeFilter::new().gtin(EqualFilter::equal_to(&barcode.gtin));
-
-    if let Some(pack_size) = barcode.pack_size {
-        filter = filter.pack_size(EqualFilter::equal_to_i32(pack_size))
-    }
-
-    let count = BarcodeRepository::new(connection).count(Some(filter))?;
-
-    Ok(count == 0)
-}
 
 fn validate(
     connection: &StorageConnection,
     store_id: &str,
     barcode: &BarcodeInput,
 ) -> Result<(), InsertBarcodeError> {
-    if !check_barcode_does_not_exist(connection, barcode)? {
-        return Err(InsertBarcodeError::BarcodeAlreadyExists);
-    }
-
     if !check_item_exists(connection, store_id.to_string(), &barcode.item_id)? {
         return Err(InsertBarcodeError::InvalidItem);
     }

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -1,14 +1,15 @@
 use chrono::{NaiveDate, Utc};
 use repository::{
-    ActivityLogType, BarcodeFilter, BarcodeRepository, BarcodeRow, BarcodeRowRepository,
-    DatetimeFilter, EqualFilter, LocationMovementFilter, LocationMovementRepository,
-    LocationMovementRow, LocationMovementRowRepository, RepositoryError, StockLine, StockLineRow,
+    ActivityLogType, BarcodeRow, BarcodeRowRepository, DatetimeFilter, EqualFilter,
+    LocationMovementFilter, LocationMovementRepository, LocationMovementRow,
+    LocationMovementRowRepository, RepositoryError, StockLine, StockLineRow,
     StockLineRowRepository, StorageConnection,
 };
 use util::uuid::uuid;
 
 use crate::{
     activity_log::activity_log_stock_entry,
+    barcode::{self, BarcodeInput},
     common_stock::{check_stock_line_exists, CommonStockLineError},
     service_provider::ServiceContext,
     stock_line::validate::check_location_exists,
@@ -26,7 +27,7 @@ pub struct UpdateStockLine {
     pub expiry_date: Option<NaiveDate>,
     pub on_hold: Option<bool>,
     pub batch: Option<String>,
-    pub barcode: Option<String>,
+    pub barcode_gtin: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -110,7 +111,7 @@ fn generate(
         expiry_date,
         batch,
         on_hold,
-        barcode,
+        barcode_gtin,
     }: UpdateStockLine,
 ) -> Result<
     (
@@ -131,8 +132,15 @@ fn generate(
         None
     };
 
-    let barcode_row = match barcode {
-        Some(barcode) => generate_barcode_row(connection, existing.clone(), barcode.clone())?,
+    let barcode_row = match barcode_gtin {
+        Some(gtin) => Some(barcode::generate(
+            connection,
+            BarcodeInput {
+                gtin,
+                item_id: existing.item_id.clone(),
+                pack_size: Some(existing.pack_size),
+            },
+        )?),
         None => None,
     };
 
@@ -195,42 +203,6 @@ fn generate_location_movement(
     });
 
     Ok(movement)
-}
-
-fn generate_barcode_row(
-    connection: &StorageConnection,
-    existing: StockLineRow,
-    gtin: String,
-) -> Result<Option<BarcodeRow>, RepositoryError> {
-    // for an empty string, simply unlink the barcode
-    if gtin.is_empty() {
-        return Ok(None);
-    }
-
-    let filter = BarcodeFilter::new()
-        .item_id(EqualFilter::equal_to(&existing.item_id))
-        .pack_size(EqualFilter::equal_to_i32(existing.pack_size));
-
-    let barcode_rows = BarcodeRepository::new(connection).query_by_filter(filter)?;
-    let barcode_row = match barcode_rows.first() {
-        // barcode already exists - persist the gtin change if there is one
-        Some(row) => BarcodeRow {
-            gtin,
-            ..row.barcode_row.clone()
-        },
-        None => {
-            // barcode does not exist - create a new one
-            BarcodeRow {
-                id: uuid(),
-                gtin,
-                item_id: existing.item_id,
-                pack_size: Some(existing.pack_size),
-                ..Default::default()
-            }
-        }
-    };
-
-    Ok(Some(barcode_row))
 }
 
 fn log_stock_changes(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1811 
Fixes #1805 

# 👩🏻‍💻 What does this PR do? 

* When upserting barcodes look them up by gtin rather then pack size and item_id.
* Combine upsert and insert logic for barcodes
* Add migrations to remove orphan barcode changelogs

# 🧪 How has/should this change been tested? 

Mostly unit tests should validate this logic, to test manually:

With develop:

With electron and sqlite, have two stock lines with different packs, enter `321` for barcode in first one, save stock line, enter `321` in barcode for second one, save stock line (should get an error notification), clear barcode from first one, save stock line, enter `321` to second one, save stock line. 

Now try syncing should get an error

Update to this version.

Sync error should disappear and above operation should work.

## 💌 Any notes for the reviewer?

I didn't end up removing barcode_id link from stock_line