### PR TITLE
1899 Stop modals from closing when clicking outside

### DIFF
--- a/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
@@ -52,6 +52,7 @@ export const CreatePatientModal: FC<CreatePatientModal> = ({ onClose }) => {
   const { currentTab, onChangeTab } = useTabs(Tabs.Form);
   const { Modal, showDialog, hideDialog } = useDialog({
     onClose,
+    disableBackdrop: true,
   });
   const navigate = useNavigate();
   const { patient, setNewPatient, updatePatient } = usePatientCreateStore();

--- a/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
+++ b/client/packages/system/src/Patient/Encounter/CreateEncounterModal.tsx
@@ -72,6 +72,7 @@ export const CreateEncounterModal: FC = () => {
   const { Modal } = useDialog({
     isOpen: current === PatientModal.Encounter,
     onClose: reset,
+    disableBackdrop: true,
   });
 
   const onChangeEncounter = (entry: EncounterRegistryByProgram) => {

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/DetailModal.tsx
@@ -63,6 +63,7 @@ export const ProgramDetailModal: FC = () => {
   const { Modal } = useDialog({
     isOpen: current === PatientModal.Program,
     onClose: reset,
+    disableBackdrop: true,
   });
 
   const isCreating = document?.name === undefined;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1899

# 👩🏻‍💻 What does this PR do? 
Upon further inspection, data lost only happens for Creation modals, so have only disabled backdrop on those since it is easy to mis-click outside.

# 🧪 How has/should this change been tested? 
Try to close by clicking outside any of the creation modals