### PR TITLE
Android: reset mode option

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,6 @@
     "test": "jest --config ./jest.config.js --maxWorkers=50% --env=jsdom",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "//": "The sed command here is a temporary workaround to fix an issue in graphql-codegen",
     "generate": "cd ../server && cargo run --bin remote_server_cli -- export-graphql-schema && cd ../client && graphql-codegen --config codegen.yml",
     "android:run": "npx cap run android",
     "android:build:server": "yarn build && lerna run --scope @openmsupply-client/android build:server --stream",

--- a/client/packages/common/src/hooks/useNativeClient/types.ts
+++ b/client/packages/common/src/hooks/useNativeClient/types.ts
@@ -2,6 +2,15 @@ import { IpcRendererEvent } from 'electron';
 export const DISCOVERY_TIMEOUT = 7000;
 export const DISCOVERED_SERVER_POLL = 2000;
 
+export const DEFAULT_LOCAL_SERVER = {
+  protocol: 'https' as 'https' | 'http',
+  port: 8000,
+  ip: '127.0.0.1',
+  clientVersion: '',
+  hardwareId: '',
+  isLocal: true,
+};
+
 export type Preference = {
   key: string;
   value: string;

--- a/client/packages/common/src/intl/locales/en/app.json
+++ b/client/packages/common/src/intl/locales/en/app.json
@@ -34,6 +34,7 @@
   "discovery.heading": "Welcome",
   "discovery.select-server": "Available servers",
   "discovery.sub-heading": "to open mSupply!",
+  "discovery.use-server-mode": "Note: You are currently using the client mode. To change to the local server mode click the button below.",
   "distribution": "Distribution",
   "docs": "Docs",
   "error.sync-api-incompatible": "Sync api version is not compatible",

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -21,6 +21,11 @@ import {
   ConnectionResult,
   useNotification,
   useMutation,
+  NativeMode,
+  useAuthContext,
+  DEFAULT_LOCAL_SERVER,
+  ExternalLinkIcon,
+  ButtonWithIcon,
 } from '@openmsupply-client/common';
 
 type ConnectToServer = ReturnType<typeof useNativeClient>['connectToServer'];
@@ -39,6 +44,24 @@ export const DiscoveredServers = ({
   discover,
 }: DiscoverServersProps) => {
   const t = useTranslation('app');
+  const { advertiseService, connectToServer, setMode } = useNativeClient();
+  const { token } = useAuthContext();
+  const { error } = useNotification();
+
+  const handleConnectionResult = async (result: ConnectionResult) => {
+    if (result.success) return;
+
+    error(t('error.unable-to-connect', { server: '' }))();
+  };
+
+  const useServerMode = () => {
+    setMode(NativeMode.Server);
+    advertiseService();
+    const path = !token ? 'login' : '';
+    connectToServer({ ...DEFAULT_LOCAL_SERVER, path })
+      .then(handleConnectionResult)
+      .catch(e => handleConnectionResult({ success: false, error: e.message }));
+  };
 
   if (discoveryTimedOut)
     return (
@@ -46,6 +69,7 @@ export const DiscoveredServers = ({
         display="flex"
         sx={{ color: 'error.main' }}
         justifyContent="center"
+        alignItems="center"
         flexDirection="column"
       >
         <Box display="flex" gap={1}>
@@ -60,6 +84,25 @@ export const DiscoveredServers = ({
               icon={<RefreshIcon color="primary" fontSize="small" />}
               onClick={discover}
               label={t('button.refresh')}
+            />
+          </Box>
+        </Box>
+        <Box
+          paddingTop={4}
+          alignItems="center"
+          flexDirection="column"
+          display="flex"
+        >
+          <Box>
+            <Typography display="inline-flex">
+              {t('discovery.use-server-mode')}
+            </Typography>
+          </Box>
+          <Box padding={2}>
+            <ButtonWithIcon
+              Icon={<ExternalLinkIcon fontStyle="small" />}
+              onClick={useServerMode}
+              label={t('label.server')}
             />
           </Box>
         </Box>

--- a/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
+++ b/client/packages/common/src/ui/discovery/DiscoveredServers.tsx
@@ -21,9 +21,6 @@ import {
   ConnectionResult,
   useNotification,
   useMutation,
-  NativeMode,
-  useAuthContext,
-  DEFAULT_LOCAL_SERVER,
   ExternalLinkIcon,
   ButtonWithIcon,
 } from '@openmsupply-client/common';
@@ -44,8 +41,7 @@ export const DiscoveredServers = ({
   discover,
 }: DiscoverServersProps) => {
   const t = useTranslation('app');
-  const { advertiseService, connectToServer, setMode } = useNativeClient();
-  const { token } = useAuthContext();
+  const { setServerMode } = useNativeClient();
   const { error } = useNotification();
 
   const handleConnectionResult = async (result: ConnectionResult) => {
@@ -55,12 +51,7 @@ export const DiscoveredServers = ({
   };
 
   const useServerMode = () => {
-    setMode(NativeMode.Server);
-    advertiseService();
-    const path = !token ? 'login' : '';
-    connectToServer({ ...DEFAULT_LOCAL_SERVER, path })
-      .then(handleConnectionResult)
-      .catch(e => handleConnectionResult({ success: false, error: e.message }));
+    setServerMode(handleConnectionResult);
   };
 
   if (discoveryTimedOut)

--- a/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
+++ b/client/packages/common/src/ui/discovery/ServerDiscovery.tsx
@@ -13,7 +13,7 @@ import { LoginIcon } from '@openmsupply-client/host/src/components/Login/LoginIc
 import { Theme } from '@common/styles';
 import { DiscoveredServers } from './DiscoveredServers';
 
-// TODO should this be disabled if native client doesn't exist ? (since it's navigatable from host)
+// TODO should this be disabled if native client doesn't exist ? (since it's navigable from host)
 
 // When discovery is opened, by default, useNativeClient will try to connect to previously connected server
 // if ?autoconnect=false url parameter is present, auto connection will be disabled, this is useful when navigating
@@ -21,7 +21,7 @@ import { DiscoveredServers } from './DiscoveredServers';
 const isAutoconnect = () => {
   const url = new URL(window.location.href);
   const params = new URLSearchParams(url.search);
-  // autoconnect deafults to true
+  // autoconnect defaults to true
   return params.get('autoconnect') !== 'false';
 };
 

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   ButtonWithIcon,
   ConnectionResult,
+  DEFAULT_LOCAL_SERVER,
   ErrorWithDetails,
   ExternalLinkIcon,
   getNativeAPI,
@@ -22,15 +23,6 @@ import {
 import { useTranslation } from '@common/intl';
 import Viewport from './Viewport';
 import { LoginIcon } from './Login/LoginIcon';
-
-const DEFAULT_LOCAL_SERVER = {
-  protocol: 'https' as 'https' | 'http',
-  port: 8000,
-  ip: '127.0.0.1',
-  clientVersion: '',
-  hardwareId: '',
-  isLocal: true,
-};
 
 const Heading = ({ text }: { text: string }) => (
   <Typography

--- a/client/packages/host/src/components/Android.tsx
+++ b/client/packages/host/src/components/Android.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   ButtonWithIcon,
   ConnectionResult,
-  DEFAULT_LOCAL_SERVER,
   ErrorWithDetails,
   ExternalLinkIcon,
   getNativeAPI,
@@ -16,7 +15,6 @@ import {
   Stack,
   Theme,
   Typography,
-  useAuthContext,
   useNativeClient,
   useNavigate,
 } from '@openmsupply-client/common';
@@ -99,20 +97,14 @@ const ModeOption = ({
 );
 
 export const Android = () => {
-  const {
-    connectToPreviousFailed,
-    previousServer,
-    connectToServer,
-    advertiseService,
-  } = useNativeClient({
+  const { connectToPreviousFailed, previousServer } = useNativeClient({
     discovery: true,
     autoconnect: true,
   });
   const t = useTranslation('app');
   const navigate = useNavigate();
-  const { token } = useAuthContext();
   const [mode, setLocalMode] = useState(NativeMode.None);
-  const { setMode } = useNativeClient();
+  const { setMode, setServerMode } = useNativeClient();
 
   const handleSetMode = (mode: NativeMode) => {
     setMode(mode);
@@ -138,13 +130,7 @@ export const Android = () => {
 
   useEffect(() => {
     if (mode === NativeMode.Server) {
-      advertiseService();
-      const path = !token ? 'login' : '';
-      connectToServer({ ...DEFAULT_LOCAL_SERVER, path })
-        .then(handleConnectionResult)
-        .catch(e =>
-          handleConnectionResult({ success: false, error: e.message })
-        );
+      setServerMode(handleConnectionResult);
     }
   }, [mode]);
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1915

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Have added a message and button, which will allow changing from client to server mode.
This only shows when the discovery page is unable to find a server using discovery. If the user is expecting to find a server on the network and it isn't shown, I don't think it's helpful to switch to the local server mode.

The result is a screen like this (emulated version):

![Screenshot 2023-07-18 at 2 37 00 PM](https://github.com/openmsupply/open-msupply/assets/9192912/4d69fccf-4d0a-4cae-949e-7975fa4c2f5d)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I'm not finding any servers on my emulator, so have used that to test. 
If you cannot connect to the local server, a toast is shown - for that I was using the web version and browsing to `/discovery` after setting `discoveryTimedOut` to true in order to show the error.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
- [ ] A screenshot would be helpful
