### PR TITLE
1884 Patient creation: input data loss when searching for a patient to quickly

### DIFF
--- a/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
@@ -12,6 +12,7 @@ import {
   useDialog,
   WizardStepper,
   useTranslation,
+  useDebounceCallback,
 } from '@openmsupply-client/common';
 import { PatientFormTab } from './PatientFormTab';
 import { PatientResultsTab } from './PatientResultsTab';
@@ -56,27 +57,14 @@ export const CreatePatientModal: FC<CreatePatientModal> = ({ onClose }) => {
   const { patient, setNewPatient, updatePatient } = usePatientCreateStore();
   const t = useTranslation('patients');
 
-  const onNext = () => {
+  const onNext = useDebounceCallback(() => {
     updatePatient({ canSearch: true });
     onChangeTab(Tabs.SearchResults);
-  };
+  }, []);
 
   const onOk = () => {
     if (patient) {
       navigate(patient.id);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Enter') {
-      switch (currentTab) {
-        case Tabs.Form:
-          onNext();
-          break;
-        case Tabs.SearchResults:
-          onOk();
-          break;
-      }
     }
   };
 
@@ -151,13 +139,7 @@ export const CreatePatientModal: FC<CreatePatientModal> = ({ onClose }) => {
       slideAnimation={false}
     >
       <DetailContainer>
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          gap={2}
-          onKeyDown={handleKeyDown}
-        >
+        <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
           <WizardStepper
             activeStep={getActiveStep()}
             steps={patientSteps}

--- a/client/packages/system/src/Patient/PatientView/Footer.tsx
+++ b/client/packages/system/src/Patient/PatientView/Footer.tsx
@@ -70,11 +70,7 @@ export const Footer: FC<FooterProps> = ({
               color="secondary"
               disabled={!isDirty || !!validationError}
               isLoading={isSaving}
-              onClick={() => {
-                setTimeout(() => {
-                  showSaveConfirmation();
-                }, 100);
-              }}
+              onClick={showSaveConfirmation}
             >
               {createDoc ? t('button.create') : t('button.save')}
             </LoadingButton>

--- a/client/packages/system/src/Patient/PatientView/Footer.tsx
+++ b/client/packages/system/src/Patient/PatientView/Footer.tsx
@@ -70,7 +70,11 @@ export const Footer: FC<FooterProps> = ({
               color="secondary"
               disabled={!isDirty || !!validationError}
               isLoading={isSaving}
-              onClick={() => showSaveConfirmation()}
+              onClick={() => {
+                setTimeout(() => {
+                  showSaveConfirmation();
+                }, 100);
+              }}
             >
               {createDoc ? t('button.create') : t('button.save')}
             </LoadingButton>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1884 

# 👩🏻‍💻 What does this PR do? 
Set a delay on the okay button to allow patient states to be updated.

# 🧪 How has/should this change been tested? 
Create a patient and press okay straight away. All inputted fields should be populated in the Patient View