### PR TITLE
1877 Display alert when all packs from stock line has been repacked

### DIFF
--- a/client/packages/common/src/intl/locales/en/inventory.json
+++ b/client/packages/common/src/intl/locales/en/inventory.json
@@ -74,6 +74,7 @@
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.no-repacks": "This stock line has not been repacked",
   "messages.no-repack-detail": "Select a line to view the details of a repack or click new to create a new repack",
+  "messages.all-packs-repacked": "Saved. The previous window has been closed since everything in the stock line has been repacked.",
   "status.new": "New",
   "status.finalised": "Finalised",
   "stocktake.description-template": "Created by {{username}} on {{date}}",

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -121,7 +121,12 @@ export const RepackModal: FC<RepackModalControlProps> = ({
                 error(errorMessage)();
               } else {
                 onChange(defaultRepack);
-                success(t('messages.saved'))();
+                if (stockLine?.totalNumberOfPacks === draft.numberOfPacks) {
+                  onClose();
+                  success(t('messages.all-packs-repacked'))();
+                } else {
+                  success(t('messages.saved'))();
+                }
               }
             } catch (e) {
               error(getErrorMessage(e))();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1877 

# 👩🏻‍💻 What does this PR do? 
Use a different alert message if everything in the stock line has been repacked and close the modal

# 🧪 How has/should this change been tested? 
Repack everything in a stock line to see message.