### PR TITLE
1947 decouple programs module from dispensary mode check

### DIFF
--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean } };
+export type UserStoreNodeFragment = { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean } };
 
 export type AuthTokenQueryVariables = Types.Exact<{
   username: Types.Scalars['String'];
@@ -17,7 +17,7 @@ export type AuthTokenQuery = { __typename: 'Queries', authToken: { __typename: '
 export type MeQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean } }> } } };
+export type MeQuery = { __typename: 'Queries', me: { __typename: 'UserNode', email?: string | null, language: Types.LanguageType, username: string, userId: string, firstName?: string | null, lastName?: string | null, phoneNumber?: string | null, jobTitle?: string | null, defaultStore?: { __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean } } | null, stores: { __typename: 'UserStoreConnector', totalCount: number, nodes: Array<{ __typename: 'UserStoreNode', code: string, id: string, name: string, storeMode: Types.StoreModeNodeType, preferences: { __typename: 'StorePreferenceNode', id: string, responseRequisitionRequiresAuthorisation: boolean, requestRequisitionRequiresAuthorisation: boolean, packToOne: boolean, omProgramModule: boolean } }> } } };
 
 export type RefreshTokenQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -49,6 +49,7 @@ export const UserStoreNodeFragmentDoc = gql`
     responseRequisitionRequiresAuthorisation
     requestRequisitionRequiresAuthorisation
     packToOne
+    omProgramModule
   }
 }
     `;

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -8,6 +8,7 @@ fragment UserStoreNode on UserStoreNode {
     responseRequisitionRequiresAuthorisation
     requestRequisitionRequiresAuthorisation
     packToOne
+    omProgramModule
   }
 }
 

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4357,6 +4357,7 @@ export type StoreNodeNameArgs = {
 export type StorePreferenceNode = {
   __typename: 'StorePreferenceNode';
   id: Scalars['String'];
+  omProgramModule: Scalars['Boolean'];
   packToOne: Scalars['Boolean'];
   requestRequisitionRequiresAuthorisation: Scalars['Boolean'];
   responseRequisitionRequiresAuthorisation: Scalars['Boolean'];

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -22,7 +22,6 @@ import {
   useLocation,
   EnvUtils,
   UserPermission,
-  StoreModeNodeType,
 } from '@openmsupply-client/common';
 import { AppRoute, ExternalURL } from '@openmsupply-client/config';
 import {
@@ -196,7 +195,7 @@ export const AppDrawer: React.FC = () => {
           <ReplenishmentNav />
           <CatalogueNav />
           <InventoryNav />
-          <DispensaryNav visible={store?.storeMode === StoreModeNodeType.Dispensary}/>
+          <DispensaryNav store={store} />
 
           {/* <AppNavLink
             to={AppRoute.Tools}

--- a/client/packages/host/src/components/Navigation/DispensaryNav.tsx
+++ b/client/packages/host/src/components/Navigation/DispensaryNav.tsx
@@ -7,19 +7,23 @@ import {
   RouteBuilder,
   AppNavLink,
   AppNavSection,
+  UserStoreNodeFragment,
+  StoreModeNodeType,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
 
 export interface DispensaryNavProps {
-  visible?: boolean;
+  store?: UserStoreNodeFragment;
 }
 
-export const DispensaryNav: FC<DispensaryNavProps> = ({ visible = false }) => {
+export const DispensaryNav: FC<DispensaryNavProps> = ({ store }) => {
   const { isActive } = useNestedNav(
     RouteBuilder.create(AppRoute.Dispensary).addWildCard().build()
   );
   const t = useTranslation('app');
+  const visible = store?.storeMode === StoreModeNodeType.Dispensary;
+  const isProgramModule = store?.preferences.omProgramModule;
 
   return (
     <AppNavSection isActive={visible} to={AppRoute.Dispensary}>
@@ -42,7 +46,7 @@ export const DispensaryNav: FC<DispensaryNavProps> = ({ visible = false }) => {
             text={t('patients')}
           />
           <AppNavLink
-            visible={visible}
+            visible={isProgramModule}
             end
             to={RouteBuilder.create(AppRoute.Dispensary)
               .addPart(AppRoute.Encounter)
@@ -50,7 +54,7 @@ export const DispensaryNav: FC<DispensaryNavProps> = ({ visible = false }) => {
             text={t('encounter')}
           />
           <AppNavLink
-            visible={visible}
+            visible={isProgramModule}
             end
             to={RouteBuilder.create(AppRoute.Dispensary)
               .addPart(AppRoute.Reports)

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -37,10 +37,12 @@ export const AppBarButtons: FC<{
   return (
     <AppBarButtonsPortal>
       <Grid container gap={1}>
-        <AddButton
-          disabled={disabled}
-          disableEncounterButton={disableEncounterButton}
-        />
+        {store?.preferences.omProgramModule && (
+          <AddButton
+            disabled={disabled}
+            disableEncounterButton={disableEncounterButton}
+          />
+        )}
         <ReportSelector context={ReportContext.Patient} onPrint={printReport}>
           <LoadingButton
             disabled={disabled}

--- a/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/PatientView/AppBarButtons.tsx
@@ -5,6 +5,7 @@ import {
   LoadingButton,
   PrinterIcon,
   useTranslation,
+  UserStoreNodeFragment,
 } from '@openmsupply-client/common';
 import React, { FC } from 'react';
 import { AddButton } from './AddButton';
@@ -12,7 +13,10 @@ import { ReportRowFragment, ReportSelector, useReport } from '../../Report';
 import { usePatient } from '../api';
 import { JsonData, useProgramEnrolments } from '@openmsupply-client/programs';
 
-export const AppBarButtons: FC<{ disabled: boolean }> = ({ disabled }) => {
+export const AppBarButtons: FC<{
+  disabled: boolean;
+  store?: UserStoreNodeFragment;
+}> = ({ disabled, store }) => {
   const t = useTranslation('common');
   const { print, isPrinting } = useReport.utils.print();
   const patientId = usePatient.utils.id();
@@ -28,6 +32,7 @@ export const AppBarButtons: FC<{ disabled: boolean }> = ({ disabled }) => {
     },
   });
   const disableEncounterButton = enrolmentData?.nodes?.length === 0;
+  if (!store?.preferences.omProgramModule) return null;
 
   return (
     <AppBarButtonsPortal>

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -7,6 +7,7 @@ import {
   useTranslation,
   EncounterSortFieldInput,
   ProgramEnrolmentSortFieldInput,
+  useAuthContext,
 } from '@openmsupply-client/common';
 import { usePatient } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -144,6 +145,7 @@ export const PatientView = () => {
   const { setCurrentPatient } = usePatientStore();
   const { data: currentPatient } = usePatient.document.get(patientId);
   const [isDirtyPatient, setIsDirtyPatient] = useState(false);
+  const { store } = useAuthContext();
 
   const requiresConfirmation = (tab: string) => {
     return tab === 'Details' && isDirtyPatient;
@@ -206,13 +208,17 @@ export const PatientView = () => {
           }}
         />
       ) : null}
-      <AppBarButtons disabled={!!createNewPatient} />
+      <AppBarButtons disabled={!!createNewPatient} store={store} />
       <PatientSummary />
-      {/* Only show tabs for saved patients */}
+      {/* Only show tabs if program module is on and patient is saved.
+      TODO: Prescription tab? - would need tab refactoring since also seems useful in programs
+      */}
       {!!createNewPatient ? (
         <PatientDetailView onEdit={setIsDirtyPatient} />
-      ) : (
+      ) : store?.preferences.omProgramModule ? (
         <DetailTabs tabs={tabs} requiresConfirmation={requiresConfirmation} />
+      ) : (
+        <PatientDetailView onEdit={setIsDirtyPatient} />
       )}
     </React.Suspense>
   );

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -213,9 +213,7 @@ export const PatientView = () => {
       {/* Only show tabs if program module is on and patient is saved.
       TODO: Prescription tab? - would need tab refactoring since also seems useful in programs
       */}
-      {!!createNewPatient ? (
-        <PatientDetailView onEdit={setIsDirtyPatient} />
-      ) : store?.preferences.omProgramModule ? (
+      {!createNewPatient && store?.preferences.omProgramModule ? (
         <DetailTabs tabs={tabs} requiresConfirmation={requiresConfirmation} />
       ) : (
         <PatientDetailView onEdit={setIsDirtyPatient} />

--- a/server/graphql/types/src/types/store_preference.rs
+++ b/server/graphql/types/src/types/store_preference.rs
@@ -26,6 +26,10 @@ impl StorePreferenceNode {
             .store_preference
             .request_requisition_requires_authorisation
     }
+
+    pub async fn om_program_module(&self) -> &bool {
+        &self.store_preference.om_program_module
+    }
 }
 
 impl StorePreferenceNode {

--- a/server/repository/src/db_diesel/store_preference_row.rs
+++ b/server/repository/src/db_diesel/store_preference_row.rs
@@ -17,6 +17,7 @@ table! {
         pack_to_one -> Bool,
         response_requisition_requires_authorisation -> Bool,
         request_requisition_requires_authorisation -> Bool,
+        om_program_module -> Bool,
     }
 }
 
@@ -41,6 +42,7 @@ pub struct StorePreferenceRow {
     pub pack_to_one: bool,
     pub response_requisition_requires_authorisation: bool,
     pub request_requisition_requires_authorisation: bool,
+    pub om_program_module: bool,
 }
 
 impl Default for StorePreferenceRow {
@@ -51,6 +53,7 @@ impl Default for StorePreferenceRow {
             pack_to_one: Default::default(),
             response_requisition_requires_authorisation: Default::default(),
             request_requisition_requires_authorisation: Default::default(),
+            om_program_module: Default::default(),
         }
     }
 }

--- a/server/repository/src/migrations/v1_02_00/mod.rs
+++ b/server/repository/src/migrations/v1_02_00/mod.rs
@@ -3,6 +3,7 @@ use super::{version::Version, Migration};
 use crate::StorageConnection;
 mod invoice;
 mod number_and_permission_type;
+mod store_preference;
 pub(crate) struct V1_02_00;
 
 impl Migration for V1_02_00 {
@@ -13,6 +14,7 @@ impl Migration for V1_02_00 {
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         invoice::migrate(connection)?;
         number_and_permission_type::migrate(connection)?;
+        store_preference::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/migrations/v1_02_00/store_preference.rs
+++ b/server/repository/src/migrations/v1_02_00/store_preference.rs
@@ -1,0 +1,14 @@
+use crate::StorageConnection;
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    use crate::migrations::sql;
+
+    sql!(
+        connection,
+        r#"
+            ALTER TABLE store_preference ADD COLUMN om_program_module bool NOT NULL DEFAULT false;
+        "#
+    )?;
+
+    Ok(())
+}

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -64,7 +64,8 @@ const STORE_PREFERENCE_1: (&'static str, &'static str) = (
         "monthsUnderstock": 4,
         "monthsItemsExpire": 2,
         "boxPrefix": "",
-        "boxPercentageSpace": 0
+        "boxPercentageSpace": 0,
+        "omSupplyUsesProgramModule": true
     }
 }"#,
 );
@@ -129,7 +130,8 @@ const STORE_PREFERENCE_2: (&'static str, &'static str) = (
         "monthsUnderstock": 3,
         "monthsItemsExpire": 3,
         "boxPrefix": "",
-        "boxPercentageSpace": 0
+        "boxPercentageSpace": 0,
+        "omSupplyUsesProgramModule": false
     }
 }"#,
 );
@@ -145,6 +147,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 pack_to_one: true,
                 response_requisition_requires_authorisation: true,
                 request_requisition_requires_authorisation: false,
+                om_program_module: true,
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
@@ -156,6 +159,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 pack_to_one: false,
                 response_requisition_requires_authorisation: false,
                 request_requisition_requires_authorisation: true,
+                om_program_module: false,
             }),
         ),
     ]

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -33,6 +33,8 @@ pub struct LegacyPrefData {
     pub response_requisition_requires_authorisation: bool,
     #[serde(rename = "includeRequisitionsInSuppliersRemoteAuthorisationProcesses")]
     pub request_requisition_requires_authorisation: bool,
+    #[serde(rename = "omSupplyUsesProgramModule")]
+    pub om_program_module: bool,
 }
 
 pub(crate) struct StorePreferenceTranslation {}
@@ -65,6 +67,7 @@ impl SyncTranslation for StorePreferenceTranslation {
             pack_to_one,
             response_requisition_requires_authorisation,
             request_requisition_requires_authorisation,
+            om_program_module,
         } = data;
 
         let result = StorePreferenceRow {
@@ -73,6 +76,7 @@ impl SyncTranslation for StorePreferenceTranslation {
             pack_to_one,
             response_requisition_requires_authorisation,
             request_requisition_requires_authorisation,
+            om_program_module,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1947

# 👩🏻‍💻 What does this PR do? 
Hides all program related components with store preference. 

# 🧪 How has/should this change been tested? 
Will need [this branch](https://github.com/openmsupply/msupply/tree/%2313221-omSupply-store-preference-for-Programs-module) for testing.
Make sure all program related things are hidden if omSupply: uses Program module is not configured for store.