### PR TITLE
1841 ID Generator reverts to previous value 

### DIFF
--- a/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
+++ b/client/packages/programs/src/JsonForms/components/IdGenerator.tsx
@@ -356,6 +356,7 @@ const UIComponent = (props: ControlProps) => {
       id = nextId;
       if (finished) break;
     }
+    onChange(id);
     setCustomError(undefined);
     handleChange(path, id);
   }, [options, path, core?.data, handleChange]);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1841

# 👩🏻‍💻 What does this PR do? 
Wasn't getting the jittering... The text state was just not changing for me at all. Updating the debouncedText input with the generated ID.

# 🧪 How has/should this change been tested? 
Generate an id for the patient
Save patient information 
Go back to same patient and generate a new id
Text component should now update with new generated id
Save patient info
See new id has been saved