### PR TITLE
1867 repack UI error messages and other bits

### DIFF
--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -17,6 +17,8 @@
   "error.reduced-below-zero": "Stock line exist in new outbound shipments. The quantity cannot be reduced below zero.",
   "error.stocktake-has-stock-reduced-below-zero": "Stock take cannot be finalised because some of the stock has been used in new outbound shipments.",
   "error.unable-to-scan": "Unable to scan barcode: {{error}}",
+    "error.repack-has-stock-reduced-below-zero": "Cannot repack stock line. New number of packs exceeds stock line number of packs.",
+    "error.repack-cannot-be-fractional": "Cannot repack into a fractional pack",
   "label.add-batch": "Add batch",
   "label.add-new-line": "Add a new line",
   "label.cost-price": "Cost price",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -361,6 +361,11 @@ export type CannotEditStocktake = DeleteStocktakeErrorInterface & DeleteStocktak
   description: Scalars['String'];
 };
 
+export type CannotHaveFractionalPack = InsertRepackErrorInterface & {
+  __typename: 'CannotHaveFractionalPack';
+  description: Scalars['String'];
+};
+
 export type CannotReverseInvoiceStatus = UpdateErrorInterface & UpdateInboundShipmentErrorInterface & {
   __typename: 'CannotReverseInvoiceStatus';
   description: Scalars['String'];

--- a/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
@@ -12,22 +12,28 @@ import {
   useStock,
 } from '@openmsupply-client/system';
 import { LocationSearchInput } from 'packages/system/src/Location/Components/LocationSearchInput';
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 interface RepackEditFormProps {
   invoiceId?: string;
   stockLine: StockLineFragment | null;
   onInsert: (repack: Repack) => void;
+  draft: Repack;
 }
 
 export const RepackEditForm: FC<RepackEditFormProps> = ({
   invoiceId,
   onInsert,
   stockLine,
+  draft,
 }) => {
   const t = useTranslation('inventory');
   const { data } = useStock.repack.get(invoiceId ?? '');
   const [location, setLocation] = useState<LocationRowFragment | null>(null);
+
+  useEffect(() => {
+    setLocation(null);
+  }, [data]);
 
   return (
     <Box display="flex" flexDirection="column" padding={2} gap={1}>
@@ -72,6 +78,7 @@ export const RepackEditForm: FC<RepackEditFormProps> = ({
                 });
               }}
               width={143}
+              value={draft.newPackSize}
               disabled={!!invoiceId}
             />
           }
@@ -86,6 +93,7 @@ export const RepackEditForm: FC<RepackEditFormProps> = ({
                 });
               }}
               width={143}
+              value={draft.numberOfPacks}
               disabled={!!invoiceId}
             />
           }

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -56,25 +56,28 @@ export const RepackModal: FC<RepackModalControlProps> = ({
   const { Modal } = useDialog({ isOpen, onClose });
   const [invoiceId, setInvoiceId] = useState<string | undefined>(undefined);
   const [isNew, setIsNew] = useState<boolean>(false);
+  const defaultRepack = {
+    stockLineId: stockLine?.id,
+    newPackSize: 0,
+    numberOfPacks: 0,
+  };
 
   const { data, isError, isLoading } = useStock.repack.list(
     stockLine?.id ?? ''
   );
-  const { draft, onInsert, onSave } = useDraftRepack({
-    stockLineId: stockLine?.id,
-    newPackSize: 0,
-    numberOfPacks: 0,
-  });
+  const { draft, onInsert, onSave } = useDraftRepack(defaultRepack);
   const { columns } = useRepackColumns();
   const displayMessage = invoiceId == undefined && !isNew;
   const showRepackDetail = invoiceId || isNew;
 
   const onRowClick = (rowData: RepackFragment) => {
+    onInsert(defaultRepack);
     setInvoiceId(rowData.id);
     setIsNew(false);
   };
 
   const onNewClick = () => {
+    onInsert(defaultRepack);
     setInvoiceId(undefined);
     setIsNew(true);
   };
@@ -114,6 +117,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
               if (errorMessage) {
                 error(errorMessage)();
               } else {
+                onInsert(defaultRepack);
                 success(t('messages.saved'))();
               }
             } catch (e) {
@@ -165,6 +169,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
                 invoiceId={invoiceId}
                 onInsert={onInsert}
                 stockLine={stockLine}
+                draft={draft}
               />
             )}
           </Box>

--- a/client/packages/system/src/Stock/api/api.ts
+++ b/client/packages/system/src/Stock/api/api.ts
@@ -147,14 +147,6 @@ export const getStockQueries = (stockApi: StockApi, storeId: string) => ({
       },
     });
 
-    if (result?.insertRepack.__typename === 'InvoiceNode') {
-      return result?.insertRepack;
-    }
-
-    if (result?.insertRepack.error) {
-      throw new Error(result.insertRepack.error.__typename);
-    }
-
-    throw new Error("Can't insert repack");
+    return result.insertRepack;
   },
 });

