### PR TITLE
Show auto created inbound shipments as enabled in list view

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/SidePanel/PricingSection.tsx
@@ -91,6 +91,7 @@ export const PricingSectionComponent = () => {
           </PanelLabel>
           <PanelField>
             <IconButton
+              disabled={isDisabled}
               icon={<EditIcon style={{ fontSize: 16, fill: 'none' }} />}
               label={t('label.edit')}
               onClick={serviceLineModal.toggleOn}

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -15,13 +15,15 @@ import {
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
-import { getStatusTranslator, isInboundDisabled } from '../../utils';
+import { getStatusTranslator, isInboundListItemDisabled } from '../../utils';
 import { useInbound, InboundRowFragment } from '../api';
 
 const useDisableInboundRows = (rows?: InboundRowFragment[]) => {
   const { setDisabledRows } = useTableStore();
   useEffect(() => {
-    const disabledRows = rows?.filter(isInboundDisabled).map(({ id }) => id);
+    const disabledRows = rows
+      ?.filter(isInboundListItemDisabled)
+      .map(({ id }) => id);
     if (disabledRows) setDisabledRows(disabledRows);
   }, [rows]);
 };

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -120,6 +120,16 @@ export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
         inbound.status === InvoiceNodeStatus.Verified;
 };
 
+export const isInboundListItemDisabled = (
+  inbound: InboundRowFragment
+): boolean => {
+  const isManuallyCreated = !inbound.linkedShipment?.id;
+  return isManuallyCreated
+    ? inbound.status === InvoiceNodeStatus.Verified
+    : inbound.status === InvoiceNodeStatus.Picked ||
+        inbound.status === InvoiceNodeStatus.Verified;
+};
+
 export const isInboundPlaceholderRow = (row: InboundLineFragment): boolean =>
   row.type === InvoiceLineNodeType.StockIn && row.numberOfPacks === 0;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1699 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Shows automatically created inbound shipments as enabled in the list view.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
- Create an outbound shipment from store A to store B and set status to `Shipped`
- Change to store B and view the list of inbound shipments
- See that the shipment is not greyed out in the list
- Observe that you cannot edit the shipment, but you can change the status (and the info message is shown)
- Change status to `Delivered` : can now edit details (and shows in the list as editable)
- Change status to `Verified`: cannot edit details (and shows in list and non-editable)


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
