### PR TITLE
OMI33 requisition processor to ignore deleted requisitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.15",
+  "version": "1.1.17",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.1.17",
+  "version": "1.1.15",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -74,6 +74,7 @@ pub struct ChangelogFilter {
     pub name_id: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
     pub record_id: Option<EqualFilter<String>>,
+    pub action: Option<EqualFilter<ChangelogAction>>,
     pub is_sync_update: Option<EqualFilter<bool>>,
 }
 
@@ -159,6 +160,7 @@ fn create_filtered_query<'a>(
             store_id,
             record_id,
             is_sync_update,
+            action,
         } = f;
 
         apply_equal_filter!(query, table_name, changelog_deduped::dsl::table_name);
@@ -170,6 +172,7 @@ fn create_filtered_query<'a>(
             is_sync_update,
             changelog_deduped::dsl::is_sync_update
         );
+        apply_equal_filter!(query, action, changelog_deduped::dsl::row_action);
     }
 
     query
@@ -216,6 +219,11 @@ impl ChangelogFilter {
         self
     }
 
+    pub fn action(mut self, filter: EqualFilter<ChangelogAction>) -> Self {
+        self.action = Some(filter);
+        self
+    }
+
     pub fn is_sync_update(mut self, filter: EqualFilter<bool>) -> Self {
         self.is_sync_update = Some(filter);
         self
@@ -223,6 +231,12 @@ impl ChangelogFilter {
 }
 
 impl ChangelogTableName {
+    pub fn equal_to(&self) -> EqualFilter<Self> {
+        inline_init(|r: &mut EqualFilter<Self>| r.equal_to = Some(self.clone()))
+    }
+}
+
+impl ChangelogAction {
     pub fn equal_to(&self) -> EqualFilter<Self> {
         inline_init(|r: &mut EqualFilter<Self>| r.equal_to = Some(self.clone()))
     }

--- a/server/service/src/processors/transfer/requisition/mod.rs
+++ b/server/service/src/processors/transfer/requisition/mod.rs
@@ -80,7 +80,9 @@ pub(crate) fn process_requisition_transfers(
     // this is the contract obligation for try_process_record in ProcessorTrait
     let filter = ChangelogFilter::new()
         .table_name(ChangelogTableName::Requisition.equal_to())
-        .name_id(EqualFilter::equal_any(active_stores.name_ids()));
+        .name_id(EqualFilter::equal_any(active_stores.name_ids()))
+        // Filter out deletes
+        .action(ChangelogAction::Upsert.equal_to());
 
     loop {
         let cursor = key_value_store_repo

--- a/server/service/src/processors/transfer/requisition/test.rs
+++ b/server/service/src/processors/transfer/requisition/test.rs
@@ -183,9 +183,7 @@ async fn stock_on_deleted_requisitions() {
         .unwrap();
 
     // 1 second delay, to allow processor_task to finish
-    let sleep_task = tokio::spawn(async {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    });
+    let sleep_task = tokio::time::sleep(Duration::from_secs(1));
     let service_provider_closure = service_provider.clone();
     let trigger_and_wait = tokio::spawn(async move {
         let ctx = service_provider_closure.basic_context().unwrap();

--- a/server/service/src/processors/transfer/requisition/test.rs
+++ b/server/service/src/processors/transfer/requisition/test.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use chrono::NaiveDate;
 use repository::{
     mock::{insert_extra_mock_data, MockData, MockDataInserts},
@@ -128,6 +130,79 @@ pub(crate) struct RequisitionTransferTester {
     request_requisition_line1: RequisitionLineRow,
     request_requisition_line2: RequisitionLineRow,
     response_requisition: Option<RequisitionRow>,
+}
+
+/// Deleted requisitions stuck forever
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stock_on_deleted_requisitions() {
+    let site_id = 25;
+    let store_name = inline_init(|r: &mut NameRow| {
+        r.id = uuid();
+        r.name = uuid();
+    });
+
+    let store = inline_init(|r: &mut StoreRow| {
+        r.id = uuid();
+        r.name_id = store_name.id.clone();
+        r.site_id = site_id;
+    });
+
+    let requisition = RequisitionRow {
+        id: uuid(),
+        requisition_number: 3,
+        name_id: store.name_id.clone(),
+        store_id: store.id.clone(),
+        r#type: RequisitionRowType::Request,
+        ..RequisitionRow::default()
+    };
+
+    let site_id_settings = inline_init(|r: &mut KeyValueStoreRow| {
+        r.id = KeyValueType::SettingsSyncSiteId;
+        r.value_int = Some(site_id);
+    });
+
+    let ServiceTestContext {
+        service_provider,
+        processors_task,
+        connection,
+        ..
+    } = setup_all_with_data_and_service_provider(
+        "stock_on_deleted_requisitions",
+        MockDataInserts::none().stores().names().items().units(),
+        inline_init(|r: &mut MockData| {
+            r.names = vec![store_name.clone()];
+            r.stores = vec![store.clone()];
+            r.requisitions = vec![requisition.clone()];
+            r.key_value_store_rows = vec![site_id_settings];
+        }),
+    )
+    .await;
+
+    RequisitionRowRepository::new(&connection)
+        .delete(&requisition.id)
+        .unwrap();
+
+    // 1 second delay, to allow processor_task to finish
+    let sleep_task = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+    let service_provider_closure = service_provider.clone();
+    let trigger_and_wait = tokio::spawn(async move {
+        let ctx = service_provider_closure.basic_context().unwrap();
+
+        ctx.processors_trigger
+            .requisition_transfer
+            .try_send(())
+            .unwrap();
+
+        ctx.processors_trigger.await_events_processed().await;
+    });
+
+    tokio::select! {
+         Err(err) = processors_task => unreachable!("{}", err),
+         _ = sleep_task => assert!(false, "Sleep task finished before processor. Processor is stuck on delete record"),
+         Ok(_) = trigger_and_wait => assert!(true),
+    };
 }
 
 impl RequisitionTransferTester {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

This is a patch PR to main

Fixes https://github.com/openmsupply/open-msupply-internal/issues/33

# 👩🏻‍💻 What does this PR do? 

Filters out deletes from requisition processor.

This fixes sync freezing that was described in the issue (btw, this was validated with a custom build)

Sync was freezing because of deleted records being processed in requisition processor (only deleted requisitions were in changelog for processing)

https://github.com/openmsupply/open-msupply/blob/4e8bc15d60be9a5f5e630f0eb1c70fb443b496e2/server/service/src/processors/transfer/requisition/mod.rs#L113

Above line will continue, and not update cursors:

https://github.com/openmsupply/open-msupply/blob/4e8bc15d60be9a5f5e630f0eb1c70fb443b496e2/server/service/src/processors/transfer/requisition/mod.rs#L131-L136

Why does sync stop thought ? It looks like it's due to the following select, which I though would be fine on multi thread application, but for some reason the processor still blocks it (at least on the cloud server, look like the test passes ):

https://github.com/openmsupply/open-msupply/blob/4e8bc15d60be9a5f5e630f0eb1c70fb443b496e2/server/server/src/lib.rs#L280-L281

# 🧪 How has/should this change been tested? 

There is already a unit test for this, but can replicate this by creating, then deleting requisitions, then trying to sync (requisition deleting should be the last operation), not sure if this manual test would work on a normal mac, may need a special single threaded environment (since unit test does something similar where timeout running similar to synchroniser, but timeout is not blocked, unless test is set to one thread) 
