### PR TITLE
Prevent duplicate save requests for stocktake_lines

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -47,12 +47,13 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const isDisabled = useStocktake.utils.isDisabled();
   const [currentItem, setCurrentItem] = useState(item);
   const isMediumScreen = useIsMediumScreen();
-  const { draftLines, update, addLine, isLoading, save, nextItem } =
+  const { draftLines, update, addLine, isSaving, save, nextItem } =
     useStocktakeLineEdit(currentItem);
   const { setRowStyles } = useRowStyle();
   const { error } = useNotification();
 
   const onNext = async () => {
+    if (isSaving) return;
     const { errorMessages } = await save();
     if (errorMessages) {
       errorMessages.forEach(errorMessage => error(errorMessage)());
@@ -67,6 +68,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   };
 
   const onOk = async () => {
+    if (isSaving) return;
     const { errorMessages } = await save();
     if (errorMessages) {
       errorMessages.forEach(errorMessage => error(errorMessage)());
@@ -100,10 +102,10 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
         mode={mode}
         isOpen={isOpen}
         hasNext={!!nextItem}
-        isValid={hasValidBatches}
+        isValid={hasValidBatches && !isSaving}
       >
         {(() => {
-          if (isLoading) {
+          if (isSaving) {
             return (
               <Box sx={{ height: isMediumScreen ? 350 : 450 }}>
                 <BasicSpinner messageKey="saving" />

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
@@ -16,7 +16,7 @@ interface useStocktakeLineEditController {
   update: (patch: RecordPatch<StocktakeLineFragment>) => void;
   addLine: () => void;
   save: () => Promise<{ errorMessages?: string[] }>;
-  isLoading: boolean;
+  isSaving: boolean;
   nextItem: ItemRowFragment | null;
 }
 
@@ -27,7 +27,8 @@ export const useStocktakeLineEdit = (
   const { id } = useStocktake.document.fields('id');
   const nextItem = useNextItem(item?.id);
   const [draftLines, setDraftLines] = useDraftStocktakeLines(item);
-  const { mutateAsync: upsertLines, isLoading } = useStocktake.line.save();
+  const { mutateAsync: upsertLines, isLoading: isSaving } =
+    useStocktake.line.save();
   const errorsContext = useStocktakeLineErrorContext();
 
   const update = (patch: RecordPatch<DraftStocktakeLine>) =>
@@ -107,7 +108,7 @@ export const useStocktakeLineEdit = (
     update,
     addLine,
     save,
-    isLoading,
+    isSaving,
     nextItem,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1662 

I was only able to replicate the issue by adding a delay to the save mutation, such as:

```
std::thread::sleep(std::time::Duration::from_secs(1));
```

to line 87 in `server/graphql/batch_mutations/src/batch_stocktake.rs`




# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Disable the OK and OK & Next buttons if the mutation is in progress already.
Also renamed the `isLoading` variable to `isSaving` to make things clearer

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
delay the server, or use a slow server. Hastily click the ok button when adding a new stocktake_line

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
