### PR TITLE
1773 Refactor "useItemFilter" to common hook

### DIFF
--- a/client/packages/common/src/utils/index.ts
+++ b/client/packages/common/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './object';
 export * from './types';
 export * from './files';
 export * from './BarcodeScannerContext';
+export * from './item';
 
 // having issues with tree shaking lodash
 // so we're just importing the functions we need

--- a/client/packages/common/src/utils/item/ItemUtils.ts
+++ b/client/packages/common/src/utils/item/ItemUtils.ts
@@ -2,22 +2,27 @@ import { useUrlQuery } from '@common/hooks';
 import { ItemNode } from '@common/types';
 import { RegexUtils } from '../regex';
 
-export const ItemUtils = {
-  itemFilter: () => {
-    const { urlQuery, updateQuery } = useUrlQuery({
-      skipParse: ['codeOrName'],
-    });
-    return {
-      itemFilter: urlQuery.codeOrName ?? '',
-      setItemFilter: (itemFilter: string) =>
-        updateQuery({ codeOrName: itemFilter }),
-    };
-  },
-  matchItem: (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+export const useItemUtils = () => {
+  const { urlQuery, updateQuery } = useUrlQuery({
+    skipParse: ['codeOrName'],
+  });
+
+  const itemFilter = urlQuery.codeOrName ?? '';
+
+  const setItemFilter = (itemFilter: string) =>
+    updateQuery({ codeOrName: itemFilter });
+
+  const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
     const filter = RegexUtils.escapeChars(itemFilter);
     return (
       RegexUtils.includes(filter, name ?? '') ||
       RegexUtils.includes(filter, code ?? '')
     );
-  },
+  };
+
+  return {
+    itemFilter,
+    setItemFilter,
+    matchItem,
+  };
 };

--- a/client/packages/common/src/utils/item/ItemUtils.ts
+++ b/client/packages/common/src/utils/item/ItemUtils.ts
@@ -1,0 +1,23 @@
+import { useUrlQuery } from '@common/hooks';
+import { ItemNode } from '@common/types';
+import { RegexUtils } from '../regex';
+
+export const ItemUtils = {
+  itemFilter: () => {
+    const { urlQuery, updateQuery } = useUrlQuery({
+      skipParse: ['codeOrName'],
+    });
+    return {
+      itemFilter: urlQuery.codeOrName ?? '',
+      setItemFilter: (itemFilter: string) =>
+        updateQuery({ codeOrName: itemFilter }),
+    };
+  },
+  matchItem: (itemFilter: string, { name, code }: Partial<ItemNode>) => {
+    const filter = RegexUtils.escapeChars(itemFilter);
+    return (
+      RegexUtils.includes(filter, name ?? '') ||
+      RegexUtils.includes(filter, code ?? '')
+    );
+  },
+};

--- a/client/packages/common/src/utils/item/index.ts
+++ b/client/packages/common/src/utils/item/index.ts
@@ -1,0 +1,1 @@
+export * from './ItemUtils';

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import {
   ItemNode,
-  ItemUtils,
   SortUtils,
+  useItemUtils,
   useUrlQueryParams,
 } from '@openmsupply-client/common';
 import { useStocktakeColumns } from '../../../DetailView';
@@ -16,7 +16,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'desc' } });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
-  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
+  const { itemFilter, setItemFilter, matchItem } = useItemUtils();
   const columns = useStocktakeColumns({
     onChangeSortBy: updateSortQuery,
     sortBy,
@@ -31,7 +31,7 @@ export const useStocktakeRows = (isGrouped = true) => {
     );
     return items
       ?.filter(item => {
-        return ItemUtils.matchItem(itemFilter, item.item as ItemNode);
+        return matchItem(itemFilter, item.item as ItemNode);
       })
       ?.sort(sorter);
   }, [items, sortBy.key, sortBy.isDesc, itemFilter]);
@@ -45,7 +45,7 @@ export const useStocktakeRows = (isGrouped = true) => {
     );
     return lines
       ?.filter(line => {
-        return ItemUtils.matchItem(itemFilter, line.item);
+        return matchItem(itemFilter, line.item);
       })
       ?.sort(sorter);
   }, [lines, sortBy.key, sortBy.isDesc, itemFilter]);

