### PR TITLE
Increase age input text to be able to display age values > 99

### DIFF
--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -98,7 +98,7 @@ const UIComponent = (props: ControlProps) => {
           <Box flex={0}>
             <NonNegativeIntegerInput
               value={age}
-              sx={{ width: 50 }}
+              sx={{ width: 65 }}
               onChange={onChangeAge}
             />
           </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Related to #1842

While looking at 1842 I noticed that large age values are not correctly displayed (partially hidden). This can be quite confusing. I slightly increase the input width to be able to show values up to 1000 years.

![image](https://github.com/openmsupply/open-msupply/assets/88299195/65887e3f-a7e4-42ca-980d-14331582afd8)
