### PR TITLE
1916 change log crate 

### DIFF
--- a/client/packages/android/README.MD
+++ b/client/packages/android/README.MD
@@ -1,9 +1,9 @@
 # Mobile App with Discovery
 
 The Android app can run as standalone site with a local server, as a client connecting to another server or as a server for other clients.
-On android, the server always starts and this allows for one mobile app for both client and client/server. 
-The mobile app will broadcast via dns sd and will be reachable by both Mobile and Electron clients on the local network. 
-We are using Capacitor to make use of existing optimisations and large library of native plugins. 
+On android, the server always starts and this allows for one mobile app for both client and client/server.
+The mobile app will broadcast via dns sd and will be reachable by both Mobile and Electron clients on the local network.
+We are using Capacitor to make use of existing optimisations and large library of native plugins.
 UI is not bundled within Capacitor, it is served by the server the client connect to, and discovery UI is always served by local bundled server.
 
 ## Getting started
@@ -18,7 +18,7 @@ Next step is to open this directory in Android Studio, this will engage gradle s
 
 It's recommended to use Android Studio for debugging and running Android App, there is a lot of functionality that cannot be replicated in Visual Studio Code (although there are some extensions for Visual Studio Code they are quite limited).
 
-Debugging native code is straight forward, breakpoint in Android Studio and press debug. 
+Debugging native code is straight forward, breakpoint in Android Studio and press debug.
 
 Debugging web app code is done by opening `chrome://inspect`, you should see Web View when app is running in emulator. When bundled is served from remote server (default setup), js bundle is minimised and this makes debugging very hard, however we can run the bundle from webpack server by commenting out plugins section in `capacitor.config.ts` and entering your local ip in the debugUrl field and running `yarn apply-config`. Please make sure that you start front end server with `yarn start-local` from 'client' directory for this to work.
 
@@ -28,7 +28,7 @@ When running the Android app in an emulator the service discovery will not work 
 
 ## Scripts
 
-The following scripts are available 
+The following scripts are available
 
 ```bash
 # Builds remote server binaries for android and copies them to android package
@@ -41,7 +41,7 @@ yarn build:release
 yarn apply-config
 ```
 
-As per earlier comment, please make sure to build front end with `yarn build` from client directory prior to runner the above or run `yarn android:{command here}` from client directory to do both with one command. 
+As per earlier comment, please make sure to build front end with `yarn build` from client directory prior to runner the above or run `yarn android:{command here}` from client directory to do both with one command.
 
 ### Know script issues
 
@@ -81,10 +81,10 @@ A few configuration/modifications were made to make sure we can serve Android bu
 
 1. capacitor.config.ts (see comment in that file)
 2. Capacitor `proxies` inject some pre-requisite <scripts> into the target webpage.
