### PR TITLE
OMI30 - Poll for initialisation

### DIFF
--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -125,6 +125,14 @@ impl SyncApiError {
             route: "".to_string(),
         }
     }
+
+    pub(crate) fn is_connection(&self) -> bool {
+        matches!(self.source, SyncApiErrorVariant::ConnectionError(_))
+    }
+
+    pub(crate) fn is_unknown(&self) -> bool {
+        matches!(self.source, SyncApiErrorVariant::Other(_))
+    }
 }
 
 #[cfg(test)]

--- a/server/service/src/sync/api/get_site_status.rs
+++ b/server/service/src/sync/api/get_site_status.rs
@@ -11,6 +11,8 @@ pub(crate) struct SiteStatusV5 {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) enum SiteStatusCodeV5 {
+    #[serde(rename = "sync_is_running")]
+    SyncIsRunning,
     #[serde(rename = "integration_in_progress")]
     IntegrationInProgress,
     #[serde(rename = "idle")]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -74,7 +74,7 @@ pub struct RemoteDataSynchroniser {
 impl RemoteDataSynchroniser {
     /// Request initialisation
     /// TODO improve logic for initialisation check, requires central changes as per this issue:
-    ///
+    /// https://github.com/openmsupply/open-msupply-internal/issues/30#issuecomment-1567639141
     ///
     /// This api call is blocking, and will wait while central server adds relevant records to
     /// sync queue. If there is a connection problem while intialisaion is happenning, we don't

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 const INITIALISATION_POLL_PERIOD_SECONDS: u64 = 15;
 // 30 minutes
-const INITIALISATION_TIMEOUT_SECONDS: u64 = 30 * 60 * 60;
+const INITIALISATION_TIMEOUT_SECONDS: u64 = 30 * 60;
 
 #[derive(Error, Debug)]
 pub(crate) enum PostInitialisationError {

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -13,7 +13,7 @@ use super::{
     central_data_synchroniser::{CentralDataSynchroniser, CentralPullError},
     remote_data_synchroniser::{
         PostInitialisationError, RemoteDataSynchroniser, RemotePullError, RemotePushError,
-        WaitForIntegrationError,
+        WaitForSyncOperationError,
     },
     settings::{SyncSettings, SYNC_VERSION},
     sync_buffer::SyncBuffer,
@@ -43,7 +43,7 @@ pub(crate) enum SyncError {
     #[error("Error while pushing remote records")]
     RemotePushError(#[from] RemotePushError),
     #[error("Error while awaiting remote record integration")]
-    WaitForIntegrationError(#[from] WaitForIntegrationError),
+    WaitForIntegrationError(#[from] WaitForSyncOperationError),
     #[error("Error while pulling central records")]
     CentralPullError(#[from] CentralPullError),
     #[error("Error while pulling remote records")]
@@ -162,7 +162,10 @@ impl Synchroniser {
                 .push(&ctx.connection, batch_size.remote_push, logger)
                 .await?;
             self.remote
-                .wait_for_integration(INTEGRATION_POLL_PERIOD_SECONDS, INTEGRATION_TIMEOUT_SECONDS)
+                .wait_for_sync_operation(
+                    INTEGRATION_POLL_PERIOD_SECONDS,
+                    INTEGRATION_TIMEOUT_SECONDS,
+                )
                 .await?;
         }
         logger.done_step(SyncStep::Push)?;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

PR is to Main branch

Partially Fixes: https://github.com/openmsupply/open-msupply-internal/issues/30

# 👩🏻‍💻 What does this PR do? 

Added polling to initialisation end point, so that if there is a connection error during initialisation, we can poll for initialisation to complete, and pressing 'retry' in UI will not restart initialisation. I am not happy with this as a permanent fix, will add a better `way` to the [underlying issue](https://github.com/openmsupply/open-msupply-internal/issues/30#issuecomment-1567639141). But for now this should deal with connection error during initialisation (without needing to re-initialise): 

# 🧪 How has/should this change been tested? '

As per replication instructions in the first comment: https://github.com/openmsupply/open-msupply-internal/issues/30#issue-1712907706.

Here are the changes for the tests:

https://github.com/openmsupply/open-msupply/compare/OMI30-Blocking-initialisation-call-to-be-more-forgiving...OMI30-Test

https://github.com/openmsupply/msupply/compare/develop...OMI30-Test

Apart from that it's pretty hard to replicate, setting the delay on central and then trying to disconnect network somehow (central would need to be on different machine). Basically after connection reset during initialisation, can resume initialisation (without restarting it)

## 💌 Any notes for the reviewer?

## 📃 Documentation