--- a/client/packages/system/src/Stock/api/hooks/line/useInsertRepack.ts
+++ b/client/packages/system/src/Stock/api/hooks/line/useInsertRepack.ts
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from 'packages/common/src';
 import { useStockApi } from '../utils/useStockApi';
 
-export const useInsertRepack = () => {
+export const useInsertRepack = (stockLineId: string) => {
   const queryClient = useQueryClient();
   const api = useStockApi();
 
   return useMutation(api.insertRepack, {
     onSuccess: () => {
       queryClient.invalidateQueries(api.keys.list());
+      queryClient.invalidateQueries(
+        api.keys.listRepackByStockLine(stockLineId)
+      );
     },
   });
 };

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -60,7 +60,7 @@ export type InsertRepackMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertRepackMutation = { __typename: 'Mutations', insertRepack: { __typename: 'InsertRepackError', error: { __typename: 'StockLineReducedBelowZero', description: string } } | { __typename: 'InvoiceNode', id: string } };
+export type InsertRepackMutation = { __typename: 'Mutations', insertRepack: { __typename: 'InsertRepackError', error: { __typename: 'CannotHaveFractionalPack', description: string } | { __typename: 'StockLineReducedBelowZero', description: string } } | { __typename: 'InvoiceNode', id: string } };
 
 export const StockLineRowFragmentDoc = gql`
     fragment StockLineRow on StockLineNode {
@@ -200,6 +200,10 @@ export const InsertRepackDocument = gql`
       error {
         description
         ... on StockLineReducedBelowZero {
+          __typename
+          description
+        }
+        ... on CannotHaveFractionalPack {
           __typename
           description
         }

--- a/client/packages/system/src/Stock/api/operations.graphql
+++ b/client/packages/system/src/Stock/api/operations.graphql
@@ -137,6 +137,10 @@ mutation insertRepack($input: InsertRepackInput!, $storeId: String!) {
           __typename
           description
         }
+        ... on CannotHaveFractionalPack {
+          __typename
+          description
+        }
       }
     }
   }

--- a/server/graphql/core/src/simple_generic_errors.rs
+++ b/server/graphql/core/src/simple_generic_errors.rs
@@ -223,6 +223,14 @@ impl CannotEditStocktake {
     }
 }
 
+pub struct CannotHaveFractionalPack;
+#[Object]
+impl CannotHaveFractionalPack {
+    pub async fn description(&self) -> &'static str {
+        "Cannot repack to fractional packs."
+    }
+}
+
 // Common Mutation Errors
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 #[graphql(rename_items = "camelCase")]

--- a/server/graphql/repack/mutations/insert.rs
+++ b/server/graphql/repack/mutations/insert.rs
@@ -1,5 +1,6 @@
 use async_graphql::*;
 use graphql_core::{
+    simple_generic_errors::CannotHaveFractionalPack,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
@@ -24,6 +25,7 @@ pub struct InsertRepackInput {
 #[graphql(field(name = "description", type = "String"))]
 pub enum InsertErrorInterface {
     StockLineReducedBelowZero(StockLineReducedBelowZero),
+    CannotHaveFractionalPack(CannotHaveFractionalPack),
 }
 
 #[derive(SimpleObject)]
@@ -102,10 +104,14 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                 StockLineReducedBelowZero::from_domain(line),
             ))
         }
+        ServiceError::CannotHaveFractionalPack => {
+            return Ok(InsertErrorInterface::CannotHaveFractionalPack(
+                CannotHaveFractionalPack {},
+            ))
+        }
         // Standard Graphql Errors
         ServiceError::StockLineDoesNotExist => BadUserInput(formatted_error),
         ServiceError::NotThisStoreStockLine => BadUserInput(formatted_error),
-        ServiceError::CannotHaveFractionalPack => BadUserInput(formatted_error),
         ServiceError::NewlyCreatedInvoiceDoesNotExist => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::InternalError(err) => InternalError(err),

--- a/server/service/src/repack/validate.rs
+++ b/server/service/src/repack/validate.rs
@@ -19,12 +19,12 @@ pub fn validate(
         },
     )?;
 
-    if check_packs_are_fractional(input, &stock_line.stock_line_row) {
-        return Err(CannotHaveFractionalPack);
-    }
-
     if check_stock_line_reduced_to_zero(input, &stock_line.stock_line_row) {
         return Err(StockLineReducedBelowZero(stock_line));
+    }
+
+    if check_packs_are_fractional(input, &stock_line.stock_line_row) {
+        return Err(CannotHaveFractionalPack);
     }
 
     Ok(stock_line.stock_line_row)


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1867 

# 👩🏻‍💻 What does this PR do? 
Show informative error message on StockLineReducedToZero and FractionalPacks. Don't close `Repack` modal on successful save and also clear inputs when changing lines/inserting repack

# 🧪 How has/should this change been tested? 
- Repack a stock line so that it is fractional or becomes reduced to zero and see error notification pop up. 
- Create successful repack and see all input has been cleared. 
- Click `New`, type in inputs, change repack line view, input should be cleared
