### PR TITLE
Adjust outbound shipment allocation and display info message

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -118,6 +118,7 @@
   "messages.saved": "Saved",
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.shipment-saved": "Shipment saved 🥳",
+  "messages.over-allocated": "Due to the pack sizes available a total quantity of {{quantity}} has been allocated rather than {{issueQuantity}}",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
   ButtonWithIcon,
   ZapIcon,
+  InfoPanel,
 } from '@openmsupply-client/common';
 import {
   StockItemSearchInput,
@@ -48,6 +49,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     Math.abs(Number(packSizeController.selected?.value || 1));
 
   const [issueQuantity, setIssueQuantity] = useState(0);
+  const [isAllocated, setIsAllocated] = useState(false);
   const { items } = useOutbound.line.rows();
 
   const onChangePackSize = (newPackSize: number) => {
@@ -68,7 +70,10 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
         ? null
         : Number(packSizeController.selected?.value)
     );
+    setIsAllocated(true);
   };
+
+  const showAllocationWarning = isAllocated && issueQuantity < quantity;
 
   useEffect(() => {
     setIssueQuantity(quantity);
@@ -123,7 +128,16 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
       {item && canAutoAllocate ? (
         <>
           <Divider margin={10} />
-
+          {showAllocationWarning && (
+            <Grid display="flex" justifyContent="center" flex={1}>
+              <InfoPanel
+                message={t('messages.over-allocated', {
+                  quantity,
+                  issueQuantity,
+                })}
+              />
+            </Grid>
+          )}
           <Grid container>
             <ModalLabel label={t('label.issue')} />
             <NonNegativeIntegerInput

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -27,10 +27,15 @@ interface OutboundLineEditFormProps {
   availableQuantity: number;
   item: DraftItem | null;
   onChangeItem: (newItem: ItemRowFragment | null) => void;
-  onChangeQuantity: (quantity: number, packSize: number | null) => void;
+  onChangeQuantity: (
+    quantity: number,
+    packSize: number | null,
+    isAutoAllocated: boolean
+  ) => void;
   packSizeController: PackSizeController;
   disabled: boolean;
   canAutoAllocate: boolean;
+  isAutoAllocated: boolean;
 }
 
 export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
@@ -42,6 +47,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
   availableQuantity,
   disabled,
   canAutoAllocate,
+  isAutoAllocated,
 }) => {
   const t = useTranslation('distribution');
   const quantity =
@@ -49,7 +55,6 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     Math.abs(Number(packSizeController.selected?.value || 1));
 
   const [issueQuantity, setIssueQuantity] = useState(0);
-  const [isAllocated, setIsAllocated] = useState(false);
   const { items } = useOutbound.line.rows();
 
   const onChangePackSize = (newPackSize: number) => {
@@ -58,7 +63,8 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
     packSizeController.setPackSize(newPackSize);
     onChangeQuantity(
       newAllocatedQuantity,
-      newPackSize === -1 ? null : newPackSize
+      newPackSize === -1 ? null : newPackSize,
+      false
     );
   };
 
@@ -68,12 +74,12 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
       issueQuantity,
       packSizeController.selected?.value === -1
         ? null
-        : Number(packSizeController.selected?.value)
+        : Number(packSizeController.selected?.value),
+      true
     );
-    setIsAllocated(true);
   };
 
-  const showAllocationWarning = isAllocated && issueQuantity < quantity;
+  const showAllocationWarning = isAutoAllocated && issueQuantity < quantity;
 
   useEffect(() => {
     setIssueQuantity(quantity);

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
@@ -218,7 +218,7 @@ const reduceBatchAllocation = ({
         isUpdated: numberOfPacks > 0,
       };
     });
-  return -1 * toAllocate;
+  return -toAllocate;
 };
 
 export const shouldUpdatePlaceholder = (

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
@@ -69,7 +69,6 @@ export const allocateQuantities =
     // calculations are normalised to units
     const totalToAllocate = newValue * (issuePackSize || 1);
     let toAllocate = totalToAllocate;
-
     const newDraftOutboundLines = draftOutboundLines.map(batch => ({
       ...batch,
       numberOfPacks: 0,
@@ -90,7 +89,18 @@ export const allocateQuantities =
       toAllocate,
     });
 
-    // when the last batch to be allocated results in over allocation due to pack size
+    // if there is still a quantity to allocate, run through all stock lines again
+    // and round up if necessary to meet or exceed the requested quantity
+    if (toAllocate > 0) {
+      toAllocate = allocateToBatches({
+        validBatches,
+        newDraftOutboundLines,
+        toAllocate,
+        roundUp: true,
+      });
+    }
+
+    // when the last batch to be allocated results in over allocation
     // reduce the quantity allocated to previous batches as required
     // if toAllocate is negative then we have over allocated
     if (toAllocate < 0) {
@@ -99,31 +109,9 @@ export const allocateQuantities =
         validBatches,
         newDraftOutboundLines,
       });
-
-      // If there is still a quantity to allocate, then still over allocated. this time reduce
-      // lines with a pack size greater than the amount to allocate
-      if (toAllocate > 0) {
-        toAllocate = reduceBatchAllocation({
-          toAllocate,
-          validBatches,
-          newDraftOutboundLines,
-          includeOversizePacks: true,
-        });
-      }
-
-      // if there is still some to allocate, then review existing allocated lines
-      // and see if they can be increased. This is to cater for the scenario where
-      // the second reduction above has reduce a line which has a larger pack size
-      if (toAllocate > 0) {
-        toAllocate = allocatedAdditionalStock({
-          validBatches,
-          newDraftOutboundLines,
-          toAllocate,
-        });
-      }
     }
 
-    if (status === InvoiceNodeStatus.New) {
+    if (status === InvoiceNodeStatus.New && toAllocate > 0) {
       const placeholderIdx = newDraftOutboundLines.findIndex(
         ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
       );
@@ -148,10 +136,12 @@ const allocateToBatches = ({
   validBatches,
   newDraftOutboundLines,
   toAllocate,
+  roundUp = false,
 }: {
   validBatches: DraftOutboundLine[];
   newDraftOutboundLines: DraftOutboundLine[];
   toAllocate: number;
+  roundUp?: boolean;
 }) => {
   validBatches.forEach(batch => {
     const draftOutboundLineIdx = newDraftOutboundLines.findIndex(
@@ -159,58 +149,34 @@ const allocateToBatches = ({
     );
     const draftOutboundLine = newDraftOutboundLines[draftOutboundLineIdx];
     if (!draftOutboundLine) return null;
-    if (toAllocate < 0) return null;
+    if (toAllocate <= 0) return null;
 
+    const stockLineNode = draftOutboundLine.stockLine;
+    // note: taking numberOfPacks into account here, because this fn is used
+    // a second time to round up the allocation
     const availableUnits =
-      Math.floor(draftOutboundLine.stockLine?.availableNumberOfPacks ?? 0) *
-      draftOutboundLine.packSize;
+      Math.floor(
+        (stockLineNode?.availableNumberOfPacks ?? 0) -
+          draftOutboundLine.numberOfPacks
+      ) * draftOutboundLine.packSize;
     const unitsToAllocate = Math.min(toAllocate, availableUnits);
-    const numberOfPacks = unitsToAllocate / draftOutboundLine.packSize;
-    const allocatedNumberOfPacks = Math.ceil(numberOfPacks);
+    const numberOfPacksToAllocate =
+      unitsToAllocate / draftOutboundLine.packSize;
+    const allocatedNumberOfPacks = roundUp
+      ? Math.ceil(numberOfPacksToAllocate)
+      : Math.floor(numberOfPacksToAllocate);
 
     toAllocate -= allocatedNumberOfPacks * draftOutboundLine.packSize;
+
+    const numberOfPacks =
+      draftOutboundLine.numberOfPacks + allocatedNumberOfPacks;
+    const isUpdated = numberOfPacks > 0;
 
     newDraftOutboundLines[draftOutboundLineIdx] = {
       ...draftOutboundLine,
-      numberOfPacks: allocatedNumberOfPacks,
-      isUpdated: true,
+      numberOfPacks,
+      isUpdated,
     };
-  });
-  return toAllocate;
-};
-
-const allocatedAdditionalStock = ({
-  validBatches,
-  newDraftOutboundLines,
-  toAllocate,
-}: {
-  validBatches: DraftOutboundLine[];
-  newDraftOutboundLines: DraftOutboundLine[];
-  toAllocate: number;
-}) => {
-  validBatches.forEach(batch => {
-    const draftOutboundLineIdx = newDraftOutboundLines.findIndex(
-      ({ id }) => batch.id === id
-    );
-    const draftOutboundLine = newDraftOutboundLines[draftOutboundLineIdx];
-    if (!draftOutboundLine) return null;
-    if (toAllocate < 0) return null;
-    if (draftOutboundLine.packSize > toAllocate) return null;
-
-    const availableUnits =
-      ((draftOutboundLine.stockLine?.availableNumberOfPacks ?? 0) -
-        draftOutboundLine.numberOfPacks) *
-      draftOutboundLine.packSize;
-
-    if (availableUnits <= 0) return null;
-
-    const unitsToAllocate = Math.min(toAllocate, availableUnits);
-    const numberOfPacks = unitsToAllocate / draftOutboundLine.packSize;
-    const allocatedNumberOfPacks = Math.floor(numberOfPacks);
-
-    toAllocate -= allocatedNumberOfPacks * draftOutboundLine.packSize;
-    draftOutboundLine.numberOfPacks = allocatedNumberOfPacks;
-    draftOutboundLine.isUpdated = true;
   });
   return toAllocate;
 };
@@ -219,12 +185,10 @@ const reduceBatchAllocation = ({
   toAllocate,
   validBatches,
   newDraftOutboundLines,
-  includeOversizePacks = false,
 }: {
   toAllocate: number;
   validBatches: DraftOutboundLine[];
   newDraftOutboundLines: DraftOutboundLine[];
-  includeOversizePacks?: boolean;
 }) => {
   validBatches
     .slice()
@@ -235,30 +199,26 @@ const reduceBatchAllocation = ({
       );
       const draftOutboundLine = newDraftOutboundLines[draftOutboundLineIdx];
       if (!draftOutboundLine) return null;
-      if (includeOversizePacks && draftOutboundLine.packSize < toAllocate)
-        return null;
-      if (!includeOversizePacks && draftOutboundLine.packSize > toAllocate)
-        return null;
+
+      if (draftOutboundLine.packSize > toAllocate) return null;
       if (draftOutboundLine.numberOfPacks === 0) return null;
 
       const allocatedUnits =
         draftOutboundLine.numberOfPacks * draftOutboundLine.packSize;
       const unitsToReduce = Math.min(toAllocate, allocatedUnits);
+
       const numberOfPacks = Math.floor(
         (allocatedUnits - unitsToReduce) / draftOutboundLine.packSize
       );
-      toAllocate -= includeOversizePacks
-        ? (draftOutboundLine.numberOfPacks - numberOfPacks) *
-          draftOutboundLine.packSize
-        : unitsToReduce;
+      toAllocate -= unitsToReduce;
 
       newDraftOutboundLines[draftOutboundLineIdx] = {
         ...draftOutboundLine,
         numberOfPacks: numberOfPacks,
-        isUpdated: true,
+        isUpdated: numberOfPacks > 0,
       };
     });
-  return Math.abs(toAllocate);
+  return -1 * toAllocate;
 };
 
 export const shouldUpdatePlaceholder = (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1717 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Allows over-allocation when the pack size requires it. When this happens, displays a message to the user warning them.

I've updated the test suite to accomodate the change in logic and have simplified the allocation routine in utils, didn't need to be as complex as it was.

One strange thing in the original issue which I could not replicate - the pack size controller should only show `100` if all stock lines have pack size of `100`. For my tests, I've added a stock line with pack size of `1` so that the `Any` option is available. This change only applies when `Any` is used, and units are being allocated.

A demo of the process:


https://github.com/openmsupply/open-msupply/assets/9192912/e9c41636-be0c-407c-b8b5-145f9d2605c0



# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
`yarn test packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.test.ts`

and some manual testing of the info panel in outbound line edits.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Add the warning to the editing outbound modal bit
