### PR TITLE
1827 Filter document_registry queries by store permissions

### DIFF
--- a/server/graphql/programs/src/lib.rs
+++ b/server/graphql/programs/src/lib.rs
@@ -78,8 +78,9 @@ impl ProgramsQueries {
         ctx: &Context<'_>,
         filter: Option<DocumentRegistryFilterInput>,
         sort: Option<Vec<DocumentRegistrySortInput>>,
+        store_id: String,
     ) -> Result<DocumentRegistryResponse> {
-        document_registries(ctx, filter, sort)
+        document_registries(ctx, filter, sort, store_id)
     }
 
     pub async fn patients(

--- a/server/graphql/programs/src/queries/document_registry.rs
+++ b/server/graphql/programs/src/queries/document_registry.rs
@@ -55,12 +55,13 @@ pub fn document_registries(
     ctx: &Context<'_>,
     filter: Option<DocumentRegistryFilterInput>,
     sort: Option<Vec<DocumentRegistrySortInput>>,
+    store_id: String,
 ) -> Result<DocumentRegistryResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::QueryDocumentRegistry,
-            store_id: None,
+            store_id: Some(store_id),
         },
     )?;
     let allowed_docs = user.capabilities(CapabilityTag::DocumentType);

--- a/server/service/src/auth.rs
+++ b/server/service/src/auth.rs
@@ -306,7 +306,13 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     );
     map.insert(
         Resource::QueryDocumentRegistry,
-        PermissionDSL::HasDynamicPermission(Permission::DocumentQuery, CapabilityTag::DocumentType),
+        PermissionDSL::And(vec![
+            PermissionDSL::HasDynamicPermission(
+                Permission::DocumentQuery,
+                CapabilityTag::DocumentType,
+            ),
+            PermissionDSL::HasStoreAccess,
+        ]),
     );
     map.insert(
         Resource::MutateDocumentRegistry,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1827

# 👩🏻‍💻 What does this PR do? 
Filter query document registries by store id 

# 🧪 How has/should this change been tested? 
Remove `DocumentQuery` permissions for store and call document registries query for that store... shouldn't see any...