### PR TITLE
1467 Can create Encounter for a program which the patient isn't enrolled in

### DIFF
--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -34,7 +34,7 @@
   "messages.patients-found_other": "{{count}} patients found matching the supplied details",
   "messages.patients-create": "Click [OK & Next] to add a new patient with the details entered, or click an existing patient below to view their details.",
   "messages.regenerate-id-confirm": "This will create a new ID and cannot be undone.",
-  "messages.inactive-programs": "Programs which are no longer active are shown in red.",
+  "messages.inactive": "Inactive",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id"

--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -34,6 +34,7 @@
   "messages.patients-found_other": "{{count}} patients found matching the supplied details",
   "messages.patients-create": "Click [OK & Next] to add a new patient with the details entered, or click an existing patient below to view their details.",
   "messages.regenerate-id-confirm": "This will create a new ID and cannot be undone.",
+  "messages.inactive-programs": "Programs which are no longer active are shown in red.",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id"

--- a/client/packages/common/src/intl/locales/en/patients.json
+++ b/client/packages/common/src/intl/locales/en/patients.json
@@ -34,7 +34,7 @@
   "messages.patients-found_other": "{{count}} patients found matching the supplied details",
   "messages.patients-create": "Click [OK & Next] to add a new patient with the details entered, or click an existing patient below to view their details.",
   "messages.regenerate-id-confirm": "This will create a new ID and cannot be undone.",
