### PR TITLE
1846 Add note input field when creating a new encounter

### DIFF
--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -14,6 +14,7 @@ import {
   useNotification,
   useAuthContext,
   DatePickerInput,
+  TextArea,
 } from '@openmsupply-client/common';
 import { DateUtils, useIntlUtils, useTranslation } from '@common/intl';
 import {
@@ -21,6 +22,7 @@ import {
   PatientModal,
   usePatientModalStore,
   useEncounter,
+  NoteSchema,
 } from '@openmsupply-client/programs';
 import { usePatient } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
@@ -30,6 +32,7 @@ import {
   ClinicianAutocompleteOption,
   ClinicianSearchInput,
 } from '../../Clinician';
+
 interface Encounter {
   status?: EncounterNodeStatus;
   createdDatetime: string;
@@ -38,6 +41,7 @@ interface Encounter {
   endDatetime?: string;
   clinician?: Clinician;
   location?: { storeId?: string };
+  notes?: NoteSchema[];
 }
 
 export const CreateEncounterModal: FC = () => {
@@ -55,6 +59,7 @@ export const CreateEncounterModal: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const [startDateTimeError, setStartDateTimeError] = useState(false);
+  const [note] = useState<NoteSchema | undefined>(undefined);
 
   const handleSave = useEncounter.document.upsert(
     patientId,
@@ -67,6 +72,7 @@ export const CreateEncounterModal: FC = () => {
     setEncounterRegistry(undefined);
     setDraft(undefined);
     setDataError(false);
+    setNote(undefined);
   };
 
   const { Modal } = useDialog({
@@ -109,6 +115,10 @@ export const CreateEncounterModal: FC = () => {
     }
     const clinician = option.value;
     setDraft({ ...currentOrNewDraft(), clinician });
+  };
+
+  const setNote = (notes: NoteSchema[] | undefined): void => {
+    setDraft({ ...currentOrNewDraft(), notes });
   };
 
   const canSubmit = () =>
@@ -183,6 +193,29 @@ export const CreateEncounterModal: FC = () => {
                       )}
                       clinicianValue={draft?.clinician}
                       width={250}
+                    />
+                  }
+                />
+                <InputWithLabelRow
+                  label={t('label.visit-notes')}
+                  Input={
+                    <TextArea
+                      InputProps={{
+                        sx: {
+                          backgroundColor: 'background.drawer',
+                        },
+                      }}
+                      value={note}
+                      onChange={e => {
+                        setNote([
+                          {
+                            authorId: user?.id,
+                            authorName: user?.name,
+                            created: new Date().toISOString(),
+                            text: e.target.value,
+                          },
+                        ]);
+                      }}
                     />
                   }
                 />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1846 

# 👩🏻‍💻 What does this PR do? 
Adds a note component to the `Create Encounter` modal which will display in the Encounter -> Side Panel note component. Currently only a single note component is implemented for Encounters... Might want to change this to display as an array, so users can see initial notes as well as updated notes. 

# 🧪 How has/should this change been tested? 
Create an encounter with some note
See note displayed in the side panel when redirected