### PR TITLE
Delete unwanted placeholder rows

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -93,11 +93,13 @@ export const OutboundLineEditTable: React.FC<OutboundLineEditTableProps> = ({
   );
   const onEditStockLine = (key: string, value: number, packSize: number) => {
     onChange(key, value, packSize);
-    if (placeholderRow && shouldUpdatePlaceholder(value, placeholderRow))
+    if (placeholderRow && shouldUpdatePlaceholder(value, placeholderRow)) {
       // if a stock line has been allocated
-      // and the placeholder row is a generated one with a zero value,
-      // this allows removal of the placeholder row
+      // and the placeholder row is a generated one,
+      // remove the placeholder row
       placeholderRow.isUpdated = true;
+      placeholderRow.numberOfPacks = 0;
+    }
   };
   const unit = item?.unitName ?? t('label.unit');
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
@@ -117,9 +117,9 @@ export const allocateQuantities =
       );
       const placeholder = newDraftOutboundLines[placeholderIdx];
       const oldPlaceholder = draftOutboundLines[placeholderIdx];
+      // remove if the oldPlaceholder.numberOfPacks is non-zero and the new placeholder.numberOfPacks is zero
       const placeholderRemoved =
-        (oldPlaceholder?.numberOfPacks ?? 0 > 0) &&
-        placeholder?.numberOfPacks === 0;
+        oldPlaceholder?.numberOfPacks && placeholder?.numberOfPacks === 0;
 
       // the isUpdated flag must be set in order to delete the placeholder row
       if (placeholderRemoved) {
@@ -234,4 +234,4 @@ const reduceBatchAllocation = ({
 export const shouldUpdatePlaceholder = (
   quantity: number,
   placeholder: DraftOutboundLine
-) => quantity > 0 && placeholder.numberOfPacks === 0 && !placeholder.isCreated;
+) => quantity > 0 && !placeholder.isCreated;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts
@@ -111,24 +111,34 @@ export const allocateQuantities =
       });
     }
 
-    if (status === InvoiceNodeStatus.New && toAllocate > 0) {
+    if (status === InvoiceNodeStatus.New) {
       const placeholderIdx = newDraftOutboundLines.findIndex(
         ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
       );
       const placeholder = newDraftOutboundLines[placeholderIdx];
+      const oldPlaceholder = draftOutboundLines[placeholderIdx];
+      const placeholderRemoved =
+        (oldPlaceholder?.numberOfPacks ?? 0 > 0) &&
+        placeholder?.numberOfPacks === 0;
 
-      if (!placeholder) throw new Error('No placeholder within item editing');
-
-      // stock has been allocated, and the auto generated placeholder is no longer required
-      if (shouldUpdatePlaceholder(newValue, placeholder))
+      // the isUpdated flag must be set in order to delete the placeholder row
+      if (placeholderRemoved) {
         placeholder.isUpdated = true;
+      }
 
-      newDraftOutboundLines[placeholderIdx] = {
-        ...placeholder,
-        numberOfPacks: placeholder.numberOfPacks + toAllocate,
-      };
+      if (toAllocate > 0) {
+        if (!placeholder) throw new Error('No placeholder within item editing');
+
+        // stock has been allocated, and the auto generated placeholder is no longer required
+        if (shouldUpdatePlaceholder(newValue, placeholder))
+          placeholder.isUpdated = true;
+
+        newDraftOutboundLines[placeholderIdx] = {
+          ...placeholder,
+          numberOfPacks: placeholder.numberOfPacks + toAllocate,
+        };
+      }
     }
-
     return newDraftOutboundLines;
   };
 

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -348,8 +348,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
           ({ type, isCreated, isUpdated, numberOfPacks }) =>
             !isCreated &&
             isUpdated &&
-            (type === InvoiceLineNodeType.StockOut ||
-              type === InvoiceLineNodeType.UnallocatedStock) &&
+            type === InvoiceLineNodeType.StockOut &&
             numberOfPacks === 0
         )
         .map(outboundParsers.toDeleteLine),

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -348,7 +348,8 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
           ({ type, isCreated, isUpdated, numberOfPacks }) =>
             !isCreated &&
             isUpdated &&
-            type === InvoiceLineNodeType.StockOut &&
+            (type === InvoiceLineNodeType.StockOut ||
+              type === InvoiceLineNodeType.UnallocatedStock) &&
             numberOfPacks === 0
         )
         .map(outboundParsers.toDeleteLine),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1894 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The placeholder row `numberOfPacks` is set to `0` when creating [newDraftOutboundLines](https://github.com/openmsupply/open-msupply/blob/develop/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/utils.ts#L74) and then lines are allocated quantities. The issue arises because the previous placeholder line has a non-zero quantity, but the new placeholder row is not allocated, and therefore does not have `isUpdated` set.

This change is to check for the specific case and set the `isUpdated` flag if there is a previous placeholder quantity which is no longer required. There's a subsequent change to allow deleting of placeholder rows.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
As per the issue - create an outbound with a placeholder row. Allocate in the modal - if all of the placeholder quantity is allocated, the placeholder row should be removed.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
