### PR TITLE
Add number of packs translation to stocktakes

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -167,6 +167,7 @@
   "label.new-stocktake": "New Stocktake",
   "label.notes": "Notes",
   "label.num-packs": "# Packs",
+  "label.num-stocktake-packs": "# Packs",
   "label.number": "Number",
   "label.auth-status": "Approval Status",
   "label.approved-quantity": "Approved Quantity",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -123,6 +123,7 @@
   "label.new-stocktake": "Nouvel Inventaire",
   "label.notes": "Notes",
   "label.num-packs": "Qté (boites)",
+  "label.num-stocktake-packs": "Stock Théorique (boites)",
   "label.number": "Numéro",
   "label.on-hold": "Bloqué?",
   "label.order-history": "Historique des commandes",

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -153,7 +153,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
     getBatchColumn(update, theme),
     {
       key: 'snapshotNumberOfPacks',
-      label: 'label.num-packs',
+      label: 'label.num-stocktake-packs',
       width: 100,
       getIsError: rowData =>
         errorsContext.getError(rowData)?.__typename ===


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1822 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds a new translation item for stocktake number of packs.

**Inbound Shipment**

![Screenshot 2023-05-23 at 5 41 41 PM](https://github.com/openmsupply/open-msupply/assets/9192912/fcc5643c-a086-4d87-8311-e35362ff257f)

**Stocktake**

![Screenshot 2023-05-23 at 5 41 06 PM](https://github.com/openmsupply/open-msupply/assets/9192912/8dfce14d-6f24-40f6-acd9-d23476495789)

![Screenshot 2023-05-23 at 5 42 15 PM](https://github.com/openmsupply/open-msupply/assets/9192912/35af83ee-1dd5-4cb1-8a17-1c9a5a5c282f)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Manual testing - opening stocktake and inbound shipment and changing languages.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
Don't think it necessary to update for this
