### PR TITLE
1899 Stop modals from closing when clicking outside 

### DIFF
--- a/client/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/client/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -99,7 +99,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
     onClose,
     isOpen,
     animationTimeout = 500,
-    disableBackdrop = false,
+    disableBackdrop = true,
     disableEscapeKey = false,
   } = dialogProps ?? {};
   const [open, setOpen] = React.useState(false);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1899

# 👩🏻‍💻 What does this PR do? 
Have defaulted disableBackdrop to true for all modals. This doesn't affect notifications, or modals without an ok/cancel button since they use different hooks. The confirmation modals also didn't close on backdrop in the first place, so have just left it. 

# 🧪 How has/should this change been tested? 
Find any modals with ok/cancel that has data entry and try to close by clicking out of the modal