### PR TITLE
1807 Show error when deleting inbound line that is already used 

### DIFF
--- a/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
+++ b/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
@@ -48,8 +48,9 @@ export const useDeleteConfirmation = <T>({
           const successSnack = success(deletedMessage);
           successSnack();
         })
-        .catch(() => {
+        .catch(err => {
           cannotDeleteSnack();
+          console.log(err.message);
         });
     },
     message: confirmMessage || t('messages.confirm-delete-generic'),

--- a/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
+++ b/client/packages/common/src/hooks/useDeleteConfirmation/useDeleteConfirmation.ts
@@ -32,6 +32,9 @@ export const useDeleteConfirmation = <T>({
   } = messages;
   const t = useTranslation('common');
   const { success, info } = useNotification();
+  const cannotDeleteSnack = info(
+    cantDelete || t('messages.cant-delete-generic')
+  );
 
   const showConfirmation = useConfirmationModal({
     onConfirm: async () => {
@@ -45,7 +48,9 @@ export const useDeleteConfirmation = <T>({
           const successSnack = success(deletedMessage);
           successSnack();
         })
-        .catch(err => console.log(err.message));
+        .catch(() => {
+          cannotDeleteSnack();
+        });
     },
     message: confirmMessage || t('messages.confirm-delete-generic'),
     title: confirmTitle || t('heading.are-you-sure'),
@@ -55,9 +60,6 @@ export const useDeleteConfirmation = <T>({
     const numberSelected = selectedRows.length || 0;
     if (selectedRows && numberSelected > 0) {
       if (!canDelete) {
-        const cannotDeleteSnack = info(
-          cantDelete || t('messages.cant-delete-generic')
-        );
         cannotDeleteSnack();
       } else showConfirmation();
     } else {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1807

# 👩🏻‍💻 What does this PR do? 
Show snack if inbound shipment line cannot be deleted.

# 🧪 How has/should this change been tested? 
- Create a manual inbound with any item
- Confirm delivered (this will create a stock line for the item)
- Create a stocktake with said item and change stock (change counted packs)
- Go back to the manual inbound invoice that was created and try to delete line
- See snack