### PR TITLE
Continuous scanning with keyboard scanner

### DIFF
--- a/client/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/client/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -14,44 +14,50 @@ export interface ButtonWithIconProps extends ButtonProps {
   shrinkThreshold?: 'sm' | 'md' | 'lg' | 'xl';
 }
 
-export const ButtonWithIcon: React.FC<ButtonWithIconProps> = ({
-  label,
-  onClick,
-  Icon,
-  shouldShrink = true,
-  variant = 'outlined',
-  color = 'primary',
-  disabled,
-  shrinkThreshold = 'md',
-  ...buttonProps
-}) => {
-  const isShrinkThreshold = useIsScreen(shrinkThreshold);
+export const ButtonWithIcon: React.FC<ButtonWithIconProps> = React.forwardRef(
+  (
+    {
+      label,
+      onClick,
+      Icon,
+      shouldShrink = true,
+      variant = 'outlined',
+      color = 'primary',
+      disabled,
+      shrinkThreshold = 'md',
+      ...buttonProps
+    },
+    ref
+  ) => {
+    const isShrinkThreshold = useIsScreen(shrinkThreshold);
 
-  // On small screens, if the button shouldShrink, then
-  // only display a centred icon, with no text.
-  const shrink = isShrinkThreshold && shouldShrink;
-  const startIcon = shrink ? null : Icon;
-  const centredIcon = shrink ? Icon : null;
-  const text = shrink ? null : label;
+    // On small screens, if the button shouldShrink, then
+    // only display a centred icon, with no text.
+    const shrink = isShrinkThreshold && shouldShrink;
+    const startIcon = shrink ? null : Icon;
+    const centredIcon = shrink ? Icon : null;
+    const text = shrink ? null : label;
 
-  return (
-    <Tooltip disableHoverListener={!shrink} title={label}>
-      <span>
-        <ShrinkableBaseButton
-          disabled={disabled}
-          shrink={shrink}
-          onClick={onClick}
-          variant={variant}
-          color={color}
-          size="small"
-          startIcon={startIcon}
-          aria-label={label}
-          {...buttonProps}
-        >
-          {centredIcon}
-          {text}
-        </ShrinkableBaseButton>
-      </span>
-    </Tooltip>
-  );
-};
+    return (
+      <Tooltip disableHoverListener={!shrink} title={label}>
+        <span>
+          <ShrinkableBaseButton
+            disabled={disabled}
+            shrink={shrink}
+            onClick={onClick}
+            variant={variant}
+            color={color}
+            size="small"
+            startIcon={startIcon}
+            aria-label={label}
+            ref={ref}
+            {...buttonProps}
+          >
+            {centredIcon}
+            {text}
+          </ShrinkableBaseButton>
+        </span>
+      </Tooltip>
+    );
+  }
+);

--- a/client/packages/electron/src/keyboardScanner/README.md
+++ b/client/packages/electron/src/keyboardScanner/README.md
@@ -6,21 +6,21 @@ To mimic existing USB serial barcode scanner implementation with keyboard scanne
 
 #### What is scanner input ?
 
-Because scanner scans and sends keyboard events very fast, we can idetify scanner input by looking the speed at which keys are entered. Two configurations are used to determine if input is form barcode scanner (at the time of writting these are hardcoded):
+Because scanner scans and sends keyboard events very fast, we can identify scanner input by looking the speed at which keys are entered. Two configurations are used to determine if input is form barcode scanner (at the time of writing these are hardcoded):
 
 `maxMSBetweenScannerKeyInputs` defaults to 50 and `minBarcodeLength` defaults to 5.
 
 Of course it's possible for user to spam keyboard and replicate scanner input, this should be OK because:
 
 * It's highly unlikely
-* Our UI is not really catered for operations at this speed (even without barcode scanner these operations are not really considered, as they are unlikely low probabiliy and low impact)
+* Our UI is not really catered for operations at this speed (even without barcode scanner these operations are not really considered, as they are unlikely low probably and low impact)
 * We actually recommend using USB serial scanner mode
 
 #### How does it work ?
 
 During barcode scanning mode (when keyboard scanner is selected), all keyboard input is captured with `window.webContents.on('before-input-event'` and stored in a buffer.
 