-Since the mSupply servers uses self signed certs, fetching the target webpage fails and the pre-requisite scripts are not inserted.
-For this reason `ExtendedWebViewClient` was created to manually inject the required <script> tags.
-[Discussion](https://github.com/ionic-team/capacitor/discussions/6166) was made on capacitor github to see if there is another way to overcome this.
-3. Base url is loaded manually in `handleOnStart()` method in `NativeApi.java` 
+   Since the mSupply servers uses self signed certs, fetching the target webpage fails and the pre-requisite scripts are not inserted.
+   For this reason `ExtendedWebViewClient` was created to manually inject the required <script> tags.
+   [Discussion](https://github.com/ionic-team/capacitor/discussions/6166) was made on capacitor github to see if there is another way to overcome this.
+3. Base url is loaded manually in `handleOnStart()` method in `NativeApi.java`
 
 ## Extra
 
@@ -96,11 +96,11 @@ The cert plugin (`app/src/main/java/org/openmsupply/client/certplugin/CertPlugin
 
 Capacitor comes with cli, we mainly use `npx cap copy` (or `yarn apply-config`), this moves bundled assets to app/src/main/assets/public. Usually capacitor would bundle web app within the APK, since we are serving front end bundle with server we don't need to move them (you will not that in capacitor.config.ts `webDir` is pointed to a non-existant directory). Capacitor also moves pre requisites to cordova plugins to that folder, which is automatically injected into served `html`. Another task of `npx cap copy` is to copy configuration files `capacitor.config.ts` is translated to JSON file and moved to app/src/main/assets
 
-`app/src/main/assets/public` directory is typically not committed, but since it's only going to have cordova artifacts, it is in our case (to reduce setup). 
+`app/src/main/assets/public` directory is typically not committed, but since it's only going to have cordova artifacts, it is in our case (to reduce setup).
 
 `npx cap copy` or `yarn apply-config` should only be run when cordova plugins are added or updated or when updating capacitor.config.ts
 
-When adding plugins - add them to the android package; if they are not here, then `npx cap sync` does not detect them. You should see 
+When adding plugins - add them to the android package; if they are not here, then `npx cap sync` does not detect them. You should see
 
 ```
 ✔ Updating Android plugins in 2.09ms
@@ -117,18 +117,23 @@ If you require the plugin to be used in other packages, then you can also instal
 
 You can check the plugins using `npx cap ls` or the configuration generally with `npx cap doctor`
 
-If you are having gradle issues, open the project (packages/android folder) in Android Studio and then click on the "Sync Project with Gradle Files" button in the top right of Android Studio (the icon looks like an elephant). 
+If you are having gradle issues, open the project (packages/android folder) in Android Studio and then click on the "Sync Project with Gradle Files" button in the top right of Android Studio (the icon looks like an elephant).
 
 ## Self signed cert SSL security
 
 To avoid an error being thrown by the native web view when the server certificate is self-signed, we override the web view certificate error listener and allow connection when:
-* In debug mode
-* The connection is local after verifying the certificate against the local `cert.pem` file : this is for discovery or when connecting to a local server
-*The stored SSL fingerprint matches the server fingerprint
 
-For the above to work we store the SSL fingerprint when we first connect to the server and then check that fingerprint on consecutive connections. 
+- In debug mode
+- The connection is local after verifying the certificate against the local `cert.pem` file : this is for discovery or when connecting to a local server
+  \*The stored SSL fingerprint matches the server fingerprint
+
+For the above to work we store the SSL fingerprint when we first connect to the server and then check that fingerprint on consecutive connections.
 The SSL fingerprint is stored in app data and is associated with the `hardwareId` and `port` of the server.
 This works very similar to ssh client, but we associate fingerprint with hardwareId and port instead of domain or ip since local ip can change for the server.
 
 App data would need to be cleared if the local certificate was changed.
 
+## Log files on Android
+
+Go to `browse files` in device manager, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view log, logs that have exceeded the max file size is compressed and saved as a `.gz` zip.
+Alternatively when using an emulator, navigate to `data/user/0/org.openmsupply.client/files/(log_name).log`.

--- a/client/packages/electron/package.json
+++ b/client/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@openmsupply-client/electron",
   "productName": "open mSupply",
   "//": "Version is updated from the root package.json when electron is built, see the 'make' script below",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Client for omSupply running on local network",
   "main": "./.webpack/main",
   "scripts": {

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -33,6 +33,7 @@ app_data/
 
 # operational logfiles
 **/*.log
+**/*.gz
 
 # report builder server credentials
 report_builder/config.yaml

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4088,6 +4088,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "serde_yaml",
+ "simple-log",
  "tera",
  "thiserror",
  "tokio",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -1676,14 +1676,12 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2951,6 +2949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4076,7 @@ dependencies = [
  "async-trait",
  "bcrypt",
  "chrono",
+ "flate2",
  "headless_chrome",
  "httpmock",
  "jsonwebtoken",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.7",
+ "time 0.3.22",
  "url",
 ]
 
@@ -358,7 +358,6 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "android_logger",
- "fast_log",
  "futures",
  "jni",
  "log",
@@ -368,6 +367,7 @@ dependencies = [
  "repository",
  "server",
  "service",
+ "simple-log",
  "tokio",
 ]
 
@@ -409,6 +409,12 @@ name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
+name = "arc-swap"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayvec"
@@ -748,7 +754,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f9020527994849d0dd91cca0552686b011ca1f580aab008a230ab83b4e48f6"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "serde 1.0.137",
@@ -1088,7 +1094,6 @@ dependencies = [
  "chrono",
  "clap",
  "diesel",
- "fast_log",
  "graphql",
  "log",
  "repository",
@@ -1097,6 +1102,7 @@ dependencies = [
  "serde_json",
  "server",
  "service",
+ "simple-log",
  "tokio",
  "util",
 ]
@@ -1153,13 +1159,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.3.7",
+ "time 0.3.22",
  "version_check",
 ]
 
@@ -1198,59 +1210,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "once_cell",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1474,7 +1437,7 @@ version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1625,7 +1588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -1688,34 +1651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 dependencies = [
  "ascii_utils",
-]
-
-[[package]]
-name = "fast_log"
-version = "1.5.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9221acd04f17815e58aa6b3b98aa8171f9400b24a2c845dc9492d15d275fad"
-dependencies = [
- "crossbeam",
- "crossbeam-channel",
- "crossbeam-utils",
- "fastdate",
- "log",
- "once_cell",
- "serde 1.0.137",
- "serde_json",
-]
-
-[[package]]
-name = "fastdate"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980641094fa68a17b5926dc194a883486652e11fb182c6de6faf3a8a188c0f07"
-dependencies = [
- "libc",
- "once_cell",
- "serde 1.0.137",
- "winapi",
 ]
 
 [[package]]
@@ -2485,6 +2420,15 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -2618,6 +2562,12 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
 
 [[package]]
 name = "isahc"
@@ -2879,8 +2829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "serde 1.0.137",
  "value-bag",
 ]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log-panics"
@@ -2890,6 +2847,30 @@ checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
  "backtrace",
  "log",
+]
+
+[[package]]
+name = "log4rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1ad45e4584824d760c35d71868dd7e6e5acd8f5195a9573743b369fc86cd6"
+dependencies = [
+ "arc-swap",
+ "chrono",
+ "flate2",
+ "fnv",
+ "humantime 1.3.0",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot 0.11.2",
+ "serde 1.0.137",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_yaml",
+ "thread-id",
+ "winapi",
 ]
 
 [[package]]
@@ -2921,15 +2902,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "migrations_internals"
@@ -3104,15 +3076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,7 +3222,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
 ]
@@ -3263,7 +3235,7 @@ checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "windows-sys 0.32.0",
 ]
