### PR TITLE
Remove need for dnssd when connecting to previous server

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -162,7 +162,7 @@ export const useNativeClient = ({
     if (!autoconnect) return;
     if (previousServer === null) return;
 
-    fetch(`${frontEndHostUrl(previousServer)}/login`)
+    fetch(frontEndHostUrl(previousServer))
       .then(response => {
         if (response.status === 200) {
           connectToServer(previousServer);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1803 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Currently, if you have `autoconnect` set, and have a previous server, then the native client requires finding the server using dnssd before allowing you to connect.

The dnssd package will attach to active network adapters - if all interfaces are inactive there is simply no response from dnssd and therefore the previous server isn't discovered and you never connect. Even though the server is up and responding to requests.

This change is to simply fetch the server URL to test if it is active. If you get a valid response, then connect. If not, show the 'unable to find server' message.

It's much quicker and resolves the issue with disconnected networks.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

**To test** 
Note: You can use v1.1.14-rc3, downloadable from jenkins.

- Install the standalone or desktop version ( the change is in the desktop app, you'll be able to test with an existing server )
- Connect to a server
- Close the desktop app
- Disconnect the network
- Open desktop app - it will connect to the server and run as normal
- Reconnect network and repeat



## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