-A processor is triggered every PROCESSOR_INTERVAL (50ms), it will try to find scanner input by iterating over buffer and finding input seqences matching scanner input criteria. Any input not matching scanner input criteria will be passed through (as if it wasn't captured).
+A processor is triggered every PROCESSOR_INTERVAL (50ms), it will try to find scanner input by iterating over buffer and finding input sequences matching scanner input criteria. Any input not matching scanner input criteria will be passed through (as if it wasn't captured).
 
 If sequence input is not `finalised` (still ongoing while processor is triggered), it will be put back into buffer.
 
@@ -40,7 +40,7 @@ We also capture and ignore `isAutoRepeat` type input, this is when they key is h
 
 When barcode is created from input sequence, we only keep inputs starting with Digit and Key, and instead of using `key` of input, we use `code` of input, i.e. (Digit1 or KeyA), this means any special characters in barcode are ignored and capitalisation is ignored. This is done to make sure that keyboard OS settings dont' interfere with resulting barcode (i.e. when French AZERTY keyboard mode is on). This should only affect lot/batch number, and from my understanding those are always capital english letters.
 
-In more complex barcodes, as per image below, special character seperates lot and [serial number](https://www.databar-barcode.info/application-identifiers/), for Zebra this special character seems to be `Numpad0` + 'alt' + 'iskeypad' and for ZKTeco it was 'F8', this is replaced with charcode `29` (when scanned with USB serial mode this appears as charcode 29):
+In more complex barcodes, as per image below, special character separates lot and [serial number](https://www.databar-barcode.info/application-identifiers/), for Zebra this special character seems to be `Numpad0` + 'alt' + 'iskeypad' and for ZKTeco it was 'F8', this is replaced with charcode `29` (when scanned with USB serial mode this appears as charcode 29):
 
 ![complex barcode](./docs/complex_barcode.png)
 

--- a/client/packages/electron/src/keyboardScanner/keyboardScanner.ts
+++ b/client/packages/electron/src/keyboardScanner/keyboardScanner.ts
@@ -55,7 +55,7 @@ export class KeyboardScanner {
   window: BrowserWindow;
   interval: NodeJS.Timer | undefined;
   // Buffer can be written concurrent in event handles and when processing input
-  // this lock is to make sure it's edited syncrhonously
+  // this lock is to make sure it's edited synchronously
   lockBuffer: boolean;
   // In scanning mode, when non barcode data entry is made, should allow it (no preventDefault())
   allowEvents: boolean;
@@ -106,7 +106,7 @@ export class KeyboardScanner {
       this.buffer.forEach((current, index) => {
         // Get ms for next input event or now
         const nextMs = this.buffer[index + 1]?.ms ?? Date.now();
-        let diff = nextMs - current.ms;
+        const diff = nextMs - current.ms;
 
         checkSequence.push(current);
         // Sequence is still ongoing
@@ -130,8 +130,8 @@ export class KeyboardScanner {
       this.buffer = checkSequence;
       if (barcode.length != 0) {
         // This console log is super useful and is supposed to be here!
-        // TODO can be improved by login to window console as per: https://github.com/openmsupply/open-msupply/pull/1804#discussion_r1199888198
-        console.log(JSON.stringify(barcode, null, ' '));
+        const msg = `console.log(${JSON.stringify(barcode, null, ' ')});`;
+        this.window.webContents.executeJavaScript(msg);
         this.sendBarcode(barcode);
       }
 
@@ -148,7 +148,7 @@ export class KeyboardScanner {
         this.allowEvents = false;
       }
     } catch (e) {
-      console.log(e);
+      console.error(e);
     } finally {
       // Make sure lockBuffer is always unlocked
       this.lockBuffer = false;
@@ -159,6 +159,11 @@ export class KeyboardScanner {
     // Bind keyboard capture on startup (this.scanning is false by default)
     this.window.webContents.on('before-input-event', (event, input) => {
       if (!this.scanning) return;
+
+      this.window.webContents.executeJavaScript(
+        `console.log('key=${input.key}');`
+      );
+
       if (keysToPassThrough.includes(input.key)) return;
 
       while (this.lockBuffer) {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   useTranslation,
   useBarcodeScannerContext,
@@ -26,6 +26,7 @@ export const AddFromScannerButtonComponent = ({
   const { isConnected, isEnabled, isScanning, startScanning, stopScan } =
     useBarcodeScannerContext();
   const { error, warning } = useNotification();
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   if (!isEnabled) return null;
 
@@ -54,6 +55,7 @@ export const AddFromScannerButtonComponent = ({
   };
 
   const handleClick = async () => {
+    buttonRef.current?.blur();
     if (isScanning) {
       stopScan();
     } else {
@@ -90,6 +92,7 @@ export const AddFromScannerButtonComponent = ({
     <Tooltip title={isConnected ? '' : t('error.scanner-not-connected')}>
       <Box>
         <ButtonWithIcon
+          ref={buttonRef}
           disabled={isDisabled || !isConnected}
           onClick={handleClick}
           Icon={


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1837 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
When the barcode scanner is in continuous scanning mode ( such as used in outbound shipments ), the following happens:

- The user clicks the `Scan` button
- This button is therefore focussed, due to the click
- if the scanner sends an `Enter` key, the button is clicked again, as it responds to `Enter` keypress events

This turns off scanning. If the barcode is scanned again without the user interacting with the page, then the button receives `Enter` again, is clicked, the scanning starts, and the buffered barcode data sent.

The change in this PR is to `blur` the button on press. It means that an `Enter` from the scanner does not stop the scanning.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Configure the scanner in keyboard mode (see #1804)
- Open an outbound shipment, and press `Scan`
- Scan a code (I tested using a 1D barcode, ymmv)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