--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -1,31 +1,13 @@
 import { useMemo } from 'react';
 import {
   ItemNode,
-  RegexUtils,
+  ItemUtils,
   SortUtils,
-  useUrlQuery,
   useUrlQueryParams,
 } from '@openmsupply-client/common';
 import { useStocktakeColumns } from '../../../DetailView';
 import { useStocktakeLines } from './useStocktakeLines';
 import { useStocktakeItems } from './useStocktakeItems';
-
-const useItemFilter = () => {
-  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['codeOrName'] });
-  return {
-    itemFilter: urlQuery.codeOrName ?? '',
-    setItemFilter: (itemFilter: string) =>
-      updateQuery({ codeOrName: itemFilter }),
-  };
-};
-
-const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
-  const filter = RegexUtils.escapeChars(itemFilter);
-  return (
-    RegexUtils.includes(filter, name ?? '') ||
-    RegexUtils.includes(filter, code ?? '')
-  );
-};
 
 export const useStocktakeRows = (isGrouped = true) => {
   const {
@@ -34,7 +16,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'desc' } });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
-  const { itemFilter, setItemFilter } = useItemFilter();
+  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
   const columns = useStocktakeColumns({
     onChangeSortBy: updateSortQuery,
     sortBy,
@@ -49,7 +31,7 @@ export const useStocktakeRows = (isGrouped = true) => {
     );
     return items
       ?.filter(item => {
-        return matchItem(itemFilter, item.item as ItemNode);
+        return ItemUtils.matchItem(itemFilter, item.item as ItemNode);
       })
       ?.sort(sorter);
   }, [items, sortBy.key, sortBy.isDesc, itemFilter]);
@@ -63,7 +45,7 @@ export const useStocktakeRows = (isGrouped = true) => {
     );
     return lines
       ?.filter(line => {
-        return matchItem(itemFilter, line.item);
+        return ItemUtils.matchItem(itemFilter, line.item);
       })
       ?.sort(sorter);
   }, [lines, sortBy.key, sortBy.isDesc, itemFilter]);

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
-import { SortUtils, ItemUtils } from '@openmsupply-client/common';
+import { SortUtils, useItemUtils } from '@openmsupply-client/common';
 import { useRequestColumns } from '../../../DetailView/columns';
 import { useHideOverStocked } from '../index';
 import { useRequestFields } from '../document/useRequestFields';
 
 export const useRequestLines = () => {
   const { on } = useHideOverStocked();
-  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
+  const { itemFilter, setItemFilter, matchItem } = useItemUtils();
   const { columns, onChangeSortBy, sortBy } = useRequestColumns();
   const { lines, minMonthsOfStock } = useRequestFields([
     'lines',
@@ -27,10 +27,10 @@ export const useRequestLines = () => {
         item =>
           item.itemStats.availableStockOnHand <
             item.itemStats.averageMonthlyConsumption * minMonthsOfStock &&
-          ItemUtils.matchItem(itemFilter, item.item)
+          matchItem(itemFilter, item.item)
       );
     } else {
-      return sorted.filter(item => ItemUtils.matchItem(itemFilter, item.item));
+      return sorted.filter(item => matchItem(itemFilter, item.item));
     }
   }, [sortBy.key, sortBy.isDesc, lines, on, minMonthsOfStock, itemFilter]);
 

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/line/useRequestLines.ts
@@ -1,34 +1,12 @@
 import { useMemo } from 'react';
-import {
-  SortUtils,
-  RegexUtils,
-  useUrlQuery,
-  ItemNode,
-} from '@openmsupply-client/common';
+import { SortUtils, ItemUtils } from '@openmsupply-client/common';
 import { useRequestColumns } from '../../../DetailView/columns';
 import { useHideOverStocked } from '../index';
 import { useRequestFields } from '../document/useRequestFields';
 
