### PR TITLE
1445 repack print

### DIFF
--- a/client/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/client/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -29,6 +29,7 @@ export interface ModalProps {
     } & React.RefAttributes<unknown>
   >;
   okButton?: JSX.Element;
+  reportSelector?: React.ReactElement;
   width?: number;
   sx?: SxProps<Theme>;
   title: string;
@@ -129,6 +130,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
     height,
     nextButton,
     okButton,
+    reportSelector,
     width,
     title,
     contentProps,
@@ -200,6 +202,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
           {cancelButton}
           {okButton}
           {WrappedNextButton}
+          {reportSelector}
         </DialogActions>
       </BasicModal>
     );

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2663,6 +2663,7 @@ export type RepackNode = {
   datetime: Scalars['DateTime'];
   from: RepackStockLineNode;
   id: Scalars['String'];
+  invoice: InvoiceNode;
   repackId: Scalars['String'];
   to: RepackStockLineNode;
 };
@@ -2686,6 +2687,7 @@ export type ReportConnector = {
 export enum ReportContext {
   InboundShipment = 'INBOUND_SHIPMENT',
   OutboundShipment = 'OUTBOUND_SHIPMENT',
+  Repack = 'REPACK',
   Requisition = 'REQUISITION',
   Resource = 'RESOURCE',
   Stocktake = 'STOCKTAKE'

--- a/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/AppBarButtons.tsx
@@ -44,10 +44,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem(true)}
         />
-        <ReportSelector
-          context={ReportContext.Stocktake}
-          onClick={printReport}
-        >
+        <ReportSelector context={ReportContext.Stocktake} onPrint={printReport}>
           <LoadingButton
             variant="outlined"
             startIcon={<PrinterIcon />}

--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -48,7 +48,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <AddFromMasterListButton />
         <ReportSelector
           context={ReportContext.InboundShipment}
-          onClick={printReport}
+          onPrint={printReport}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AppBarButtons.tsx
@@ -50,7 +50,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <AddFromScannerButton onAddItem={onAddItem} />
         <ReportSelector
           context={ReportContext.OutboundShipment}
-          onClick={printReport}
+          onPrint={printReport}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -54,7 +54,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
 
         <ReportSelector
           context={ReportContext.Requisition}
-          onClick={printReport}
+          onPrint={printReport}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -35,7 +35,7 @@ export const AppBarButtonsComponent = () => {
         <SupplyRequestedQuantityButton />
         <ReportSelector
           context={ReportContext.Requisition}
-          onClick={printReport}
+          onPrint={printReport}
         >
           <LoadingButton
             variant="outlined"

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -12,7 +12,8 @@ import { ReportRowFragment, useReport } from '../api';
 
 interface ReportSelectorProps {
   context?: ReportContext;
-  onClick: (report: ReportRowFragment) => void;
+  onPrint: (report: ReportRowFragment) => void;
+  disabled?: boolean;
 }
 
 const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
@@ -36,7 +37,8 @@ const NoReports = ({ hasPermission }: { hasPermission: boolean }) => {
 export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   context,
   children,
-  onClick,
+  onPrint,
+  disabled,
 }) => {
   const { hide, PaperClickPopover } = usePaperClickPopover();
   const { data, isLoading } = useReport.document.list(context);
@@ -47,7 +49,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
       label={report.name}
       onClick={() => {
         hide();
-        onClick(report);
+        onPrint(report);
       }}
       key={report.id}
       sx={{ textAlign: 'left', justifyContent: 'left' }}
@@ -59,8 +61,8 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
   const oneReport =
     !isLoading && data?.nodes?.length === 1 ? data.nodes[0] : null;
 
-  return !!oneReport ? (
-    <div onClick={() => onClick(oneReport)}>{children}</div>
+  return !!oneReport && !disabled ? (
+    <div onClick={() => onPrint(oneReport)}>{children}</div>
   ) : (
     <PaperClickPopover
       placement="bottom"
@@ -82,7 +84,7 @@ export const ReportSelector: FC<PropsWithChildren<ReportSelectorProps>> = ({
               display="flex"
               flexDirection="column"
             >
-              {noReports ? (
+              {noReports || disabled ? (
                 <NoReports hasPermission={hasPermission} />
               ) : (
                 reportButtons

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -13,9 +13,18 @@ import {
   useNotification,
   getErrorMessage,
   noOtherVariants,
+  ReportContext,
+  LoadingButton,
+  PrinterIcon,
 } from '@openmsupply-client/common';
 import { RepackEditForm } from './RepackEditForm';
-import { Repack, useStock } from '@openmsupply-client/system';
+import {
+  Repack,
+  ReportRowFragment,
+  ReportSelector,
+  useReport,
+  useStock,
+} from '@openmsupply-client/system';
 import { RepackFragment, StockLineRowFragment } from '../../api';
 import { useRepackColumns } from './column';
 
@@ -53,8 +62,8 @@ export const RepackModal: FC<RepackModalControlProps> = ({
 }) => {
   const t = useTranslation('inventory');
   const { error, success } = useNotification();
-
   const { Modal } = useDialog({ isOpen, onClose });
+
   const [invoiceId, setInvoiceId] = useState<string | undefined>(undefined);
   const [isNew, setIsNew] = useState<boolean>(false);
   const defaultRepack = {
@@ -70,6 +79,13 @@ export const RepackModal: FC<RepackModalControlProps> = ({
   const { columns } = useRepackColumns();
   const displayMessage = invoiceId == undefined && !isNew;
   const showRepackDetail = invoiceId || isNew;
+
+  const { print, isPrinting } = useReport.utils.print();
+
+  const printReport = (report: ReportRowFragment) => {
+    if (!data) return;
+    print({ reportId: report.id, dataId: invoiceId || '' });
+  };
 
   const onRowClick = (rowData: RepackFragment) => {
     onChange(defaultRepack);
@@ -130,6 +146,19 @@ export const RepackModal: FC<RepackModalControlProps> = ({
         />
       }
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      reportSelector={
+        <ReportSelector context={ReportContext.Repack} onClick={printReport}>
+          <LoadingButton
+            sx={{ marginLeft: 1 }}
+            variant="outlined"
+            startIcon={<PrinterIcon />}
+            isLoading={isPrinting}
+            disabled={!invoiceId}
+          >
+            {t('button.print')}
+          </LoadingButton>
+        </ReportSelector>
+      }
     >
       <Box>
         <Grid

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -147,7 +147,11 @@ export const RepackModal: FC<RepackModalControlProps> = ({
       }
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
       reportSelector={
-        <ReportSelector context={ReportContext.Repack} onClick={printReport}>
+        <ReportSelector
+          context={ReportContext.Repack}
+          onPrint={printReport}
+          disabled={!invoiceId}
+        >
           <LoadingButton
             sx={{ marginLeft: 1 }}
             variant="outlined"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/graphql/reports/src/reports.rs
+++ b/server/graphql/reports/src/reports.rs
@@ -37,6 +37,7 @@ pub enum ReportContext {
     Requisition,
     Stocktake,
     Resource,
+    Repack,
 }
 
 #[derive(InputObject, Clone)]
@@ -86,6 +87,7 @@ impl ReportNode {
             ReportContextDomain::Requisition => ReportContext::Requisition,
             ReportContextDomain::Stocktake => ReportContext::Stocktake,
             ReportContextDomain::Resource => ReportContext::Resource,
+            ReportContextDomain::Repack => ReportContext::Repack,
         }
     }
 }
@@ -158,6 +160,7 @@ impl ReportContext {
             ReportContext::Requisition => ReportContextDomain::Requisition,
             ReportContext::Stocktake => ReportContextDomain::Stocktake,
             ReportContext::Resource => ReportContextDomain::Resource,
+            ReportContext::Repack => ReportContextDomain::Repack,
         }
     }
 }

--- a/server/graphql/types/src/types/repack.rs
+++ b/server/graphql/types/src/types/repack.rs
@@ -1,13 +1,13 @@
 use async_graphql::{dataloader::DataLoader, *};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use graphql_core::{
-    loader::{LocationByIdLoader, StockLineByIdLoader},
+    loader::{InvoiceByIdLoader, LocationByIdLoader, StockLineByIdLoader},
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
 };
 use service::repack::query::Repack;
 
-use super::{LocationNode, StockLineNode};
+use super::{InvoiceNode, LocationNode, StockLineNode};
 
 pub struct RepackNode {
     // Invoice id
@@ -37,6 +37,15 @@ pub struct RepackConnector {
 impl RepackNode {
     async fn id(&self) -> &str {
         &self.id
+    }
+
+    async fn invoice(&self, ctx: &Context<'_>) -> Result<InvoiceNode> {
+        let loader = ctx.get_loader::<DataLoader<InvoiceByIdLoader>>();
+        let invoice = loader.load_one(self.id.clone()).await?.ok_or(
+            StandardGraphqlError::InternalError(format!("Cannot find invoice {}", self.id))
+                .extend(),
+        )?;
+        Ok(InvoiceNode { invoice })
     }
 
     async fn repack_id(&self) -> &str {

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -22,6 +22,7 @@ pub enum ReportContext {
     /// Not an actual report but a resource entry used by other reports, e.g. to provide footers or
     /// logos
     Resource,
+    Repack,
 }
 
 table! {

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -8,6 +8,7 @@ mod v1_01_11;
 mod v1_01_12;
 mod v1_01_13;
 mod v1_01_14;
+mod v1_01_15;
 mod version;
 pub(crate) use self::types::*;
 use self::v1_00_04::V1_00_04;
@@ -72,6 +73,7 @@ pub fn migrate(
         Box::new(v1_01_12::V1_01_12),
         Box::new(v1_01_13::V1_01_13),
         Box::new(v1_01_14::V1_01_14),
+        Box::new(v1_01_15::V1_01_15),
     ];
 
     // Historic diesel migrations

--- a/server/repository/src/migrations/v1_01_15/mod.rs
+++ b/server/repository/src/migrations/v1_01_15/mod.rs
@@ -1,0 +1,35 @@
+use super::{version::Version, Migration};
+
+use crate::StorageConnection;
+mod repack_report;
+pub(crate) struct V1_01_15;
+
+impl Migration for V1_01_15 {
+    fn version(&self) -> Version {
+        Version::from_str("1.1.15")
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        repack_report::migrate(connection)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[actix_rt::test]
+async fn migration_1_01_15() {
+    use crate::migrations::*;
+    use crate::test_db::*;
+
+    let version = V1_01_15.version();
+
+    // This test allows checking sql syntax
+    let SetupResult { connection, .. } = setup_test(SetupOption {
+        db_name: &format!("migration_{version}"),
+        version: Some(version.clone()),
+        ..Default::default()
+    })
+    .await;
+
+    assert_eq!(get_database_version(&connection), version);
+}

--- a/server/repository/src/migrations/v1_01_15/repack_report.rs
+++ b/server/repository/src/migrations/v1_01_15/repack_report.rs
@@ -1,0 +1,15 @@
+use crate::StorageConnection;
+
+#[cfg(feature = "postgres")]
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    use crate::migrations::sql;
+
+    sql!(connection, r#"ALTER TYPE context_type ADD VALUE 'REPACK';"#)?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "postgres"))]
+pub(crate) fn migrate(_connection: &StorageConnection) -> anyhow::Result<()> {
+    Ok(())
+}

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -27,6 +27,7 @@ pub enum LegacyReportContext {
     #[serde(rename = "Stock Take")]
     Stocktake,
     #[serde(rename = "Repack Finalised")]
+    Repack,
     #[serde(other)]
     Others,
 }
@@ -79,6 +80,7 @@ impl SyncTranslation for ReportTranslation {
             LegacyReportContext::SupplierInvoice => ReportContext::InboundShipment,
             LegacyReportContext::Requisition => ReportContext::Requisition,
             LegacyReportContext::Stocktake => ReportContext::Stocktake,
+            LegacyReportContext::Repack => ReportContext::Repack,
             LegacyReportContext::Others => return Ok(None),
         };
 

--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -26,7 +26,7 @@ pub enum LegacyReportContext {
     Requisition,
     #[serde(rename = "Stock Take")]
     Stocktake,
-
+    #[serde(rename = "Repack Finalised")]
     #[serde(other)]
     Others,
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1445 

# 👩🏻‍💻 What does this PR do? 
Sync repack reports from central. Add the print button on the repack modal to print out a repack. Also added some more information to the endpoint for the [print report](https://github.com/openmsupply/open-msupply-reports/issues/30).

# 🧪 How has/should this change been tested? 
- Add the repack report from above link to central reports.
- Sync.
- Create a repack, click on the packed line and click print.

## 💌 Any notes for the reviewer?
- The print button looks disabled with styling but isn't actually disabled... tried disabling all the button components in the ReportSelector but doesn't seem to want to disable??? 👀 