@@ -3545,6 +3517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,9 +3589,15 @@ checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.7",
+ "time 0.3.22",
  "yasna",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -3631,7 +3615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -3970,6 +3954,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+dependencies = [
+ "ordered-float",
+ "serde 1.0.137",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4039,7 +4033,6 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "fast_log",
  "futures",
  "graphql",
  "graphql_core",
@@ -4058,6 +4051,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "service",
+ "simple-log",
  "thiserror",
  "tokio",
  "util",
@@ -4178,6 +4172,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
+name = "simple-log"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110feefe2a808cadb7fe8c07c615ac82e899f1795fec063ed2fb1d72de5d417b"
+dependencies = [
+ "convert_case 0.5.0",
+ "is_debug",
+ "log",
+ "log4rs",
+ "once_cell",
+ "serde 1.0.137",
+]
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,7 +4194,7 @@ dependencies = [
  "num-bigint 0.4.3",
  "num-traits 0.2.14",
  "thiserror",
- "time 0.3.7",
+ "time 0.3.22",
 ]
 
 [[package]]
@@ -4350,7 +4358,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
 ]
@@ -4424,6 +4432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,22 +4463,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa 1.0.1",
- "libc",
- "num_threads",
  "quickcheck",
+ "serde 1.0.137",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.3"
+name = "time-core"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -5216,7 +5244,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "time 0.3.7",
+ "time 0.3.22",
 ]
 
 [[package]]

--- a/server/android/Cargo.toml
+++ b/server/android/Cargo.toml
@@ -23,4 +23,4 @@ server = { path = "../server", default-features = false, features = [
 ] }
 tokio = { version = "1.17.0", features = ["macros"] }
 android_logger = { version = "0.13.0" }
-fast_log = { version = "1.5" }
+simple-log = { version = "1.6" }

--- a/server/android/README.md
+++ b/server/android/README.md
@@ -1,25 +1,24 @@
- # Android build
+# Android build
 
-
-* Install Android Studio
-* Install NDK (as per screenshot below)  **important to use version 22**
+- Install Android Studio
+- Install NDK (as per screenshot below) **important to use version 22**
 
 ![omSupply Android NDK](./doc/omSupply_android_ndk.png)
 
 Next we need to tell rust compiler to use pre built linked for target Android ABI.
-The two main (supported by devices) ABI architectures are: 
+The two main (supported by devices) ABI architectures are:
 
 | rust target             | android ABI |
-|-------------------------|-------------|
+| ----------------------- | ----------- |
 | aarch64-linux-android   | arm64-v8a   |
 | armv7-linux-androideabi | armeabi-v7a |
 
-* Add targets to to rust `rustup target add aarch64-linux-android && rustup target add armv7-linux-androideabi`
-* Tell rust to use pre built linker from NDK. This is defined in .cargo/config.toml, underd [target.*]. We need to add prebuild Android ABI from NDK to PATH so that linkers/ar files can be found. 
-   * Find your NDK location, my one is `~/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/bin/`
-   * Permanently add NDK_BIN env variable `echo "export NDK_BIN=~/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/bin/" >> ~/.zshrc`
-   * Open new terminal and validate $NDK_BIN is set correctly: `ls $NDK_BIN` (should give a list of files starting with aarch64 and armv7a)
-   * Now we can add `$NDK_BIN` to path when buiding: `PATH=$PATH:$NDK_BIN cargo build --release`
+- Add targets to to rust `rustup target add aarch64-linux-android && rustup target add armv7-linux-androideabi`
+- Tell rust to use pre built linker from NDK. This is defined in .cargo/config.toml, underd [target.*]. We need to add prebuild Android ABI from NDK to PATH so that linkers/ar files can be found.
+  - Find your NDK location, my one is `~/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/bin/`
+  - Permanently add NDK_BIN env variable `echo "export NDK_BIN=~/Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/bin/" >> ~/.zshrc`
+  - Open new terminal and validate $NDK_BIN is set correctly: `ls $NDK_BIN` (should give a list of files starting with aarch64 and armv7a)
+  - Now we can add `$NDK_BIN` to path when buiding: `PATH=$PATH:$NDK_BIN cargo build --release`
 
 `PATH=$PATH:$NDK_BIN cargo build --release` from this directory will build for both ABI mentioned above, it's quicker to build one when doing a debug build `PATH=$PATH:$NDK_BIN cargo build --target aarch64-linux-android --release`
 