-const useItemFilter = () => {
-  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['codeOrName'] });
-  return {
-    itemFilter: urlQuery.codeOrName ?? '',
-    setItemFilter: (itemFilter: string) =>
-      updateQuery({ codeOrName: itemFilter }),
-  };
-};
-
-const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
-  const filter = RegexUtils.escapeChars(itemFilter);
-  return (
-    RegexUtils.includes(filter, name ?? '') ||
-    RegexUtils.includes(filter, code ?? '')
-  );
-};
-
 export const useRequestLines = () => {
   const { on } = useHideOverStocked();
-  const { itemFilter, setItemFilter } = useItemFilter();
+  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
   const { columns, onChangeSortBy, sortBy } = useRequestColumns();
   const { lines, minMonthsOfStock } = useRequestFields([
     'lines',
@@ -49,10 +27,10 @@ export const useRequestLines = () => {
         item =>
           item.itemStats.availableStockOnHand <
             item.itemStats.averageMonthlyConsumption * minMonthsOfStock &&
-          matchItem(itemFilter, item.item)
+          ItemUtils.matchItem(itemFilter, item.item)
       );
     } else {
-      return sorted.filter(item => matchItem(itemFilter, item.item));
+      return sorted.filter(item => ItemUtils.matchItem(itemFilter, item.item));
     }
   }, [sortBy.key, sortBy.isDesc, lines, on, minMonthsOfStock, itemFilter]);
 

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
@@ -3,9 +3,7 @@ import {
   SortController,
   SortUtils,
   Column,
-  RegexUtils,
-  useUrlQuery,
-  ItemNode
+  ItemUtils,
 } from '@openmsupply-client/common';
 import { ResponseLineFragment } from '../../operations.generated';
 import { useResponseColumns } from '../../../DetailView/columns';
@@ -20,28 +18,10 @@ interface UseResponseLinesController
   onChangeSortBy: any;
 }
 
-const useItemFilter = () => {
-  // const { urlQuery, updateQuery } = useUrlQuery();
-  const { urlQuery, updateQuery } = useUrlQuery({ skipParse: ['codeOrName'] });
-  return {
-    itemFilter: urlQuery.codeOrName ?? '',
-    setItemFilter: (itemFilter: string) =>
-      updateQuery({ codeOrName: itemFilter }),
-  };
-};
-
-const matchItem = (itemFilter: string, { name, code }: Partial<ItemNode>) => {
-  const filter = RegexUtils.escapeChars(itemFilter);
-  return (
-    RegexUtils.includes(filter, name ?? '') ||
-    RegexUtils.includes(filter, code ?? '')
-  );
-};
-
 export const useResponseLines = (): UseResponseLinesController => {
   const { lines } = useResponseFields('lines');
   const { columns, onChangeSortBy, sortBy } = useResponseColumns();
-  const { itemFilter, setItemFilter } = useItemFilter();
+  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
 
   const sorted = useMemo(() => {
     const currentColumn = columns.find(({ key }) => key === sortBy.key);
@@ -51,9 +31,9 @@ export const useResponseLines = (): UseResponseLinesController => {
           SortUtils.getColumnSorter(getSortValue, !!sortBy.isDesc)
         )
       : lines?.nodes;
-    return sortedLines.filter(
-      item => matchItem(itemFilter, item.item)
-    )
+    return sortedLines.filter(item =>
+      ItemUtils.matchItem(itemFilter, item.item)
+    );
   }, [sortBy.key, sortBy.isDesc, lines, itemFilter]);
 
   return {

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/line/useResponseLines.ts
@@ -3,7 +3,7 @@ import {
   SortController,
   SortUtils,
   Column,
-  ItemUtils,
+  useItemUtils,
 } from '@openmsupply-client/common';
 import { ResponseLineFragment } from '../../operations.generated';
 import { useResponseColumns } from '../../../DetailView/columns';
@@ -21,7 +21,7 @@ interface UseResponseLinesController
 export const useResponseLines = (): UseResponseLinesController => {
   const { lines } = useResponseFields('lines');
   const { columns, onChangeSortBy, sortBy } = useResponseColumns();
-  const { itemFilter, setItemFilter } = ItemUtils.itemFilter();
+  const { itemFilter, setItemFilter, matchItem } = useItemUtils();
 
   const sorted = useMemo(() => {
     const currentColumn = columns.find(({ key }) => key === sortBy.key);
@@ -31,9 +31,7 @@ export const useResponseLines = (): UseResponseLinesController => {
           SortUtils.getColumnSorter(getSortValue, !!sortBy.isDesc)
         )
       : lines?.nodes;
-    return sortedLines.filter(item =>
-      ItemUtils.matchItem(itemFilter, item.item)
-    );
+    return sortedLines.filter(item => matchItem(itemFilter, item.item));
   }, [sortBy.key, sortBy.isDesc, lines, itemFilter]);
 
   return {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1773 

# 👩🏻‍💻 What does this PR do? 
Moved `useItemFilter` and `matchItem` to common. 

# 🧪 How has/should this change been tested? 
Test if item search functionality is still working in requisitions and stocktake