### PR TITLE
Enable android barcode scanner

### DIFF
--- a/client/packages/common/src/utils/BarcodeScannerContext.test.ts
+++ b/client/packages/common/src/utils/BarcodeScannerContext.test.ts
@@ -47,22 +47,3 @@ describe('GS1 parsing', () => {
     expect(result.expiryDate).toBe('2014-07-04');
   });
 });
-
-describe('Data matrix parsing', () => {
-  // const barcode = '010031414199999521100000002341715012510987654321GFEDCBA';
-  const barcode = '010031414199999521100000002341715012510987654321GFEDCBA';
-  it('parses GTIN', () => {
-    const result = parseResult(barcode);
-    expect(result.gtin).toBe('00314141999995');
-  });
-
-  it('parses batch', () => {
-    const result = parseResult(barcode);
-    expect(result.batch).toBe('987654321GFEDCBA');
-  });
-
-  it('parses expiry', () => {
-    const result = parseResult(barcode);
-    expect(result.expiryDate).toBe('2015-01-25');
-  });
-});

--- a/client/packages/common/src/utils/BarcodeScannerContext.test.ts
+++ b/client/packages/common/src/utils/BarcodeScannerContext.test.ts
@@ -47,3 +47,22 @@ describe('GS1 parsing', () => {
     expect(result.expiryDate).toBe('2014-07-04');
   });
 });
+
+describe('Data matrix parsing', () => {
+  // const barcode = '010031414199999521100000002341715012510987654321GFEDCBA';
+  const barcode = '010031414199999521100000002341715012510987654321GFEDCBA';
+  it('parses GTIN', () => {
+    const result = parseResult(barcode);
+    expect(result.gtin).toBe('00314141999995');
+  });
+
+  it('parses batch', () => {
+    const result = parseResult(barcode);
+    expect(result.batch).toBe('987654321GFEDCBA');
+  });
+
+  it('parses expiry', () => {
+    const result = parseResult(barcode);
+    expect(result.expiryDate).toBe('2015-01-25');
+  });
+});


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1859 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Enables the scanner for android devices.
As an aside, I was testing 2D codes and these do scan correctly on android! 🎉 

I did have to implement a small fix for the parsing of Data Matrix codes. Have tested using these, and they all work now:

<img width="452" alt="image" src="https://github.com/openmsupply/open-msupply/assets/9192912/a9a72b13-bbc4-4de5-a922-4254c880034c">



Refer to the [parsing library ](https://www.npmjs.com/package/gs1-barcode-parser-mod#about-the-structure-of-gs1-barcodes) for the code parsing, and to the [scanning library](https://github.com/zxing-js/library) for the supported formats

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Run on android. e.g. from the client directory:

```
yarn android:build:debug
adb install -r ./packages/android/app/build/outputs/apk/debug/open-msupply-1.1.14-debug.apk
```

and try to scan a barcode. Should be enabled in the edit stock modal and outbound shipment detail pages.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] Mention that we can scan on android
