### PR TITLE
Notify if build fails on jenkins

### DIFF
--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -14,18 +14,18 @@ xcopy "build\windows\demo" "omSupply\demo" /c /y /i
 copy "version.txt" "omSupply\version.txt"
 
 @cd "build\windows"
-start /b /wait omsupply-prepare.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@REM start /b /wait omsupply-prepare.bat
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%
 
-start /b /wait omsupply-sqlite-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+call omsupply-sqlite-build.bat
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-start /b /wait omsupply-postgres-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@REM start /b /wait omsupply-postgres-build.bat
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%
 
-start /b /wait omsupply-desktop-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@REM start /b /wait omsupply-desktop-build.bat
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%
 
-cd "..\..\server"
-start /wait cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%
+@REM cd "..\..\server"
+@REM start /wait cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -15,8 +15,17 @@ copy "version.txt" "omSupply\version.txt"
 
 @cd "build\windows"
 start /b /wait omsupply-prepare.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 start /b /wait omsupply-sqlite-build.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 start /b /wait omsupply-postgres-build.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 start /b /wait omsupply-desktop-build.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 cd "..\..\server"
 start /wait cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -13,19 +13,21 @@ xcopy "build\windows\*.*" "omSupply" /c
 xcopy "build\windows\demo" "omSupply\demo" /c /y /i
 copy "version.txt" "omSupply\version.txt"
 
-@cd "build\windows"
-call omsupply-prepare.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@ECHO ##### Prepare omsupply build #####
+cd "client" && yarn install --force --frozen-lockfile && yarn build
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-call omsupply-sqlite-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@ECHO ##### Building omsupply for the sqlite #####
+cd "server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-call omsupply-postgres-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@ECHO ##### Building omsupply for the postgres #####
+cd "server" && cargo build --release --bin omsupply_service --features postgres && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-call omsupply-desktop-build.bat
-if %errorlevel% neq 0 exit /b %errorlevel%
+@ECHO ##### Building omSupply for the desktop #####
+cd "client" && yarn electron:build && xcopy "packages\electron\out\open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-cd "..\..\server"
-call cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%
+cd "server" && cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -13,9 +13,8 @@ xcopy "build\windows\*.*" "omSupply" /c
 xcopy "build\windows\demo" "omSupply\demo" /c /y /i
 copy "version.txt" "omSupply\version.txt"
 
-@REM @ECHO ##### Prepare omsupply build #####
-@REM cd "client" && yarn install --force --frozen-lockfile && yarn build
-@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+start /wait /b build\windows\omsupply-prepare.bat
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
 @ECHO ##### Building omsupply for the sqlite #####
 cd "server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -15,17 +15,17 @@ copy "version.txt" "omSupply\version.txt"
 
 @cd "build\windows"
 call omsupply-prepare.bat
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 call omsupply-sqlite-build.bat
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 call omsupply-postgres-build.bat
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 call omsupply-desktop-build.bat
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 cd "..\..\server"
 call cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -14,18 +14,18 @@ xcopy "build\windows\demo" "omSupply\demo" /c /y /i
 copy "version.txt" "omSupply\version.txt"
 
 @cd "build\windows"
-@REM start /b /wait omsupply-prepare.bat
-@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+call omsupply-prepare.bat
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
 call omsupply-sqlite-build.bat
 @if %errorlevel% neq 0 exit /b %errorlevel%
 
-@REM start /b /wait omsupply-postgres-build.bat
-@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+call omsupply-postgres-build.bat
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-@REM start /b /wait omsupply-desktop-build.bat
-@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+call omsupply-desktop-build.bat
+@if %errorlevel% neq 0 exit /b %errorlevel%
 
-@REM cd "..\..\server"
-@REM start /wait cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
-@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+cd "..\..\server"
+call cargo build --release && copy "target\release\remote_server.exe" "..\omSupply\Server\omSupply-server-sqlite.exe"
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -13,9 +13,9 @@ xcopy "build\windows\*.*" "omSupply" /c
 xcopy "build\windows\demo" "omSupply\demo" /c /y /i
 copy "version.txt" "omSupply\version.txt"
 
