### PR TITLE
Add spinner modal while printing

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -326,6 +326,7 @@
   "messages.no-scanners-found": "No scanners found",
   "messages.scanner-connected": "Connected",
   "messages.scanner-disconnected": "Not connected",
+  "messages.fetching-report-data": "Fetching report data...",
   "placeholder.filter-by-status": "Filter by status",
   "placeholder.filter-items": "Filter items",
   "placeholder.search-by-name": "Search by name",

--- a/client/packages/system/src/Report/ListView/ListView.tsx
+++ b/client/packages/system/src/Report/ListView/ListView.tsx
@@ -85,6 +85,8 @@ const ReportListComponent = ({ context }: { context: ReportContext }) => {
   >();
   const { print, isPrinting } = useReport.utils.print();
 
+  // Wait a little bit before showing the modal, e.g. when the report prints very quickly, don't
+  // show the modal.
   const debouncedIsPrinting = useDebouncedValue(isPrinting, 300);
 
   const columns = useColumns<ReportRowFragment>(

--- a/client/packages/system/src/Report/ListView/ListView.tsx
+++ b/client/packages/system/src/Report/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   BaseButton,
   useDialog,
   BasicSpinner,
+  useDebouncedValue,
 } from '@openmsupply-client/common';
 import { JsonData } from '@openmsupply-client/programs';
 import { useReport, ReportRowFragment } from '../api';
@@ -84,6 +85,8 @@ const ReportListComponent = ({ context }: { context: ReportContext }) => {
   >();
   const { print, isPrinting } = useReport.utils.print();
 
+  const debouncedIsPrinting = useDebouncedValue(isPrinting, 300);
+
   const columns = useColumns<ReportRowFragment>(
     [
       'name',
@@ -152,7 +155,7 @@ const ReportListComponent = ({ context }: { context: ReportContext }) => {
         onReset={() => setReportWithArgs(undefined)}
         onArgumentsSelected={printReport}
       />
-      <PrintingDialog isPrinting={isPrinting} />
+      <PrintingDialog isPrinting={debouncedIsPrinting && isPrinting} />
     </>
   );
 };

--- a/client/packages/system/src/Report/ListView/ListView.tsx
+++ b/client/packages/system/src/Report/ListView/ListView.tsx
@@ -18,11 +18,7 @@ import { useReport, ReportRowFragment } from '../api';
 import { Toolbar } from './Toolbar';
 import { ReportArgumentsModal } from '../components/ReportArgumentsModal';
 
-type PrintingDialogProps = { isPrinting: boolean };
-const PrintingDialog: React.FC<PrintingDialogProps> = (
-  props: PrintingDialogProps
-) => {
-  const { isPrinting } = props;
+const PrintingDialog: React.FC<{ isPrinting: boolean }> = ({ isPrinting }) => {
   const { Modal, showDialog, hideDialog } = useDialog();
 
   useEffect(() => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1683 

# 👩🏻‍💻 What does this PR do? 
Adds a simple spinner modal while fetching the report data.

# 🧪 How has/should this change been tested? 

Follow `png/TestingSetupInstructions.md` from the schema repository and the print reports from the printing menu.

It also helps to use to import some data using the import script from `png/date_import` to increase the time needed for the reports.
