### PR TITLE
1808 [Deployment Feedback] Add "Unit" to stocktake modal 

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   useTranslation,
   ModalMode,
+  BasicTextInput,
 } from '@openmsupply-client/common';
 import {
   StockItemSearchInput,
@@ -46,6 +47,16 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
           />
         </Grid>
       </ModalRow>
+      {item && (
+        <ModalRow margin={3}>
+          <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
+          <BasicTextInput
+            disabled
+            sx={{ width: 150 }}
+            value={item.unitName ?? ''}
+          />
+        </ModalRow>
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1808

# 👩🏻‍💻 What does this PR do? 
Adds item unit to the stocktake line modal

# 🧪 How has/should this change been tested? 
Go to a stocktake line and see item unit