### PR TITLE
Focus the batch input of the first row in a stocktake

### DIFF
--- a/client/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/client/packages/common/src/ui/layout/tables/columns/types.ts
@@ -13,6 +13,7 @@ export interface CellProps<T extends RecordWithId> {
   isDisabled?: boolean;
   isRequired?: boolean;
   isError?: boolean;
+  isAutoFocus?: boolean;
   // Unique name for browser autocomplete (to remember previously entered values for that name)
   autocompleteName?: string;
   localisedText: TypedTFunction<LocaleKey>;

--- a/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -15,7 +15,7 @@ export const TextInputCell = <T extends RecordWithId>({
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
   const updater = useDebounceCallback(column.setter, [column.setter], 500);
   const { maxLength } = column;
-  const autoFocus = rowIndex === 0 && columnIndex === 0;
+  const autoFocus = rowIndex === 0 && columnIndex === 1;
   // This enables browser autocomplete for suggesting previously entered input
   // (input needs to be wrapped in form with autoComplete="on", doesn't quite work in firefox)
   // see https://github.com/openmsupply/open-msupply/pull/305

--- a/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -7,6 +7,7 @@ import { useBufferState, useDebounceCallback } from '@common/hooks';
 export const TextInputCell = <T extends RecordWithId>({
   rowData,
   column,
+  isAutoFocus,
   isDisabled = false,
   rowIndex,
   columnIndex,
@@ -15,7 +16,7 @@ export const TextInputCell = <T extends RecordWithId>({
   const [buffer, setBuffer] = useBufferState(column.accessor({ rowData }));
   const updater = useDebounceCallback(column.setter, [column.setter], 500);
   const { maxLength } = column;
-  const autoFocus = rowIndex === 0 && columnIndex === 1;
+  const autoFocus = isAutoFocus || (rowIndex === 0 && columnIndex === 0);
   // This enables browser autocomplete for suggesting previously entered input
   // (input needs to be wrapped in form with autoComplete="on", doesn't quite work in firefox)
   // see https://github.com/openmsupply/open-msupply/pull/305

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -51,15 +51,12 @@ const useDisableStocktakeRows = (rows?: DraftStocktakeLine[]) => {
   }, [rows]);
 };
 
-const StocktakeTextInputCell = ({
+const BatchInputCell = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isAutoFocus,
   ...props
 }: CellProps<DraftStocktakeLine>): JSX.Element => (
-  <TextInputCell
-    {...props}
-    isAutoFocus={props.rowIndex === 0 && props.columnIndex === 1}
-  />
+  <TextInputCell {...props} isAutoFocus={props.rowIndex === 0} />
 );
 
 const getBatchColumn = (
@@ -72,7 +69,7 @@ const getBatchColumn = (
       width: 150,
       maxWidth: 150,
       maxLength: 50,
-      Cell: StocktakeTextInputCell,
+      Cell: BatchInputCell,
       setter: patch => setter({ ...patch, countThisLine: true }),
       backgroundColor: alpha(theme.palette.background.menu, 0.4),
       accessor: ({ rowData }) => rowData.batch || '',

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -15,6 +15,7 @@ import {
   Theme,
   useTheme,
   useTableStore,
+  CellProps,
 } from '@openmsupply-client/common';
 import { DraftStocktakeLine } from './utils';
 import {
@@ -50,6 +51,17 @@ const useDisableStocktakeRows = (rows?: DraftStocktakeLine[]) => {
   }, [rows]);
 };
 
+const StocktakeTextInputCell = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isAutoFocus,
+  ...props
+}: CellProps<DraftStocktakeLine>): JSX.Element => (
+  <TextInputCell
+    {...props}
+    isAutoFocus={props.rowIndex === 0 && props.columnIndex === 1}
+  />
+);
+
 const getBatchColumn = (
   setter: DraftLineSetter,
   theme: Theme
@@ -60,7 +72,7 @@ const getBatchColumn = (
       width: 150,
       maxWidth: 150,
       maxLength: 50,
-      Cell: TextInputCell,
+      Cell: StocktakeTextInputCell,
       setter: patch => setter({ ...patch, countThisLine: true }),
       backgroundColor: alpha(theme.palette.background.menu, 0.4),
       accessor: ({ rowData }) => rowData.batch || '',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1498

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The default behaviour of the `TextInputCell` is to auto focus if this is the first cell in the first row.
However.. the stocktake input modal has a checkbox in the first column!

Have added an option for the cell to specify whether it is auto focussed or not, and in the case of the stocktake modal, have set this for the first row, second column.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Add a stocktake which has multiple lines:

- On clicking on the first line, the batch input of the first row should have focus.
- On clicking OK & Next, the batch input of the first row should have focus.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
