### PR TITLE
1819 [Deployment Feedback] Dashboard page (welcome screen) doesn't update 

### DIFF
--- a/server/service/src/dashboard/stock_expiry_count.rs
+++ b/server/service/src/dashboard/stock_expiry_count.rs
@@ -35,7 +35,8 @@ impl StockExpiryCountServiceTrait for StockExpiryServiceCount {
                         before_or_equal_to: Some(date_time),
                         after_or_equal_to: None,
                     })
-                    .store_id(EqualFilter::equal_to(&store_id)),
+                    .store_id(EqualFilter::equal_to(&store_id))
+                    .is_available(true),
             ),
             None,
         )

--- a/server/service/src/dashboard/stock_expiry_count.rs
+++ b/server/service/src/dashboard/stock_expiry_count.rs
@@ -42,3 +42,85 @@ impl StockExpiryCountServiceTrait for StockExpiryServiceCount {
         )
     }
 }
+
+#[cfg(test)]
+mod stock_count_test {
+    use chrono::{Days, Utc};
+    use repository::{
+        mock::{mock_item_a, mock_store_a, MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        StockLineRow, StockLineRowRepository,
+    };
+    use util::{inline_edit, inline_init};
+
+    use crate::service_provider::ServiceProvider;
+
+    fn expired_stock_a() -> StockLineRow {
+        inline_init(|r: &mut StockLineRow| {
+            r.id = "expired_stock_a".to_string();
+            r.item_id = mock_item_a().id;
+            r.store_id = mock_store_a().id;
+            r.available_number_of_packs = 100.0;
+            r.total_number_of_packs = 100.0;
+            r.expiry_date = Utc::now()
+                .naive_utc()
+                .date()
+                .checked_sub_days(Days::new(20));
+        })
+    }
+
+    fn expired_stock_b() -> StockLineRow {
+        inline_init(|r: &mut StockLineRow| {
+            r.id = "expired_stock_b".to_string();
+            r.item_id = mock_item_a().id;
+            r.store_id = mock_store_a().id;
+            r.available_number_of_packs = 500.0;
+            r.total_number_of_packs = 500.0;
+            r.expiry_date = Utc::now()
+                .naive_utc()
+                .date()
+                .checked_sub_days(Days::new(10));
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_stock_expiry_count() {
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "test_stock_expiry_count",
+            MockDataInserts::none().items().stores().names().units(),
+            inline_init(|r: &mut MockData| {
+                r.stock_lines = vec![expired_stock_a(), expired_stock_b()]
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager, "app_data");
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let count_service = service_provider.stock_expiry_count_service;
+
+        let date_now = Utc::now().naive_utc().date();
+
+        let expired_stock_count = count_service
+            .count_expired_stock(&context, &mock_store_a().id, date_now)
+            .unwrap();
+        assert_eq!(expired_stock_count, 2);
+
+        // Update one of the stock lines to have 0 packs
+        let expired_stock_a: StockLineRow = inline_edit(&expired_stock_a(), |mut r| {
+            r.available_number_of_packs = 0.0;
+            r.total_number_of_packs = 20.0;
+            r
+        });
+
+        StockLineRowRepository::new(&connection)
+            .upsert_one(&expired_stock_a)
+            .unwrap();
+
+        let expired_stock_count = count_service
+            .count_expired_stock(&context, &mock_store_a().id, date_now)
+            .unwrap();
+        assert_eq!(expired_stock_count, 1);
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1819 

# 👩🏻‍💻 What does this PR do? 
Count expired stocks also counted stock lines with 0 number of packs. Have added check to filter out stock lines with 0 available number of packs, and also added a test.

# 🧪 How has/should this change been tested? 
- Run tests
OR
- Use stocktake to create some expired stock.
- Go to dashboard and see expired count. 
- Go back to stocktake and put expired stock line's counted packs to 0.
- Go back to dashboard and see new expired count.