### PR TITLE
OMI30 Sync initialisation resilience to connection loss

### DIFF
--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -10,7 +10,7 @@ pub struct SiteInfoV5 {
     pub(crate) initialisation_status: InitialisationStatus,
 }
 
-// SITE_INITIALISATION_STATUS.4dm
+// See SITE_INITIALISATION_STATUS mSupply method
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InitialisationStatus {

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -3,10 +3,21 @@ use serde::Deserialize;
 use super::*;
 
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SiteInfoV5 {
     pub(crate) id: String,
-    #[serde(rename = "siteId")]
     pub(crate) site_id: i32,
+    pub(crate) initialisation_status: InitialisationStatus,
+}
+
+// SITE_INITIALISATION_STATUS.4dm
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InitialisationStatus {
+    New,
+    Started,
+    Completed,
+    Error,
 }
 
 impl SyncApiV5 {
@@ -39,8 +50,9 @@ mod test {
                     "id": "abc123",
                     "siteId": 123,
                     "code": "s123",
-                    "name": "Site 123"
-            }"#,
+                    "name": "Site 123",
+                    "initialisationStatus": "new"
+                }"#,
             );
         });
 
@@ -55,6 +67,7 @@ mod test {
             SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
+                initialisation_status: InitialisationStatus::New,
             }
         );
     }

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -74,9 +74,9 @@ pub struct RemoteDataSynchroniser {
 impl RemoteDataSynchroniser {
     /// Request initialisation
     /// This api call is blocking, and will wait while central server adds relevant records to sync queue.
-    /// If there is a connection problem while intialisaion is happenning, we don't want to restart initialisation on next sync
-    /// thus polling and check for initialisation status is introduced.
-    /// When initialisaiton is in progress api will return sync_is_running and get_site_info will return initalisationStatus = started
+    /// If there is a connection problem while initialisation is happening, we don't want to restart initialisation on next sync
+    /// thus polling and a check for initialisation status was introduced. When initialisation is in progress,
+    /// api will return `sync_is_running` and `get_site_info` will return `initialisationStatus` = `started`
     pub(crate) async fn request_initialisation(&self) -> Result<(), PostInitialisationError> {
         // First check if already initialising
         let initialisation_status = self

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -76,7 +76,7 @@ impl RemoteDataSynchroniser {
     /// This api call is blocking, and will wait while central server adds relevant records to sync queue.
     /// If there is a connection problem while initialisation is happening, we don't want to restart initialisation on next sync
     /// thus polling and a check for initialisation status was introduced. When initialisation is in progress,
-    /// api will return `sync_is_running` and `get_site_info` will return `initialisationStatus` = `started`
+    /// api will return `initialisation_in_progress` and `get_site_info` will return `initialisationStatus` = `started`
     pub(crate) async fn request_initialisation(&self) -> Result<(), PostInitialisationError> {
         // First check if already initialising
         let initialisation_status = self

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_VERSION: u32 = 1;
+pub(crate) static SYNC_VERSION: u32 = 2;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -128,6 +128,7 @@ async fn sync_status() {
 /// * /queued_records
 /// * /acknowledged_records (placeholder)
 /// * /site (placeholder)
+/// * /site_status (placeholder)
 /// * /final (manually called as last step)
 fn get_initialisation_sync_status_tester(service_provider: Arc<ServiceProvider>) -> Tester {
     Tester::new(service_provider.clone())
@@ -319,7 +320,7 @@ fn get_initialisation_sync_status_tester(service_provider: Arc<ServiceProvider>)
         })
         .add_test("site", |ctx| TestOutput {
             new_status: ctx.current_status,
-            response: r#"{"id":"abc123","siteId": 123}"#.to_string(),
+            response: r#"{"id":"abc123","siteId":123,"initialisationStatus":"new"}"#.to_string(),
         })
         .add_test(
             "final",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes https://github.com/openmsupply/open-msupply-internal/issues/30

Need this central [PR](https://github.com/openmsupply/msupply/pull/13111) with this change [update compatibility](https://github.com/openmsupply/msupply/compare/%2313101-sync-v5-init-status-improvements...13101-Update-compatibility), so best to use [this branch](https://github.com/openmsupply/msupply/tree/13101-Update-compatibility)

# 👩🏻‍💻 What does this PR do? 

* Parse initialisation status from site end point
* Check site before attempting to post initialisation and only post initialisation if it hasn't been started yet

This PR improves on the test done in this [PR](https://github.com/openmsupply/open-msupply/pull/1865)

# 🧪 How has/should this change been tested? 

* Shouldn't work with lower version of mSupply
* Same test as [previous pr](https://github.com/openmsupply/open-msupply/pull/1865), basically try to initialise but break connection while initialising 