@@ -31,3 +30,8 @@ This can be fixed by creating an empty `libunwind.a` file in `$NDK_HOME/{version
 ## How it connects to Mobile ?
 
 See [mobile app readme](../../client/packages/mobile/README.md) for further description of how libs are connected to native java. Specifically `RemoteServer.java`, and referenced yarn scripts
+
+## Log files on Android
+
+Go to `browse files` in `Android Studio`, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view logs.
+Alternatively when using an emulator, navigate to `data/user/0/org.openmsupply.client/files/(log_name).log`.

--- a/server/android/README.md
+++ b/server/android/README.md
@@ -33,5 +33,5 @@ See [mobile app readme](../../client/packages/mobile/README.md) for further desc
 
 ## Log files on Android
 
-Go to `browse files` in `Android Studio`, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view logs.
+Go to `browse files` in `Android Studio`, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view log, logs that have exceeded the max file size is compressed and saved as a `.gz` zip.
 Alternatively when using an emulator, navigate to `data/user/0/org.openmsupply.client/files/(log_name).log`.

--- a/server/android/README.md
+++ b/server/android/README.md
@@ -33,5 +33,5 @@ See [mobile app readme](../../client/packages/mobile/README.md) for further desc
 
 ## Log files on Android
 
-Go to `browse files` in `Android Studio`, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view log, logs that have exceeded the max file size is compressed and saved as a `.gz` zip.
+Go to `browse files` in device manager, then navigate to `data/org.openmsupply.client/files/(log_name).log` to view log, logs that have exceeded the max file size is compressed and saved as a `.gz` zip.
 Alternatively when using an emulator, navigate to `data/user/0/org.openmsupply.client/files/(log_name).log`.

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -64,7 +64,7 @@ pub mod android {
             ),
         };
 
-        logging_init(settings.logging.clone(), None, false);
+        logging_init(settings.logging.clone(), None);
         log_panics::init();
         log::info!("omSupply server starting...");
 

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -6,9 +6,7 @@ pub mod android {
     use std::sync::Mutex;
     use std::thread::{self, JoinHandle};
 
-    use fast_log::appender::{FastLogRecord, LogAppender};
     use jni::sys::jchar;
-    use log::Record;
     use repository::database_settings::DatabaseSettings;
     use server::{logging_init, start_server};
     use service::settings::{LogMode, LoggingSettings, ServerSettings, Settings};
@@ -23,23 +21,6 @@ pub mod android {
     }
 
     static SERVER_BUCKET: Mutex<Option<ServerBucket>> = Mutex::new(None);
-
-    struct AndroidLogger {}
-    impl LogAppender for AndroidLogger {
-        fn do_logs(&self, records: &[FastLogRecord]) {
-            // logs to the android logcat in addition to the standard oms log file
-            records.iter().for_each(|record| {
-                android_logger::log(
-                    &Record::builder()
-                        .args(format_args!("{}", record.args))
-                        .target("omSupply")
-                        .module_path(Some("omSupply"))
-                        .level(record.level)
-                        .build(),
-                )
-            });
-        }
-    }
 
     #[no_mangle]
     pub unsafe extern "C" fn Java_org_openmsupply_client_RemoteServer_startServer(
@@ -83,11 +64,7 @@ pub mod android {
             ),
         };
 
-        logging_init(
-            settings.logging.clone(),
-            Some(Box::new(|config| config.custom(AndroidLogger {}))),
-            None,
-        );
+        logging_init(settings.logging.clone(), None, false);
         log_panics::init();
         log::info!("omSupply server starting...");
 

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -26,7 +26,7 @@ diesel = { version = "1.4.7", default-features = false, features = ["chrono"] }
 chrono = { version = "0.4.23" }
 reqwest = { version = "0.11.10" }
 tokio = { version = "1.17.0", features = ["macros"] }
-fast_log = { version = "1.5" }
+simple-log = { version = "1.6" }
 log = "0.4.14"
 async-graphql = "3.0.35"
 anyhow = "1.0.56"

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -154,7 +154,7 @@ fn set_server_is_initialised(ctx: &ServiceContext) -> anyhow::Result<()> {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     simple_log::new(LogConfigBuilder::builder().output_console().build())
-        .expect("Problem initializing logger");
+        .expect("Unable to initialise logger");
 
     let args = Args::parse();
 

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -1,10 +1,8 @@
-use crate::fast_log::Config;
 use anyhow::anyhow;
 use async_graphql::EmptySubscription;
 use chrono::Utc;
 use clap::StructOpt;
 use cli::RefreshDatesRepository;
-use fast_log;
 use graphql::{Mutations, OperationalSchema, Queries};
 use log::info;
 use repository::{
@@ -25,6 +23,7 @@ use service::{
     },
     token_bucket::TokenBucket,
 };
+use simple_log::LogConfigBuilder;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -154,7 +153,9 @@ fn set_server_is_initialised(ctx: &ServiceContext) -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    fast_log::init(Config::new().console())?;
+    simple_log::new(LogConfigBuilder::builder().output_console().build())
+        .expect("Problem initializing logger");
+
     let args = Args::parse();
 
     let settings: Settings =

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -31,7 +31,7 @@
 # logging:
 ##   one of: All | Console | File
 #   mode: Console
-##   one of:  Off | Error | Warn | Info (default) | Debug | Trace
+##   one of:  Error | Warn | Info (default) | Debug | Trace
 #   level: Info
 #   directory: log
 #   filename: remote_server.log

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -16,7 +16,7 @@ use mutations::{
         update_display_settings, DisplaySettingsInput, UpdateDisplaySettingsResponse,
     },
     initialise_site::{initialise_site, InitialiseSiteResponse},
-    log::{upsert_log_level, LogLevelInput, UpsertLogLevelResponse},
+    log::{update_log_level, LogLevelInput, UpsertLogLevelResponse},
     manual_sync::manual_sync,
     sync_settings::{update_sync_settings, UpdateSyncSettingsResponse},
 };
@@ -308,13 +308,13 @@ impl GeneralMutations {
         insert_barcode(ctx, &store_id, input)
     }
 
-    pub async fn upsert_log_level(
+    pub async fn update_log_level(
         &self,
         ctx: &Context<'_>,
         store_id: String,
         input: LogLevelInput,
     ) -> Result<UpsertLogLevelResponse> {
-        upsert_log_level(ctx, store_id, input)
+        update_log_level(ctx, store_id, input)
     }
 }
 

--- a/server/graphql/general/src/mutations/log.rs
+++ b/server/graphql/general/src/mutations/log.rs
@@ -38,7 +38,6 @@ pub fn update_log_level(
         LogLevelEnum::Info => Level::Info,
         LogLevelEnum::Debug => Level::Debug,
         LogLevelEnum::Trace => Level::Trace,
-        LogLevelEnum::Off => Level::Off,
     };
 
     let service_provider = ctx.service_provider();

--- a/server/graphql/general/src/mutations/log.rs
+++ b/server/graphql/general/src/mutations/log.rs
@@ -19,7 +19,7 @@ pub struct UpsertLogLevelResponse {
     pub level: LogLevelEnum,
 }
 
-pub fn upsert_log_level(
+pub fn update_log_level(
     ctx: &Context<'_>,
     store_id: String,
     input: LogLevelInput,
@@ -46,7 +46,7 @@ pub fn upsert_log_level(
 
     service_provider
         .log_service
-        .upsert_log_level(&service_context, level.clone())?;
+        .update_log_level(&service_context, level.clone())?;
 
     Ok(UpsertLogLevelResponse { level: input.level })
 }

--- a/server/graphql/general/src/queries/log.rs
+++ b/server/graphql/general/src/queries/log.rs
@@ -22,7 +22,6 @@ impl LogNode {
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum LogLevelEnum {
-    Off,
     Error,
     Warn,
     Info,
@@ -91,7 +90,6 @@ pub fn log_level(ctx: &Context<'_>) -> Result<LogLevelNode> {
                 Level::Info => LogLevelEnum::Info,
                 Level::Debug => LogLevelEnum::Debug,
                 Level::Trace => LogLevelEnum::Trace,
-                Level::Off => LogLevelEnum::Off,
             },
             None => LogLevelEnum::Info,
         },

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -48,7 +48,7 @@ clap = { version = "3.1.8", features = ["derive"] }
 rust-embed = "6.4.0"
 mime_guess = "2.0.4"
 futures = "0.3"
-fast_log = { version = "1.5" }
+simple-log = { version = "1.6" }
 rcgen = "0.9.2"
 
 [dev-dependencies]

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn start_server(
             .unwrap();
     }
 
-    logging_init(settings.logging.clone(), None, log_level, true);
+    logging_init(settings.logging.clone(), log_level, true);
 
     // SET HARDWARE UUID
     info!("Setting hardware uuid..");

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -115,11 +115,9 @@ pub async fn start_server(
 
     if log_level.is_none() && settings.logging.is_some() {
         log_service
-            .upsert_log_level(&service_context, settings.logging.clone().unwrap().level)
+            .update_log_level(&service_context, settings.logging.clone().unwrap().level)
             .unwrap();
     }
-
-    logging_init(settings.logging.clone(), log_level, true);
 
     // SET HARDWARE UUID
     info!("Setting hardware uuid..");

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn start_server(
             .unwrap();
     }
 
-    logging_init(settings.logging.clone(), None, log_level);
+    logging_init(settings.logging.clone(), None, log_level, true);
 
     // SET HARDWARE UUID
     info!("Setting hardware uuid..");

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -5,7 +5,7 @@ use simple_log::LogConfigBuilder;
 
 // Can use log4rs to extend logging functionality beyond what is available in current
 // log crate since simple-log is based on log4rs.
-pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>, update: bool) {
+pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>) {
     let settings = settings.unwrap_or(LoggingSettings::new(
         LogMode::Console,
         service::settings::Level::Info,
@@ -24,11 +24,7 @@ pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>, upd
         LogMode::All => file_logger(&settings).level(log_level.to_string()).build(),
     };
 
-    if update {
-        simple_log::update_log_conf(config).expect("Unable to update logger");
-    } else {
-        simple_log::new(config).expect("Unable to initialise logger");
-    }
+    simple_log::new(config).expect("Unable to initialise logger");
 }
 
 fn file_logger(settings: &LoggingSettings) -> LogConfigBuilder {

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -19,11 +19,7 @@ pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>, upd
             .level(log_level.to_string())
             .output_console()
             .build(),
-        LogMode::All => file_logger(&settings)
-            .level(log_level.to_string())
-            .output_console()
-            .output_file()
-            .build(),
+        LogMode::All => file_logger(&settings).level(log_level.to_string()).build(),
     };
 
     if update {

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -7,6 +7,7 @@ pub fn logging_init(
     settings: Option<LoggingSettings>,
     apply_config: Option<Box<dyn Fn(LogConfig) -> LogConfig>>,
     level: Option<Level>,
+    update: bool,
 ) {
     let settings = settings.unwrap_or(LoggingSettings::new(
         LogMode::Console,
@@ -34,7 +35,11 @@ pub fn logging_init(
         config = apply_config(config);
     }
 
-    simple_log::new(config).expect("Unable to initialise logger");
+    if update {
+        simple_log::update_log_conf(config).expect("Unable to update logger");
+    } else {
+        simple_log::new(config).expect("Unable to initialise logger");
+    }
 }
 
 fn file_logger(settings: &LoggingSettings) -> LogConfigBuilder {

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -3,6 +3,8 @@ use std::env;
 use service::settings::{Level, LogMode, LoggingSettings};
 use simple_log::LogConfigBuilder;
 
+// Can use log4rs to extend logging functionality beyond what is available in current
+// log crate since simple-log is based on log4rs.
 pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>, update: bool) {
     let settings = settings.unwrap_or(LoggingSettings::new(
         LogMode::Console,

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -1,21 +1,16 @@
 use std::env;
 
 use service::settings::{Level, LogMode, LoggingSettings};
-use simple_log::{LogConfig, LogConfigBuilder};
+use simple_log::LogConfigBuilder;
 
-pub fn logging_init(
-    settings: Option<LoggingSettings>,
-    apply_config: Option<Box<dyn Fn(LogConfig) -> LogConfig>>,
-    level: Option<Level>,
-    update: bool,
-) {
+pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>, update: bool) {
     let settings = settings.unwrap_or(LoggingSettings::new(
         LogMode::Console,
         service::settings::Level::Info,
     ));
 
     let log_level = level.unwrap_or(settings.level.clone());
-    let mut config = match settings.mode {
+    let config = match settings.mode {
         LogMode::File => file_logger(&settings)
             .level(log_level.to_string())
             .output_file()
@@ -30,10 +25,6 @@ pub fn logging_init(
             .output_file()
             .build(),
     };
-
-    if let Some(apply_config) = apply_config {
-        config = apply_config(config);
-    }
 
     if update {
         simple_log::update_log_conf(config).expect("Unable to update logger");

--- a/server/server/src/logging.rs
+++ b/server/server/src/logging.rs
@@ -1,12 +1,7 @@
 use std::env;
 
-use fast_log::{
-    consts::LogSize,
-    plugin::{file_split::RollingType, packer::LogPacker},
-    Config as LogConfig,
-};
-use log::LevelFilter;
 use service::settings::{Level, LogMode, LoggingSettings};
+use simple_log::{LogConfig, LogConfigBuilder};
 
 pub fn logging_init(
     settings: Option<LoggingSettings>,
@@ -17,23 +12,32 @@ pub fn logging_init(
         LogMode::Console,
         service::settings::Level::Info,
     ));
+
+    let log_level = level.unwrap_or(settings.level.clone());
     let mut config = match settings.mode {
-        LogMode::File => file_logger(&settings),
-        LogMode::Console => LogConfig::new().console(),
-        LogMode::All => file_logger(&settings).console(),
+        LogMode::File => file_logger(&settings)
+            .level(log_level.to_string())
+            .output_file()
+            .build(),
+        LogMode::Console => LogConfigBuilder::builder()
+            .level(log_level.to_string())
+            .output_console()
+            .build(),
+        LogMode::All => file_logger(&settings)
+            .level(log_level.to_string())
+            .output_console()
+            .output_file()
+            .build(),
     };
 
     if let Some(apply_config) = apply_config {
         config = apply_config(config);
     }
 
-    let log_level = level.unwrap_or(settings.level.clone());
-
-    fast_log::init(config.level(LevelFilter::from(log_level)))
-        .expect("Unable to initialise logger");
+    simple_log::new(config).expect("Unable to initialise logger");
 }
 
-fn file_logger(settings: &LoggingSettings) -> LogConfig {
+fn file_logger(settings: &LoggingSettings) -> LogConfigBuilder {
     let default_log_file = "remote_server.log".to_string();
     let default_log_dir = "log".to_string();
     let default_max_file_count = 10;
@@ -55,18 +59,8 @@ fn file_logger(settings: &LoggingSettings) -> LogConfig {
     let max_file_count = settings.max_file_count.unwrap_or(default_max_file_count);
     let max_file_size = settings.max_file_size.unwrap_or(default_max_file_size);
 
-    // file_loop will append to the specified log file until the max size is reached,
-    // then create a new log file with the same name, with date and time appended
-    // file_split will split the temp file when the max file size is reached
-    // and retain the max number of files while the server is running
-    // Note: when the server is started, the temp files are removed. The main log file is
-    // appended to, but only to the max size limit. Only one additional main log is created
-    LogConfig::new()
-        .file_split(
-            &log_dir,
-            LogSize::MB(max_file_size),
-            RollingType::KeepNum(max_file_count),
-            LogPacker {},
-        )
-        .file_loop(&log_file, LogSize::MB(max_file_size))
+    LogConfigBuilder::builder()
+        .path(&log_file)
+        .size(max_file_size as u64)
+        .roll_count(max_file_count as u32)
 }

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
-    logging_init(settings.logging.clone(), None, false);
+    logging_init(settings.logging.clone(), None);
 
     let off_switch = tokio::sync::mpsc::channel(1).1;
     start_server(settings, off_switch).await

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
-    logging_init(settings.logging.clone(), None, None, false);
+    logging_init(settings.logging.clone(), None, false);
 
     let off_switch = tokio::sync::mpsc::channel(1).1;
     start_server(settings, off_switch).await

--- a/server/server/src/main.rs
+++ b/server/server/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(where_clauses_object_safety)]
 
-use server::{configuration, start_server};
+use server::{configuration, logging_init, start_server};
 use service::settings::Settings;
 // use std::sync::mpsc;
 
@@ -8,6 +8,8 @@ use service::settings::Settings;
 async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
+
+    logging_init(settings.logging.clone(), None, None, false);
 
     let off_switch = tokio::sync::mpsc::channel(1).1;
     start_server(settings, off_switch).await

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -29,13 +29,14 @@ tera = "1"
 tokio = { version = "1.17.0", features = ["macros", "sync", "time"] }
 headless_chrome = "1.0.5"
 pretty_assertions = "1.3.0"
+flate2 = "1.0.26"
 
 [dev-dependencies]
 actix-rt = "2.6.0"
 httpmock = "0.6.6"
 rand = "0.8.5"
-actix-web = { version= "4.0.1" } 
-tokio = {version = "1.21.1", features = ["macros","rt-multi-thread", "time" ]}
+actix-web = { version = "4.0.1" }
+tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread", "time"] }
 
 [features]
 default = ["sqlite"]

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.17.0", features = ["macros", "sync", "time"] }
 headless_chrome = "1.0.5"
 pretty_assertions = "1.3.0"
 flate2 = "1.0.26"
+simple-log = { version = "1.6" }
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/service/src/log_service.rs
+++ b/server/service/src/log_service.rs
@@ -63,7 +63,6 @@ pub trait LogServiceTrait: Send + Sync {
 
         let level = match log_level {
             Some(log_level) => match log_level.as_str() {
-                "off" => Some(Level::Off),
                 "error" => Some(Level::Error),
                 "warn" => Some(Level::Warn),
                 "info" => Some(Level::Info),
@@ -85,7 +84,6 @@ pub trait LogServiceTrait: Send + Sync {
         let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
 
         let log_level = match log_level {
-            Level::Off => "off",
             Level::Error => "error",
             Level::Warn => "warn",
             Level::Info => "info",

--- a/server/service/src/log_service.rs
+++ b/server/service/src/log_service.rs
@@ -77,7 +77,7 @@ pub trait LogServiceTrait: Send + Sync {
         Ok(level)
     }
 
-    fn upsert_log_level(
+    fn update_log_level(
         &self,
         ctx: &ServiceContext,
         log_level: Level,
@@ -94,6 +94,7 @@ pub trait LogServiceTrait: Send + Sync {
         };
 
         key_value_store.set_string(KeyValueType::LogLevel, Some(log_level.to_string()))?;
+        simple_log::update_log_level(log_level).expect("Couldn't update log level");
 
         Ok(())
     }

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result};
+
 use log::LevelFilter;
 use repository::database_settings::DatabaseSettings;
 
@@ -71,6 +73,20 @@ impl From<Level> for LevelFilter {
             Level::Debug => LevelFilter::Debug,
             Level::Trace => LevelFilter::Trace,
         }
+    }
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let level = match self {
+            Level::Off => "off",
+            Level::Error => "error",
+            Level::Warn => "warn",
+            Level::Info => "info",
+            Level::Debug => "debug",
+            Level::Trace => "trace",
+        };
+        write!(f, "{}", level)
     }
 }
 

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -54,7 +54,6 @@ pub enum LogMode {
 
 #[derive(serde::Deserialize, Clone, Debug)]
 pub enum Level {
-    Off,
     Error,
     Warn,
     Info,
@@ -65,7 +64,6 @@ pub enum Level {
 impl Display for Level {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let level = match self {
-            Level::Off => "off",
             Level::Error => "error",
             Level::Warn => "warn",
             Level::Info => "info",

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Display, Formatter, Result};
 
-use log::LevelFilter;
 use repository::database_settings::DatabaseSettings;
 
 use crate::sync::settings::SyncSettings;
@@ -61,19 +60,6 @@ pub enum Level {
     Info,
     Debug,
     Trace,
-}
-
-impl From<Level> for LevelFilter {
-    fn from(level: Level) -> Self {
-        match level {
-            Level::Off => LevelFilter::Off,
-            Level::Error => LevelFilter::Error,
-            Level::Warn => LevelFilter::Warn,
-            Level::Info => LevelFilter::Info,
-            Level::Debug => LevelFilter::Debug,
-            Level::Trace => LevelFilter::Trace,
-        }
-    }
 }
 
 impl Display for Level {

--- a/server/service/src/sync/api/post_initialise.rs
+++ b/server/service/src/sync/api/post_initialise.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl SyncApiV5 {
     // Initialize remote sync queue.
-    // Should only be called on initial sync or when re-initializing an existing data file.
+    // Should only be called on initial sync or when re-initialising an existing data file.
     pub(crate) async fn post_initialise(&self) -> Result<RemoteSyncBatchV5, SyncApiError> {
         let route = "/sync/v5/initialise";
         let response = self.do_empty_post(route).await?;

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -65,7 +65,7 @@ mod omsupply_service {
                 return;
             }
         };
-        logging_init(settings.logging.clone(), None);
+        logging_init(settings.logging.clone(), None, true);
 
         panic::set_hook(Box::new(|panic_info| {
             error!("panic occurred {:?}", panic_info);

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -65,7 +65,7 @@ mod omsupply_service {
                 return;
             }
         };
-        logging_init(settings.logging.clone(), None, false);
+        logging_init(settings.logging.clone(), None);
 
         panic::set_hook(Box::new(|panic_info| {
             error!("panic occurred {:?}", panic_info);

--- a/server/windows/src/windows.rs
+++ b/server/windows/src/windows.rs
@@ -65,7 +65,7 @@ mod omsupply_service {
                 return;
             }
         };
-        logging_init(settings.logging.clone(), None, true);
+        logging_init(settings.logging.clone(), None, false);
 
         panic::set_hook(Box::new(|panic_info| {
             error!("panic occurred {:?}", panic_info);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1916

# 👩🏻‍💻 What does this PR do? 
Change the log crate as suggested [here](https://github.com/openmsupply/open-msupply/pull/1897#discussion_r1228834457). This crate allows `log_level` to be updated at runtime, though server will still need to be restarted. Though, the LogSettings can be saved to `key_value_store` and `log_level` update can be moved out of the `start_server` method to allow `log_level` to update without having to restart the server. 

When the log file has exceeded the file size, it is compressed, so have added a check in `get_log_content` to decompress the file to allow content to be fetched.

# 🧪 How has/should this change been tested? 
- Probably best to use a bigger data file so logs get split, then call log endpoints to see information such as log_files/contents.
- Test on Android as well. Initialise on Android -> Go to Admin -> Show log. Log should still be there. 