-  "messages.inactive": "Inactive",
+  "messages.inactive": "Program inactive",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id"

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -14,7 +14,6 @@ import {
   useNotification,
   useAuthContext,
   DatePickerInput,
-  ProgramEnrolmentNodeStatus,
 } from '@openmsupply-client/common';
 import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import {
@@ -22,7 +21,6 @@ import {
   PatientModal,
   usePatientModalStore,
   useEncounter,
-  useProgramEnrolments,
 } from '@openmsupply-client/programs';
 import { usePatient } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
@@ -57,13 +55,6 @@ export const CreateEncounterModal: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const [startDateTimeError, setStartDateTimeError] = useState(false);
-
-  const { data } = useProgramEnrolments.document.list({
-    filterBy: {
-      patientId: { equalTo: patientId },
-      status: { notEqualTo: ProgramEnrolmentNodeStatus.Active },
-    },
-  });
 
   const handleSave = useEncounter.document.upsert(
     patientId,
@@ -154,11 +145,6 @@ export const CreateEncounterModal: FC = () => {
     >
       <React.Suspense fallback={<div />}>
         <Stack alignItems="flex-start" gap={1} sx={{ paddingLeft: '20px' }}>
-          {!!data && (
-            <Typography color={'error'} paddingBottom={1}>
-              {t('messages.inactive-programs')}
-            </Typography>
-          )}
           <InputWithLabelRow
             label={t('label.encounter')}
             Input={

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -14,6 +14,7 @@ import {
   useNotification,
   useAuthContext,
   DatePickerInput,
+  ProgramEnrolmentNodeStatus,
 } from '@openmsupply-client/common';
 import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import {
@@ -21,6 +22,7 @@ import {
   PatientModal,
   usePatientModalStore,
   useEncounter,
+  useProgramEnrolments,
 } from '@openmsupply-client/programs';
 import { usePatient } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
@@ -55,6 +57,13 @@ export const CreateEncounterModal: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const [startDateTimeError, setStartDateTimeError] = useState(false);
+
+  const { data } = useProgramEnrolments.document.list({
+    filterBy: {
+      patientId: { equalTo: patientId },
+      status: { notEqualTo: ProgramEnrolmentNodeStatus.Active },
+    },
+  });
 
   const handleSave = useEncounter.document.upsert(
     patientId,
@@ -145,6 +154,11 @@ export const CreateEncounterModal: FC = () => {
     >
       <React.Suspense fallback={<div />}>
         <Stack alignItems="flex-start" gap={1} sx={{ paddingLeft: '20px' }}>
+          {!!data && (
+            <Typography color={'error'} paddingBottom={1}>
+              {t('messages.inactive-programs')}
+            </Typography>
+          )}
           <InputWithLabelRow
             label={t('label.encounter')}
             Input={

--- a/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
+++ b/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
@@ -7,6 +7,7 @@ import {
   ProgramEnrolmentNodeStatus,
   Typography,
   useBufferState,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { usePatient } from '../api';
 import {
@@ -23,21 +24,18 @@ interface EncounterSearchInputProps {
 }
 
 export const getEncounterOptionRenderer =
-  (): AutocompleteOptionRenderer<EncounterRegistryByProgram> =>
+  (
+    t: ReturnType<typeof useTranslation>
+  ): AutocompleteOptionRenderer<EncounterRegistryByProgram> =>
   (props, node) => {
     const name = node.encounter.name ?? '';
+    const isActive = node.program.status === ProgramEnrolmentNodeStatus.Active;
+
     return (
       <DefaultAutocompleteItemOption {...props} key={props.id}>
         <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Typography
-            sx={{
-              color:
-                node.program.status === ProgramEnrolmentNodeStatus.Active
-                  ? 'black'
-                  : 'red',
-            }}
-          >
-            {name}
+          <Typography>
+            {isActive ? name : <i>{`${name} (${t('messages.inactive')})`}</i>}
           </Typography>
         </Box>
       </DefaultAutocompleteItemOption>
@@ -50,6 +48,7 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
   value,
   disabled = false,
 }) => {
+  const t = useTranslation('patients');
   const patientId = usePatient.utils.id();
   const { data: enrolmentData, isLoading: isEnrolmentDataLoading } =
     useProgramEnrolments.document.list({
@@ -62,7 +61,7 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
       enrolmentData?.nodes ?? []
     );
   const [buffer, setBuffer] = useBufferState(value);
-  const EncounterOptionRenderer = getEncounterOptionRenderer();
+  const EncounterOptionRenderer = getEncounterOptionRenderer(t);
 
   return (
     <Autocomplete

--- a/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
+++ b/client/packages/system/src/Patient/Encounter/EncounterSearchInput.tsx
@@ -29,7 +29,16 @@ export const getEncounterOptionRenderer =
     return (
       <DefaultAutocompleteItemOption {...props} key={props.id}>
         <Box display="flex" alignItems="flex-end" gap={1} height={25}>
-          <Typography>{name}</Typography>
+          <Typography
+            sx={{
+              color:
+                node.program.status === ProgramEnrolmentNodeStatus.Active
+                  ? 'black'
+                  : 'red',
+            }}
+          >
+            {name}
+          </Typography>
         </Box>
       </DefaultAutocompleteItemOption>
     );
@@ -46,7 +55,6 @@ export const EncounterSearchInput: FC<EncounterSearchInputProps> = ({
     useProgramEnrolments.document.list({
       filterBy: {
         patientId: { equalTo: patientId },
-        status: { equalTo: ProgramEnrolmentNodeStatus.Active },
       },
     });
   const { data: encounterData, isLoading: isEncounterLoading } =

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -5,7 +5,6 @@ import {
   LoadingButton,
   PrinterIcon,
   useTranslation,
-  ProgramEnrolmentNodeStatus,
 } from '@openmsupply-client/common';
 import React, { FC } from 'react';
 import { AddButton } from './AddButton';
@@ -26,7 +25,6 @@ export const AppBarButtons: FC<{ disabled: boolean }> = ({ disabled }) => {
   const { data: enrolmentData } = useProgramEnrolments.document.list({
     filterBy: {
       patientId: { equalTo: patientId },
-      status: { equalTo: ProgramEnrolmentNodeStatus.Active },
     },
   });
   const disableEncounterButton = enrolmentData?.nodes?.length === 0;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1467 

# 👩🏻‍💻 What does this PR do? 
`Add Encounter` button is only disabled if the patient is enrolled in no programs.

If the patient is enrolled in any programs but the programs are inactive then a message will be displayed to let the user know which programs are inactive (in red text as shown below)
![Screenshot 2023-06-22 at 11 28 29 AM](https://github.com/openmsupply/open-msupply/assets/61820074/69a99049-9c8d-4c78-9ed0-35a47461da31)

# 🧪 How has/should this change been tested? 
Enrol patient into any program.
Change the status of the program to anything but `Active`
Click on `Add Encounter` button
See inactive programs in red in the dropdown list