### PR TITLE
1661 contact info

### DIFF
--- a/client/packages/common/src/intl/locales/en/programs.json
+++ b/client/packages/common/src/intl/locales/en/programs.json
@@ -8,6 +8,7 @@
   "control.search.search-patient-placeholder": "Search by patient code...",
   "control.search.error.no-document": "Unable to access requested document",
   "control.search.error.no-data": "Unable to extract path \"{{docPath}}\" from document",
+  "control.search.error.no-patient-contact": "No matching patient contact found",
   "control.search.below-min-chars": "Please enter at least {{minChars}} characters",
   "label.total-quantity": "Total Quantity"
 }

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -43,6 +43,8 @@ import {
   ConditionalSelect,
   spacerTester,
   Spacer,
+  keyedItemArrayTester,
+  KeyedItemArray,
 } from './components';
 import {
   AccordionGroup,
@@ -174,6 +176,7 @@ const renderers = [
   { tester: datetimeTester, renderer: DateTime },
   { tester: arrayTester, renderer: ArrayControl },
   { tester: firstItemArrayTester, renderer: FirstItemArray },
+  { tester: keyedItemArrayTester, renderer: KeyedItemArray },
   { tester: categorizationTabLayoutTester, renderer: CategorizationTabLayout },
   { tester: autocompleteTester, renderer: Autocomplete },
   { tester: conditionalSelectTester, renderer: ConditionalSelect },

--- a/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
@@ -68,10 +68,10 @@ const KeyedItemArrayComponent: ComponentType<
   useEffect(() => {
     if (!options) return;
     const arrayData = data ?? [];
-    const elementIndex = arrayData.findIndex(it => {
-      if (!it || typeof it !== 'object' || Array.isArray(it)) return;
+    const elementIndex = arrayData.findIndex(item => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return;
 
-      return it[options.keyField] === options.keyValue;
+      return item[options.keyField] === options.keyValue;
     });
     if (elementIndex >= 0) {
       // Only set the index when the entry exists otherwise the renderer might overwrite the object

--- a/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
@@ -1,0 +1,134 @@
+import React, { ComponentType, useEffect, useMemo, useState } from 'react';
+import {
+  rankWith,
+  ArrayControlProps,
+  findUISchema,
+  ControlElement,
+  composePaths,
+  uiTypeIs,
+  ControlProps,
+} from '@jsonforms/core';
+import {
+  withJsonFormsArrayControlProps,
+  JsonFormsDispatch,
+} from '@jsonforms/react';
+import { Typography } from '@openmsupply-client/common';
+
+import { JsonData } from '../../JsonForm';
+import { z } from 'zod';
+import { useZodOptionsValidation } from '../../hooks/useZodOptionsValidation';
+
+const Options = z
+  .object({
+    /** The field in the object which is used to extract the keyValue */
+    keyField: z.string(),
+    keyValue: z.string(),
+    detail: z.any().optional(),
+  })
+  .strict();
+type Options = z.infer<typeof Options>;
+
+interface UISchemaWithCustomProps extends ControlElement {
+  defaultNewItem?: JsonData;
+  itemLabel?: string;
+}
+
+interface KeyedItemArrayControlCustomProps
+  extends ArrayControlProps,
+    ControlProps {
+  uischema: UISchemaWithCustomProps;
+  data: JsonData[];
+  options: Options;
+}
+
+export const keyedItemArrayTester = rankWith(10, uiTypeIs('KeyedItemArray'));
+
+const KeyedItemArrayComponent: ComponentType<
+  KeyedItemArrayControlCustomProps
+> = (props: KeyedItemArrayControlCustomProps) => {
+  const {
+    uischema,
+    uischemas,
+    schema,
+    path,
+    enabled,
+    visible,
+    rootSchema,
+    renderers,
+    data,
+    handleChange,
+  } = props;
+
+  const [index, setIndex] = useState<number>(-1);
+  const { errors: zErrors, options } = useZodOptionsValidation(
+    Options,
+    uischema.options
+  );
+
+  useEffect(() => {
+    if (!options) return;
+    const arrayData = data ?? [];
+    const elementIndex = arrayData.findIndex(it => {
+      if (!it || typeof it !== 'object' || Array.isArray(it)) return;
+
+      return it[options.keyField] === options.keyValue;
+    });
+    if (elementIndex >= 0) {
+      // Only set the index when the entry exists otherwise the renderer might overwrite the object
+      // created below, removing the the `keyField` while doing so...
+      setIndex(elementIndex);
+      return;
+    }
+    arrayData.push({
+      [options.keyField]: options.keyValue,
+    });
+    handleChange(path, arrayData);
+  }, [options, data]);
+
+  const childUiSchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas ?? [],
+        schema,
+        uischema.scope,
+        path,
+        undefined,
+        uischema,
+        rootSchema
+      ),
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
+  );
+
+  const childPath = composePaths(path, `${index}`);
+
+  if (zErrors) {
+    return <Typography color="error">{zErrors}</Typography>;
+  }
+
+  if (!visible || index < 0) return null;
+
+  return (
+    <JsonFormsDispatch
+      key={childPath}
+      schema={schema}
+      uischema={childUiSchema || uischema}
+      enabled={enabled}
+      path={childPath}
+      renderers={renderers}
+    />
+  );
+};
+
+/**
+ * Displays the first item from an array of objects which contains a `keyField` with a matching
+ * `keyValue`.
+ *
+ * For example, with the config `keyField: "key"` and `keyValue: "KeyValue"` the second item from
+ * the following list will be displayed.
+ * `[{"key": "Value1", ...}, {"key": "KeyValue", ...}]`
+ *
+ * How the object is displayed is configured using a default `detail` option.
+ */
+export const KeyedItemArray = withJsonFormsArrayControlProps(
+  KeyedItemArrayComponent as ComponentType<ArrayControlProps>
+);

--- a/client/packages/programs/src/JsonForms/common/components/Array/index.ts
+++ b/client/packages/programs/src/JsonForms/common/components/Array/index.ts
@@ -3,3 +3,4 @@ export * from './FirstItemArray';
 export * from './common';
 export * from './EnumArray';
 export * from './Notes';
+export * from './KeyedItemArray';

--- a/client/packages/programs/src/JsonForms/components/Search/Search.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/Search.tsx
@@ -6,6 +6,7 @@ import { useZodOptionsValidation } from '../../common/hooks/useZodOptionsValidat
 import { SearchWithUserSource } from './SearchWithUserSource';
 import { SearchWithDocumentSource } from './SearchWithDocumentSource';
 import { QueryValues } from './useSearchQueries';
+import { SearchWithPatientContactSource } from './SearchWithPatientContactSource';
 
 const UserOptions = z.object({
   /**
@@ -48,10 +49,29 @@ const DocumentOptions = z.object({
   saveFields: z.array(z.string()).optional(),
 });
 
-const Options = z.discriminatedUnion('source', [DocumentOptions, UserOptions]);
+const PatientContactOptions = z.object({
+  /**
+   * Source of the search data -- looks up the first contact from the patient contact list using
+   * with has the matching `category`.
+   */
+  source: z.literal('patientContact'),
+
+  /**
+   * The contact category, e.g. NextOfKin
+   */
+  category: z.string(),
+  displayString: z.string().optional(),
+});
+
+const Options = z.discriminatedUnion('source', [
+  DocumentOptions,
+  UserOptions,
+  PatientContactOptions,
+]);
 
 export type UserOptions = z.infer<typeof UserOptions>;
 export type DocumentOptions = z.infer<typeof DocumentOptions>;
+export type PatientContactOptions = z.infer<typeof PatientContactOptions>;
 
 export const searchTester = rankWith(10, uiTypeIs('Search'));
 
@@ -68,6 +88,10 @@ const UIComponent = (props: ControlProps) => {
       return <SearchWithUserSource {...childProps} options={options} />;
     case 'document':
       return <SearchWithDocumentSource {...childProps} options={options} />;
+    case 'patientContact':
+      return (
+        <SearchWithPatientContactSource {...childProps} options={options} />
+      );
     default:
       return null;
   }

--- a/client/packages/programs/src/JsonForms/components/Search/Search.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/Search.tsx
@@ -50,6 +50,7 @@ const DocumentOptions = z.object({
 });
 
 const PatientContactOptions = z.object({
+  /*
    * Source of the search data -- looks up the first contact from the patient contact list using
    * the matching `category`.
    */

--- a/client/packages/programs/src/JsonForms/components/Search/Search.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/Search.tsx
@@ -50,9 +50,8 @@ const DocumentOptions = z.object({
 });
 
 const PatientContactOptions = z.object({
-  /**
    * Source of the search data -- looks up the first contact from the patient contact list using
-   * with has the matching `category`.
+   * the matching `category`.
    */
   source: z.literal('patientContact'),
 

--- a/client/packages/programs/src/JsonForms/components/Search/SearchWithPatientContactSource.tsx
+++ b/client/packages/programs/src/JsonForms/components/Search/SearchWithPatientContactSource.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { ControlProps } from '@jsonforms/core';
+import {
+  useTranslation,
+  Box,
+  Typography,
+  DetailInputWithLabelRow,
+} from '@openmsupply-client/common';
+import {
+  FORM_INPUT_COLUMN_WIDTH,
+  DefaultFormRowSx,
+  FORM_LABEL_WIDTH,
+} from '../../common/styleConstants';
+import { usePatientStore } from '@openmsupply-client/programs';
+import { RegexUtils } from '@openmsupply-client/common';
+import { PatientContactOptions } from './Search';
+
+const { formatTemplateString, removeEmptyLines } = RegexUtils;
+
+/**
+ * Simplified patient data type
+ *
+ * TODO: store/import the full definition somewhere
+ */
+type Patient = {
+  contacts?: {
+    category?: string;
+  }[];
+};
+
+export const SearchWithPatientContactSource = (
+  props: ControlProps & { options: PatientContactOptions }
+) => {
+  const { errors: formErrors, label, visible, options } = props;
+
+  const { currentPatient } = usePatientStore();
+  const t = useTranslation('programs');
+
+  const patientData: Patient | undefined = currentPatient?.document?.data;
+
+  const contact = patientData?.contacts?.find(
+    it => it.category === options.category
+  );
+
+  const displayElement = (
+    <Typography style={{ whiteSpace: 'pre' }}>
+      {options?.displayString ? (
+        removeEmptyLines(
+          formatTemplateString(options.displayString, contact ?? {}, '')
+        )
+      ) : (
+        <pre>{JSON.stringify(contact, null, 2)}</pre>
+      )}
+    </Typography>
+  );
+
+  const getError = () => {
+    if (formErrors) return formErrors;
+    if (!contact) return t('control.search.error.no-patient-contact');
+    return null;
+  };
+
+  const error = getError();
+
+  if (!visible) return null;
+
+  return (
+    <DetailInputWithLabelRow
+      sx={DefaultFormRowSx}
+      label={label}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+      Input={
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ width: FORM_INPUT_COLUMN_WIDTH }}
+        >
+          {!error ? (
+            displayElement
+          ) : (
+            <Typography color="error">{error}</Typography>
+          )}
+        </Box>
+      }
+    />
+  );
+};

--- a/server/service/src/programs/patient/patient_schema.rs
+++ b/server/service/src/programs/patient/patient_schema.rs
@@ -20,10 +20,8 @@ impl Default for SchemaPatient {
             date_of_birth: Default::default(),
             date_of_birth_is_estimated: Default::default(),
             date_of_death: Default::default(),
-            family: Default::default(),
             first_name: Default::default(),
             gender: Default::default(),
-            health_center: Default::default(),
             id: Default::default(),
             is_deceased: Default::default(),
             last_name: Default::default(),
@@ -31,6 +29,9 @@ impl Default for SchemaPatient {
             notes: Default::default(),
             passport_number: Default::default(),
             socio_economics: Default::default(),
+            marital_status: Default::default(),
+            contacts: Default::default(),
+            extension: Default::default(),
         }
     }
 }

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -59,23 +59,23 @@ pub fn update_patient_row(
         middle_name: _,
         date_of_birth_is_estimated: _,
         date_of_death: _,
-        family: _,
-        health_center: _,
         is_deceased: _,
         notes: _,
         passport_number: _,
         socio_economics: _,
         allergies: _,
         birth_place: _,
+        marital_status: _,
+        contacts: _,
+        extension: _,
     } = patient;
-    let contact = contact_details.get(0);
+    let contact = contact_details.as_ref().and_then(|it| it.get(0));
     let date_of_birth = match date_of_birth {
         Some(date_of_birth) => Some(NaiveDate::from_str(&date_of_birth).map_err(|err| {
             UpdatePatientError::InternalError(format!("Invalid date of birth format: {}", err))
         })?),
         None => None,
     };
-    let address = contact_details.get(0);
     let name_repo = NameRowRepository::new(con);
     let existing_name = name_repo.find_one_by_id(&id)?;
     let existing_name = existing_name.as_ref();
@@ -101,9 +101,9 @@ pub fn update_patient_row(
         date_of_birth,
         charge_code: existing_name.and_then(|n| n.charge_code.clone()),
         comment: existing_name.and_then(|n| n.comment.clone()),
-        country: address.and_then(|a| a.country.clone()),
-        address1: address.and_then(|a| a.address_1.clone()),
-        address2: address.and_then(|a| a.address_2.clone()),
+        country: contact.and_then(|a| a.country.clone()),
+        address1: contact.and_then(|a| a.address_1.clone()),
+        address2: contact.and_then(|a| a.address_2.clone()),
         phone: contact.and_then(|c| c.phone.clone().or(c.mobile.clone())),
         email: contact.and_then(|c| c.email.clone()),
         website: contact.and_then(|c| c.website.clone()),
@@ -199,7 +199,7 @@ mod test {
         };
         let patient = inline_init(|p: &mut SchemaPatient| {
             p.id = "testId".to_string();
-            p.contact_details = vec![contact_details.clone()];
+            p.contact_details = Some(vec![contact_details.clone()]);
             p.date_of_birth = Some("2000-03-04".to_string());
             p.first_name = Some("firstname".to_string());
             p.last_name = Some("lastname".to_string());

--- a/server/service/src/programs/patient/upsert.rs
+++ b/server/service/src/programs/patient/upsert.rs
@@ -255,7 +255,7 @@ pub mod test {
         inline_init(|p: &mut SchemaPatient| {
             p.id = "updatePatientId1".to_string();
             p.code = Some("national_id".to_string());
-            p.contact_details = vec![contact_details.clone()];
+            p.contact_details = Some(vec![contact_details.clone()]);
             p.date_of_birth = Some("2000-03-04".to_string());
             p.first_name = Some("firstname".to_string());
             p.last_name = Some("lastname".to_string());

--- a/server/service/src/programs/program_enrolment/program_schema.rs
+++ b/server/service/src/programs/program_enrolment/program_schema.rs
@@ -16,6 +16,8 @@ impl Default for SchemaProgramEnrolment {
             program_enrolment_id: Default::default(),
             status: SchemaProgramEnrolmentStatus::Active,
             notes: Default::default(),
+            contacts: Default::default(),
+            extension: Default::default(),
         }
     }
 }

--- a/server/service/src/programs/schemas/patient.json
+++ b/server/service/src/programs/schemas/patient.json
@@ -98,32 +98,12 @@
     "DrugAllergy": {
       "properties": {
         "description": {
-          "description": "Description of the allergy",
+          "description": "Description of the allergy.",
           "type": "string"
         },
         "drug": {
           "description": "The drug name",
           "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "Family": {
-      "properties": {
-        "caregiver": {
-          "$ref": "#/definitions/RelatedPerson"
-        },
-        "maritalStatus": {
-          "$ref": "#/definitions/MaritalStatus",
-          "description": "125680007 Marital Status"
-        },
-        "mother": {
-          "$ref": "#/definitions/RelatedPerson",
-          "description": "Mother (if infant)"
-        },
-        "nextOfKin": {
-          "$ref": "#/definitions/RelatedPerson",
-          "description": "Patient's next of kin 184142008 Patient's next of kin"
         }
       },
       "type": "object"
@@ -139,19 +119,6 @@
         "NON_BINARY"
       ],
       "type": "string"
-    },
-    "HealthCenter": {
-      "properties": {
-        "id": {
-          "description": "Health Center Code",
-          "type": "string"
-        },
-        "name": {
-          "description": "Health Center Name",
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "MaritalStatus": {
       "enum": [
@@ -183,7 +150,7 @@
           "type": "string"
         }
       },
-      "required": ["text", "created", "authorId", "authorName"],
+      "required": ["text"],
       "type": "object"
     },
     "Patient": {
@@ -209,6 +176,12 @@
           },
           "type": "array"
         },
+        "contacts": {
+          "items": {
+            "$ref": "#/definitions/RelatedPerson"
+          },
+          "type": "array"
+        },
         "dateOfBirth": {
           "description": "184099003 Date of birth",
           "format": "date",
@@ -223,8 +196,8 @@
           "format": "date",
           "type": "string"
         },
-        "family": {
-          "$ref": "#/definitions/Family"
+        "extension": {
+          "type": "object"
         },
         "firstName": {
           "type": "string"
@@ -232,10 +205,6 @@
         "gender": {
           "$ref": "#/definitions/Gender",
           "description": "394744001 Gender unspecified"
-        },
-        "healthCenter": {
-          "$ref": "#/definitions/HealthCenter",
-          "description": "Health Center"
         },
         "id": {
           "description": "Medical record number\n\n398225001",
@@ -248,6 +217,10 @@
         "lastName": {
           "description": "184096005 Patient Surname",
           "type": "string"
+        },
+        "maritalStatus": {
+          "$ref": "#/definitions/MaritalStatus",
+          "description": "125680007 Marital Status"
         },
         "middleName": {
           "type": "string"
@@ -266,7 +239,7 @@
           "$ref": "#/definitions/SocioEconomics"
         }
       },
-      "required": ["contactDetails", "id"],
+      "required": ["id"],
       "type": "object"
     },
     "RelatedPerson": {
@@ -274,6 +247,10 @@
         "birthPlace": {
           "$ref": "#/definitions/Address",
           "description": "Place of birth"
+        },
+        "category": {
+          "description": "Can be used to group or mark a person entry. For example, nextOfKin | caregiver | mother",
+          "type": "string"
         },
         "code": {
           "description": "Patient code, e.g. national id or other patient identifier",
@@ -336,14 +313,13 @@
           "type": "string"
         },
         "relationship": {
-          "description": "Relationship with patient",
+          "description": "Relationship with the patient, e.g. mother, brother, cousin, friend...",
           "type": "string"
         },
         "socioEconomics": {
           "$ref": "#/definitions/SocioEconomics"
         }
       },
-      "required": ["contactDetails"],
       "type": "object"
     },
     "SocioEconomics": {

--- a/server/service/src/programs/schemas/program_enrolment.json
+++ b/server/service/src/programs/schemas/program_enrolment.json
@@ -1,6 +1,99 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Address": {
+      "properties": {
+        "address1": {
+          "description": "184097001 Patient Address",
+          "type": "string"
+        },
+        "address2": {
+          "description": "Second address line",
+          "type": "string"
+        },
+        "city": {
+          "description": "433178008 City of residence",
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "district": {
+          "type": "string"
+        },
+        "region": {
+          "description": "Region or province",
+          "type": "string"
+        },
+        "zipCode": {
+          "description": "184102003 Patient zip code",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ContactDetails": {
+      "properties": {
+        "address1": {
+          "description": "184097001 Patient Address",
+          "type": "string"
+        },
+        "address2": {
+          "description": "Second address line",
+          "type": "string"
+        },
+        "city": {
+          "description": "433178008 City of residence",
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "description": {
+          "description": "Clemens e.g. home, work, etc",
+          "type": "string"
+        },
+        "district": {
+          "type": "string"
+        },
+        "email": {
+          "description": "424966008 Patient - email address",
+          "type": "string"
+        },
+        "mobile": {
+          "description": "428481002 Patient mobile telephone number",
+          "type": "string"
+        },
+        "phone": {
+          "description": "429697006 Patient home telephone number",
+          "type": "string"
+        },
+        "region": {
+          "description": "Region or province",
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "zipCode": {
+          "description": "184102003 Patient zip code",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Gender": {
+      "enum": [
+        "FEMALE",
+        "MALE",
+        "TRANSGENDER",
+        "TRANSGENDER_MALE",
+        "TRANSGENDER_FEMALE",
+        "UNKNOWN",
+        "NON_BINARY"
+      ],
+      "type": "string"
+    },
     "Note": {
       "properties": {
         "authorId": {
@@ -25,10 +118,19 @@
     },
     "ProgramEnrolment": {
       "properties": {
+        "contacts": {
+          "items": {
+            "$ref": "#/definitions/RelatedPerson"
+          },
+          "type": "array"
+        },
         "enrolmentDatetime": {
           "description": "Enrolment date and time",
           "format": "date-time",
           "type": "string"
+        },
+        "extension": {
+          "type": "object"
         },
         "notes": {
           "description": "An overall note for additional comments about the program enrolment",
@@ -52,6 +154,105 @@
     "ProgramEnrolmentStatus": {
       "enum": ["ACTIVE", "OPTED_OUT", "TRANSFERRED_OUT", "PAUSED"],
       "type": "string"
+    },
+    "RelatedPerson": {
+      "properties": {
+        "birthPlace": {
+          "$ref": "#/definitions/Address",
+          "description": "Place of birth"
+        },
+        "category": {
+          "description": "Can be used to group or mark a person entry. For example, nextOfKin | caregiver | mother",
+          "type": "string"
+        },
+        "code": {
+          "description": "Patient code, e.g. national id or other patient identifier",
+          "type": "string"
+        },
+        "code2": {
+          "description": "Secondary patient code, e.g. another type of health id",
+          "type": "string"
+        },
+        "contactDetails": {
+          "items": {
+            "$ref": "#/definitions/ContactDetails"
+          },
+          "type": "array"
+        },
+        "dateOfBirth": {
+          "description": "184099003 Date of birth",
+          "format": "date",
+          "type": "string"
+        },
+        "dateOfBirthIsEstimated": {
+          "description": "Date of birth is estimated",
+          "type": "boolean"
+        },
+        "dateOfDeath": {
+          "description": "Date of death",
+          "format": "date",
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "gender": {
+          "$ref": "#/definitions/Gender",
+          "description": "394744001 Gender unspecified"
+        },
+        "id": {
+          "description": "mSupply Patient id",
+          "type": "string"
+        },
+        "isDeceased": {
+          "description": "Person is deceased",
+          "type": "boolean"
+        },
+        "lastName": {
+          "description": "184096005 Patient Surname",
+          "type": "string"
+        },
+        "middleName": {
+          "type": "string"
+        },
+        "notes": {
+          "items": {
+            "$ref": "#/definitions/Note"
+          },
+          "type": "array"
+        },
+        "passportNumber": {
+          "description": "1601000122107 Passport Number",
+          "type": "string"
+        },
+        "relationship": {
+          "description": "Relationship with the patient, e.g. mother, brother, cousin, friend...",
+          "type": "string"
+        },
+        "socioEconomics": {
+          "$ref": "#/definitions/SocioEconomics"
+        }
+      },
+      "type": "object"
+    },
+    "SocioEconomics": {
+      "properties": {
+        "education": {
+          "description": "224293004 Education received in the past",
+          "type": "string"
+        },
+        "employmentStatus": {
+          "type": "string"
+        },
+        "literate": {
+          "type": "string"
+        },
+        "occupation": {
+          "description": "14679004 Occupation",
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "type": "object",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1661

This PR goes together with the `1661-contact-info` branch in the schema repository and the latest develop branch for mSupply.

# 👩🏻‍💻 What does this PR do? 
- Removes the family object from the patient schema
- Adds a `contacts` array to the patient schema
- Adds a `contacts` array to the enrolment schema
- Adds a new generic JSONForms control which is used to display and edit an entry from the contacts array
- Add a search component to lookup an entry from the patient contacts

The RelatedPerson has a `category` field now. This can, for example, be used to mark a contact as "Mother" or "Next of Kin". The "Next of Kin" can then be picked from the contacts list using the category field.
However, there is still the `relationship` field which can be used, for example, like:
```ts
{
  category: 'NextOfKin',
  relationship: 'Father',
}
```

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Create/ update a new patient and edit the next of kin contact
- In the HIV care enrolment select "same as next of kin" for the treatment supporter and check it load correctly