### PR TITLE
Handle no network when running SSL

### DIFF
--- a/client/packages/common/src/hooks/useNativeClient/types.ts
+++ b/client/packages/common/src/hooks/useNativeClient/types.ts
@@ -7,13 +7,17 @@ export type Preference = {
   value: string;
   error?: string;
 };
+export type ConnectionResult = {
+  success: boolean;
+  error?: string;
+};
 export interface NativeAPI {
   // Method used in polling for found servers
   discoveredServers: () => Promise<{ servers: FrontEndHost[] }>;
   // Starts server discovery (connectToServer stops server discovery)
   startServerDiscovery: () => void;
   // Asks client to connect to server (causing window to navigate to server url and stops discovery)
-  connectToServer: (server: FrontEndHost) => void;
+  connectToServer: (server: FrontEndHost) => Promise<ConnectionResult>;
   // Will return currently connected client (to display in UI)
   connectedServer: () => Promise<FrontEndHost | null>;
   goBackToDiscovery: () => void;

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -62,7 +62,7 @@ export const useNativeClient = ({
     );
   };
 
-  const handleConnectionResult = (result: ConnectionResult) => {
+  const handleConnectionResult = async (result: ConnectionResult) => {
     if (!result.success) {
       console.error('Connecting to previous server:', result.error);
     }

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -2,7 +2,6 @@ import { uniqWith } from 'lodash';
 import { useState, useEffect } from 'react';
 import { KeepAwake } from '@capacitor-community/keep-awake';
 import {
-  // frontEndHostUrl,
   getNativeAPI,
   getPreference,
   matchUniqueServer,
@@ -120,15 +119,6 @@ export const useNativeClient = ({
   useEffect(() => {
     if (!state.isDiscovering) return;
 
-    let connectToPreviousTimer: NodeJS.Timer | undefined = undefined;
-
-    if (autoconnect && !!state.previousServer) {
-      connectToPreviousTimer = setTimeout(
-        () => setState(state => ({ ...state, connectToPreviousFailed: true })),
-        DISCOVERY_TIMEOUT
-      );
-    }
-
     const timeoutTimer = setTimeout(() => {
       setState(state => ({
         ...state,
@@ -151,7 +141,6 @@ export const useNativeClient = ({
     }, DISCOVERED_SERVER_POLL);
 
     return () => {
-      clearTimeout(connectToPreviousTimer);
       clearTimeout(timeoutTimer);
       clearInterval(pollInterval);
     };

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -110,7 +110,7 @@ export const useNativeClient = ({
     if (result.isSupported) await KeepAwake.keepAwake();
   };
 
-  const handleConnectionError = (result: ConnectionResult) => {
+  const handleConnectionResult = (result: ConnectionResult) => {
     if (result.success) return;
 
     setState(state => ({ ...state, connectToPreviousFailed: true }));
@@ -173,8 +173,8 @@ export const useNativeClient = ({
 
     // this will check to see if the server is alive and if so, connect to it
     connectToServer(previousServer)
-      .then(result => handleConnectionError(result))
-      .catch(e => handleConnectionError({ success: false, error: e.message }));
+      .then(handleConnectionResult)
+      .catch(e => handleConnectionResult({ success: false, error: e.message }));
   }, [state.previousServer, autoconnect]);
 
   return {

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -26,7 +26,7 @@ declare global {
 
 type NativeClientState = {
   // A previous server is set in local storage, but was not returned in the list of available servers
-  connectToPreviousTimedOut: boolean;
+  connectToPreviousFailed: boolean;
   connectedServer: FrontEndHost | null;
   // Indicate that server discovery has taken too long without finding server
   discoveryTimedOut: boolean;
@@ -47,7 +47,7 @@ export const useNativeClient = ({
     );
 
   const [state, setState] = useState<NativeClientState>({
-    connectToPreviousTimedOut: false,
+    connectToPreviousFailed: false,
     connectedServer: null,
     discoveryTimedOut: false,
     isDiscovering: false,
@@ -113,7 +113,7 @@ export const useNativeClient = ({
   const handleConnectionError = (result: ConnectionResult) => {
     if (result.success) return;
 
-    setState(state => ({ ...state, connectToPreviousTimedOut: true }));
+    setState(state => ({ ...state, connectToPreviousFailed: true }));
     console.error('Connecting to previous server:', result.error);
   };
 
@@ -124,8 +124,7 @@ export const useNativeClient = ({
 
     if (autoconnect && !!state.previousServer) {
       connectToPreviousTimer = setTimeout(
-        () =>
-          setState(state => ({ ...state, connectToPreviousTimedOut: true })),
+        () => setState(state => ({ ...state, connectToPreviousFailed: true })),
         DISCOVERY_TIMEOUT
       );
     }

--- a/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
+++ b/client/packages/common/src/hooks/useNativeClient/useNativeClient.ts
@@ -2,7 +2,7 @@ import { uniqWith } from 'lodash';
 import { useState, useEffect } from 'react';
 import { KeepAwake } from '@capacitor-community/keep-awake';
 import {
-  frontEndHostUrl,
+  // frontEndHostUrl,
   getNativeAPI,
   getPreference,
   matchUniqueServer,
@@ -162,16 +162,18 @@ export const useNativeClient = ({
     if (!autoconnect) return;
     if (previousServer === null) return;
 
-    fetch(frontEndHostUrl(previousServer))
-      .then(response => {
-        if (response.status === 200) {
-          connectToServer(previousServer);
-        }
-      })
-      .catch(error => {
-        setState(state => ({ ...state, connectToPreviousTimedOut: true })),
-          console.error('Connecting to previous server:', error);
-      });
+    // this will check to see if the server is alive and if so, connect to it
+    connectToServer(previousServer);
+    // fetch(frontEndHostUrl(previousServer))
+    //   .then(response => {
+    //     if (response.status === 200) {
+    //       connectToServer(previousServer);
+    //     }
+    //   })
+    //   .catch(error => {
+    //     setState(state => ({ ...state, connectToPreviousTimedOut: true })),
+    //       console.error('Connecting to previous server:', error);
+    //   });
   }, [state.previousServer, autoconnect]);
 
   return {

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -131,7 +131,7 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
   connect,
 }) => {
   const { data: initStatus } = useInitialisationStatus();
-  const t = useTranslation();
+  const t = useTranslation('app');
   const { error } = useNotification();
 
   const getSiteName = () => {
@@ -140,7 +140,7 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
     return t('messages.not-initialised');
   };
 
-  const handleConnectResult = (result: ConnectionResult) => {
+  const handleConnectionResult = (result: ConnectionResult) => {
     if (result.success) return;
 
     error(t('error.connection-error'))();
@@ -151,8 +151,10 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
     <MenuItem
       onClick={() => {
         connect(server)
-          .then(result => handleConnectResult(result))
-          .catch(e => ({ success: false, error: e.message }));
+          .then(handleConnectionResult)
+          .catch(e =>
+            handleConnectionResult({ success: false, error: e.message })
+          );
       }}
       sx={{ color: 'inherit' }}
     >

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -13,8 +13,6 @@ import {
   FrontEndHost,
   useNativeClient,
   GqlProvider,
-  QueryClientProvider,
-  QueryClient,
   useInitialisationStatus,
   InitialisationStatusType,
   frontEndHostDiscoveryGraphql,
@@ -22,6 +20,7 @@ import {
   RefreshIcon,
   ConnectionResult,
   useNotification,
+  useMutation,
 } from '@openmsupply-client/common';
 
 type ConnectToServer = ReturnType<typeof useNativeClient>['connectToServer'];
@@ -119,11 +118,9 @@ export const DiscoveredServers = ({
 type DiscoveredServerProps = { server: FrontEndHost; connect: ConnectToServer };
 
 const DiscoveredServerWrapper: React.FC<DiscoveredServerProps> = params => (
-  <QueryClientProvider client={new QueryClient()}>
-    <GqlProvider url={frontEndHostDiscoveryGraphql(params.server)}>
-      <DiscoveredServer {...params} />
-    </GqlProvider>
-  </QueryClientProvider>
+  <GqlProvider url={frontEndHostDiscoveryGraphql(params.server)}>
+    <DiscoveredServer {...params} />
+  </GqlProvider>
 );
 
 const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
@@ -147,17 +144,14 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
     console.error(result.error);
   };
 
+  const { mutate: connectToServer } = useMutation(connect, {
+    onSuccess: handleConnectionResult,
+    onError: (e: Error) =>
+      handleConnectionResult({ success: false, error: e.message }),
+  });
+
   return (
-    <MenuItem
-      onClick={() => {
-        connect(server)
-          .then(handleConnectionResult)
-          .catch(e =>
-            handleConnectionResult({ success: false, error: e.message })
-          );
-      }}
-      sx={{ color: 'inherit' }}
-    >
+    <MenuItem onClick={() => connectToServer(server)} sx={{ color: 'inherit' }}>
       <Box alignItems="center" display="flex" gap={2}>
         <Box flex={0}>
           <CheckboxEmptyIcon fontSize="small" color="primary" />

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -122,7 +122,6 @@ const DiscoveredServerWrapper: React.FC<DiscoveredServerProps> = params => (
     <DiscoveredServer {...params} />
   </GqlProvider>
 );
-
 const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
   server,
   connect,
@@ -137,7 +136,7 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
     return t('messages.not-initialised');
   };
 
-  const handleConnectionResult = (result: ConnectionResult) => {
+  const handleConnectionResult = async (result: ConnectionResult) => {
     if (result.success) return;
 
     error(t('error.connection-error'))();

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -20,6 +20,8 @@ import {
   frontEndHostDiscoveryGraphql,
   IconButton,
   RefreshIcon,
+  ConnectionResult,
+  useNotification,
 } from '@openmsupply-client/common';
 
 type ConnectToServer = ReturnType<typeof useNativeClient>['connectToServer'];
@@ -130,6 +132,7 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
 }) => {
   const { data: initStatus } = useInitialisationStatus();
   const t = useTranslation();
+  const { error } = useNotification();
 
   const getSiteName = () => {
     if (initStatus?.status == InitialisationStatusType.Initialised)
@@ -137,10 +140,19 @@ const DiscoveredServer: React.FC<DiscoveredServerProps> = ({
     return t('messages.not-initialised');
   };
 
+  const handleConnectResult = (result: ConnectionResult) => {
+    if (result.success) return;
+
+    error(t('error.connection-error'))();
+    console.error(result.error);
+  };
+
   return (
     <MenuItem
       onClick={() => {
-        connect(server);
+        connect(server)
+          .then(result => handleConnectResult(result))
+          .catch(e => ({ success: false, error: e.message }));
       }}
       sx={{ color: 'inherit' }}
     >

--- a/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
+++ b/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
@@ -37,7 +37,7 @@ export const ServerDiscovery = () => {
     connectToServer,
     startDiscovery,
     stopDiscovery,
-    connectToPreviousTimedOut,
+    connectToPreviousFailed,
     previousServer,
   } = useNativeClient({
     discovery: true,
@@ -135,7 +135,7 @@ export const ServerDiscovery = () => {
         >
           {t('discovery.body')}
         </Typography>
-        {(connectToPreviousTimedOut || isTimedOut()) && (
+        {(connectToPreviousFailed || isTimedOut()) && (
           <Box padding={2}>
             <ErrorWithDetails
               error={t('error.unable-to-connect', { server })}

--- a/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
+++ b/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
@@ -7,6 +7,7 @@ import {
   useNativeClient,
   ErrorWithDetails,
   frontEndHostDisplay,
+  SnackbarProvider,
 } from '@openmsupply-client/common';
 import { LoginIcon } from '@openmsupply-client/host/src/components/Login/LoginIcon';
 import { Theme } from '@common/styles';
@@ -52,106 +53,108 @@ export const ServerDiscovery = () => {
   const server = previousServer ? frontEndHostDisplay(previousServer) : '';
 
   return (
-    <Stack
-      display="flex"
-      style={{ minHeight: '100%' }}
-      alignItems="center"
-      flex={1}
-    >
-      <Box
+    <SnackbarProvider maxSnack={3}>
+      <Stack
         display="flex"
-        flex="0 0 40%"
-        alignSelf="center"
-        style={{ marginLeft: '-10%' }}
+        style={{ minHeight: '100%' }}
+        alignItems="center"
+        flex={1}
       >
         <Box
           display="flex"
-          alignItems="center"
-          justifyContent="center"
-          padding={2}
+          flex="0 0 40%"
+          alignSelf="center"
+          style={{ marginLeft: '-10%' }}
         >
-          <LoginIcon />
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            padding={2}
+          >
+            <LoginIcon />
+          </Box>
+          <Box display="flex" flexDirection="column" justifyContent="center">
+            <Typography
+              component="div"
+              sx={{
+                color: (theme: Theme) => theme.palette.gray.main,
+                fontSize: {
+                  xs: '38px',
+                  sm: '38px',
+                  md: '48px',
+                  lg: '64px',
+                  xl: '64px',
+                },
+                fontWeight: 'bold',
+                display: 'flex',
+                justifyContent: 'center',
+                flexDirection: 'column',
+              }}
+            >
+              {t('discovery.heading')}
+            </Typography>
+            <Typography
+              component="div"
+              sx={{
+                color: (theme: Theme) => theme.palette.gray.main,
+                fontSize: {
+                  xs: '19px',
+                  sm: '19px',
+                  md: '24px',
+                  lg: '32px',
+                  xl: '32px',
+                },
+                fontWeight: 'bold',
+                display: 'flex',
+                justifyContent: 'center',
+                flexDirection: 'column',
+              }}
+            >
+              {t('discovery.sub-heading')}
+            </Typography>
+          </Box>
         </Box>
-        <Box display="flex" flexDirection="column" justifyContent="center">
+        <Box display="flex" flexDirection="column" flex={1} padding={1}>
           <Typography
             component="div"
+            display="flex"
+            flex={0}
+            justifyContent="center"
             sx={{
-              color: (theme: Theme) => theme.palette.gray.main,
               fontSize: {
-                xs: '38px',
-                sm: '38px',
-                md: '48px',
-                lg: '64px',
-                xl: '64px',
+                xs: '12px',
+                sm: '14px',
+                md: '16px',
+                lg: '20px',
+                xl: '20px',
               },
-              fontWeight: 'bold',
-              display: 'flex',
-              justifyContent: 'center',
-              flexDirection: 'column',
+              color: 'gray.main',
+              fontWeight: 600,
+              whiteSpace: 'pre-line',
+              paddingBottom: '5%',
             }}
           >
-            {t('discovery.heading')}
+            {t('discovery.body')}
           </Typography>
-          <Typography
-            component="div"
-            sx={{
-              color: (theme: Theme) => theme.palette.gray.main,
-              fontSize: {
-                xs: '19px',
-                sm: '19px',
-                md: '24px',
-                lg: '32px',
-                xl: '32px',
-              },
-              fontWeight: 'bold',
-              display: 'flex',
-              justifyContent: 'center',
-              flexDirection: 'column',
-            }}
-          >
-            {t('discovery.sub-heading')}
-          </Typography>
-        </Box>
-      </Box>
-      <Box display="flex" flexDirection="column" flex={1} padding={1}>
-        <Typography
-          component="div"
-          display="flex"
-          flex={0}
-          justifyContent="center"
-          sx={{
-            fontSize: {
-              xs: '12px',
-              sm: '14px',
-              md: '16px',
-              lg: '20px',
-              xl: '20px',
-            },
-            color: 'gray.main',
-            fontWeight: 600,
-            whiteSpace: 'pre-line',
-            paddingBottom: '5%',
-          }}
-        >
-          {t('discovery.body')}
-        </Typography>
-        {(connectToPreviousFailed || isTimedOut()) && (
-          <Box padding={2}>
-            <ErrorWithDetails
-              error={t('error.unable-to-connect', { server })}
-              details=""
+          {(connectToPreviousFailed || isTimedOut()) && (
+            <Box padding={2}>
+              <ErrorWithDetails
+                error={t('error.unable-to-connect', { server })}
+                details=""
+              />
+            </Box>
+          )}
+          <Box display="flex" flex={1} justifyContent="center">
+            <DiscoveredServers
+              servers={servers}
+              connect={connectToServer}
+              discoveryTimedOut={discoveryTimedOut}
+              discover={discover}
             />
           </Box>
-        )}
-        <Box display="flex" flex={1} justifyContent="center">
-          <DiscoveredServers
-            servers={servers}
-            connect={connectToServer}
-            discoveryTimedOut={discoveryTimedOut}
-            discover={discover}
-          />
         </Box>
-      </Box>
-    </Stack>
+      </Stack>
+    </SnackbarProvider>
   );
 };

--- a/client/packages/electron/src/electron.ts
+++ b/client/packages/electron/src/electron.ts
@@ -168,6 +168,7 @@ const tryToConnectToServer = (window: BrowserWindow, server: FrontEndHost) => {
     console.error('Error received connecting to server:', e);
     return { success: false, error: e.message };
   });
+  return { success: false };
 };
 
 const connectToServer = (window: BrowserWindow, server: FrontEndHost) => {
@@ -205,7 +206,7 @@ const start = (): void => {
 
   ipcMain.handle(
     IPC_MESSAGES.CONNECT_TO_SERVER,
-    (_event, server: FrontEndHost) => tryToConnectToServer(window, server)
+    async (_event, server: FrontEndHost) => tryToConnectToServer(window, server)
   );
 
   ipcMain.handle(IPC_MESSAGES.CONNECTED_SERVER, async () => connectedServer);

--- a/client/packages/electron/src/home.tsx
+++ b/client/packages/electron/src/home.tsx
@@ -5,6 +5,8 @@ import {
   AppThemeProvider,
   HashRouter,
   IntlProvider,
+  QueryClient,
+  QueryClientProvider,
   RandomLoader,
   Route,
   Routes,
@@ -18,14 +20,16 @@ const ClientHomeScreen = () => (
     <IntlProvider isElectron={true}>
       <React.Suspense fallback={<RandomLoader />}>
         <AppThemeProvider>
-          <HashRouter>
-            <Viewport>
-              <Routes>
-                <Route path="/error" element={<ErrorPage />} />
-                <Route path="/" element={<ServerDiscovery />} />
-              </Routes>
-            </Viewport>
-          </HashRouter>
+          <QueryClientProvider client={new QueryClient()}>
+            <HashRouter>
+              <Viewport>
+                <Routes>
+                  <Route path="/error" element={<ErrorPage />} />
+                  <Route path="/" element={<ServerDiscovery />} />
+                </Routes>
+              </Viewport>
+            </HashRouter>
+          </QueryClientProvider>
         </AppThemeProvider>
       </React.Suspense>
     </IntlProvider>

--- a/client/packages/electron/src/preload.ts
+++ b/client/packages/electron/src/preload.ts
@@ -7,7 +7,7 @@ const electronNativeAPI: NativeAPI = {
     ipcRenderer.send(IPC_MESSAGES.START_SERVER_DISCOVERY),
   connectedServer: () => ipcRenderer.invoke(IPC_MESSAGES.CONNECTED_SERVER),
   connectToServer: server =>
-    ipcRenderer.send(IPC_MESSAGES.CONNECT_TO_SERVER, server),
+    ipcRenderer.invoke(IPC_MESSAGES.CONNECT_TO_SERVER, server),
   startBarcodeScan: () => ipcRenderer.invoke(IPC_MESSAGES.START_BARCODE_SCAN),
   stopBarcodeScan: () => ipcRenderer.invoke(IPC_MESSAGES.STOP_BARCODE_SCAN),
   onBarcodeScan: callback => {

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -98,7 +98,7 @@ const ModeOption = ({
 
 export const Android = () => {
   const {
-    connectToPreviousTimedOut,
+    connectToPreviousFailed,
     previousServer,
     servers,
     connectToServer,
@@ -144,15 +144,15 @@ export const Android = () => {
   useEffect(() => {
     if (
       mode === NativeMode.Client &&
-      (!previousServer?.ip || connectToPreviousTimedOut)
+      (!previousServer?.ip || connectToPreviousFailed)
     ) {
       navigate(
         RouteBuilder.create(AppRoute.Discovery)
-          .addPart(`?timedout=${!!connectToPreviousTimedOut}`)
+          .addPart(`?timedout=${!!connectToPreviousFailed}`)
           .build()
       );
     }
-  }, [mode, previousServer, connectToPreviousTimedOut]);
+  }, [mode, previousServer, connectToPreviousFailed]);
 
   if (mode === NativeMode.None)
     return (
@@ -196,7 +196,7 @@ export const Android = () => {
       </Viewport>
     );
 
-  if (mode === NativeMode.Server && connectToPreviousTimedOut)
+  if (mode === NativeMode.Server && connectToPreviousFailed)
     return (
       <Viewport>
         <Box

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -119,7 +119,7 @@ export const Android = () => {
     setLocalMode(mode);
   };
 
-  const handleConnectionResult = (result: ConnectionResult) => {
+  const handleConnectionResult = async (result: ConnectionResult) => {
     if (result.success) return;
 
     console.error('Connecting to previous server:', result.error);

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -5,6 +5,7 @@ import {
   BasicSpinner,
   Box,
   ButtonWithIcon,
+  ConnectionResult,
   ErrorWithDetails,
   ExternalLinkIcon,
   getNativeAPI,
@@ -118,6 +119,17 @@ export const Android = () => {
     setLocalMode(mode);
   };
 
+  const handleConnectionResult = (result: ConnectionResult) => {
+    if (result.success) return;
+
+    console.error('Connecting to previous server:', result.error);
+    navigate(
+      RouteBuilder.create(AppRoute.Discovery)
+        .addPart(`?timedout=${!!connectToPreviousFailed}`)
+        .build()
+    );
+  };
+
   useEffect(() => {
     // this page is not for web users! begone!
     if (!getNativeAPI()) navigate(RouteBuilder.create(AppRoute.Login).build());
@@ -135,8 +147,11 @@ export const Android = () => {
       const localServer = servers.find(server => server.isLocal);
       if (localServer) {
         const path = !token ? 'login' : '';
-        // TODO
-        connectToServer({ ...localServer, path }).then();
+        connectToServer({ ...localServer, path })
+          .then(handleConnectionResult)
+          .catch(e =>
+            handleConnectionResult({ success: false, error: e.message })
+          );
       }
     }
   }, [mode, servers]);

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -135,7 +135,8 @@ export const Android = () => {
       const localServer = servers.find(server => server.isLocal);
       if (localServer) {
         const path = !token ? 'login' : '';
-        connectToServer({ ...localServer, path });
+        // TODO
+        connectToServer({ ...localServer, path }).then();
       }
     }
   }, [mode, servers]);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1856 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Implements the SSL handling by pushing the check into the native layer.
This also provides a fix for the scenario where

- server discovery page is shown, a server (a) is found
- server (a) shuts down
- user clicks server (a) on the discovery page

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
- On windows, start a server, both with and without certificates.
- Connect, then close the desktop version and disconnect the network. Start the desktop again. Should connect.

- Start a server, open the desktop client
- stop the server, click on it in the discovery list

- Start android in server mode, connect to the local server
- close android, disable network and open again

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