-@ECHO ##### Prepare omsupply build #####
-cd "client" && yarn install --force --frozen-lockfile && yarn build
-@if %errorlevel% neq 0 exit /b %errorlevel%
+@REM @ECHO ##### Prepare omsupply build #####
+@REM cd "client" && yarn install --force --frozen-lockfile && yarn build
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%
 
 @ECHO ##### Building omsupply for the sqlite #####
 cd "server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"

--- a/build/windows/omsupply-desktop-build.bat
+++ b/build/windows/omsupply-desktop-build.bat
@@ -1,3 +1,0 @@
-@ECHO ##### Building omSupply for the desktop #####
-cd "..\..\client" && yarn electron:build && xcopy "packages\electron\out\open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
-if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-desktop-build.bat
+++ b/build/windows/omsupply-desktop-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omSupply for the desktop #####
 cd "..\..\client" && yarn electron:build && xcopy "packages\electron\out\open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-desktop-build.bat
+++ b/build/windows/omsupply-desktop-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omSupply for the desktop #####
 cd "..\..\client" && yarn electron:build && xcopy "packages\electron\out\open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-desktop-build.bat
+++ b/build/windows/omsupply-desktop-build.bat
@@ -1,2 +1,3 @@
 @ECHO ##### Building omSupply for the desktop #####
 cd "..\..\client" && yarn electron:build && xcopy "packages\electron\out\open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-postgres-build.bat
+++ b/build/windows/omsupply-postgres-build.bat
@@ -1,2 +1,3 @@
 @ECHO ##### Building omsupply for the postgres #####
 cd "..\..\server" && cargo build --release --bin omsupply_service --features postgres && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-postgres-build.bat
+++ b/build/windows/omsupply-postgres-build.bat
@@ -1,3 +1,0 @@
-@ECHO ##### Building omsupply for the postgres #####
-cd "..\..\server" && cargo build --release --bin omsupply_service --features postgres && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-postgres-build.bat
+++ b/build/windows/omsupply-postgres-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omsupply for the postgres #####
 cd "..\..\server" && cargo build --release --bin omsupply_service --features postgres && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-postgres-build.bat
+++ b/build/windows/omsupply-postgres-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omsupply for the postgres #####
 cd "..\..\server" && cargo build --release --bin omsupply_service --features postgres && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,2 +1,3 @@
 @ECHO ##### Prepare omsupply build #####
 cd "..\..\client" && yarn install --force --frozen-lockfile && yarn build
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,0 +1,3 @@
+ECHO ##### Prepare omsupply build #####
+cd "client" && yarn install --force --frozen-lockfile && yarn build
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Prepare omsupply build #####
 cd "..\..\client" && yarn install --force --frozen-lockfile && yarn build
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Prepare omsupply build #####
 cd "..\..\client" && yarn install --force --frozen-lockfile && yarn build
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,3 +1,0 @@
-@ECHO ##### Prepare omsupply build #####
-cd "..\..\client" && yarn install --force --frozen-lockfile && yarn build
-if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-sqlite-build.bat
+++ b/build/windows/omsupply-sqlite-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omsupply for the sqlite #####
 cd "..\..\server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%
+@if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-sqlite-build.bat
+++ b/build/windows/omsupply-sqlite-build.bat
@@ -1,2 +1,3 @@
 @ECHO ##### Building omsupply for the sqlite #####
 cd "..\..\server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-sqlite-build.bat
+++ b/build/windows/omsupply-sqlite-build.bat
@@ -1,3 +1,0 @@
-@ECHO ##### Building omsupply for the sqlite #####
-cd "..\..\server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
-if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/windows/omsupply-sqlite-build.bat
+++ b/build/windows/omsupply-sqlite-build.bat
@@ -1,3 +1,3 @@
 @ECHO ##### Building omsupply for the sqlite #####
 cd "..\..\server" && cargo build --release --bin omsupply_service && copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
-@if %errorlevel% neq 0 exit /b %errorlevel%
+if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2005 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
I was unable to get the secondary batch files to report failures correctly, so have removed them and lifted the calls up to the main batch. This is now working, in that a cargo build failure or copy failure will stop the build, raise the error and prevent the installers from building.

The omsupply-prepare.bat has been kept though: running that with `call` rather than `start /wait` results in the main batch completing at the end of the `yarn install`. Similarly, if the code is within the batch, the same result. There's something with the `yarn` command that ends the process.


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I've run some builds. you'll see them on jenkins. Simply switch to this branch and create a tag to see it happen.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
