### PR TITLE
1933.1 Align is sync update common

### DIFF
--- a/server/repository/src/db_diesel/clinician.rs
+++ b/server/repository/src/db_diesel/clinician.rs
@@ -276,7 +276,6 @@ mod tests {
                 id: "JoinId1".to_string(),
                 store_id: mock_store_a().id,
                 clinician_id: "clinician_store_a".to_string(),
-                is_sync_update: false,
             })
             .unwrap();
 

--- a/server/repository/src/db_diesel/clinician_store_join_row.rs
+++ b/server/repository/src/db_diesel/clinician_store_join_row.rs
@@ -9,20 +9,26 @@ table! {
     id -> Text,
     store_id -> Text,
     clinician_id -> Text,
-    is_sync_update -> Bool,
   }
+}
+
+table! {
+    #[sql_name = "clinician_store_join"]
+    clinician_store_join_is_sync_update (id) {
+        id -> Text,
+        is_sync_update -> Bool,
+    }
 }
 
 joinable!(clinician_store_join -> clinician (clinician_id));
 allow_tables_to_appear_in_same_query!(clinician, clinician_store_join);
 
-#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
 #[table_name = "clinician_store_join"]
 pub struct ClinicianStoreJoinRow {
     pub id: String,
     pub store_id: String,
     pub clinician_id: String,
-    pub is_sync_update: bool,
 }
 
 pub struct ClinicianStoreJoinRowRepository<'a> {
@@ -35,7 +41,7 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
     }
 
     #[cfg(feature = "postgres")]
-    pub fn upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
         diesel::insert_into(clinician_store_join::dsl::clinician_store_join)
             .values(row)
             .on_conflict(clinician_store_join::dsl::id)
@@ -46,14 +52,27 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
     }
 
     #[cfg(not(feature = "postgres"))]
-    pub fn upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
         diesel::replace_into(clinician_store_join::dsl::clinician_store_join)
             .values(row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
+    pub fn upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        self.toggle_is_sync_update(&row.id, false)?;
+        Ok(())
+    }
 
-    pub fn find_one_by_id(
+    fn toggle_is_sync_update(&self, id: &str, is_sync_update: bool) -> Result<(), RepositoryError> {
+        diesel::update(clinician_store_join_is_sync_update::table.find(id))
+            .set(clinician_store_join_is_sync_update::dsl::is_sync_update.eq(is_sync_update))
+            .execute(&self.connection.connection)?;
+
+        Ok(())
+    }
+
+    pub fn find_one_by_id_option(
         &self,
         row_id: &str,
     ) -> Result<Option<ClinicianStoreJoinRow>, RepositoryError> {
@@ -71,5 +90,93 @@ impl<'a> ClinicianStoreJoinRowRepository<'a> {
         )
         .execute(&self.connection.connection)?;
         Ok(())
+    }
+
+    pub fn sync_upsert_one(&self, row: &ClinicianStoreJoinRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        self.toggle_is_sync_update(&row.id, true)?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn find_is_sync_update_by_id(&self, id: &str) -> Result<Option<bool>, RepositoryError> {
+        let result = clinician_store_join_is_sync_update::table
+            .find(id)
+            .select(clinician_store_join_is_sync_update::dsl::is_sync_update)
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use util::uuid::uuid;
+
+    use crate::{
+        mock::{mock_store_a, MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        ClinicianRow, ClinicianStoreJoinRow, ClinicianStoreJoinRowRepository,
+    };
+
+    #[actix_rt::test]
+    async fn clinician_store_join_is_sync_update() {
+        let clinician = ClinicianRow {
+            id: uuid(),
+            ..Default::default()
+        };
+
+        let (_, connection, _, _) = setup_all_with_data(
+            "clinician_store_join_is_sync_update",
+            MockDataInserts::none()
+                .items()
+                .units()
+                .names()
+                .stores()
+                .clinicians(),
+            MockData {
+                clinicians: vec![clinician.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let repo = ClinicianStoreJoinRowRepository::new(&connection);
+
+        let base_row = ClinicianStoreJoinRow {
+            clinician_id: clinician.id,
+            store_id: mock_store_a().id,
+            ..Default::default()
+        };
+
+        // Two rows, to make sure is_sync_update update only affects one row
+        let row = ClinicianStoreJoinRow {
+            id: uuid(),
+            ..base_row.clone()
+        };
+        let row2 = ClinicianStoreJoinRow {
+            id: uuid(),
+            ..base_row.clone()
+        };
+
+        // First insert
+        repo.upsert_one(&row).unwrap();
+        repo.upsert_one(&row2).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(false)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
+
+        // Synchronisation upsert
+        repo.sync_upsert_one(&row).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(true)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
+
+        // Normal upsert
+        repo.upsert_one(&row).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(false)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
     }
 }

--- a/server/repository/src/db_diesel/name_row.rs
+++ b/server/repository/src/db_diesel/name_row.rs
@@ -37,6 +37,13 @@ table! {
         created_datetime -> Nullable<Timestamp>,
         is_deceased -> Bool,
         national_health_number -> Nullable<Text>,
+    }
+}
+
+table! {
+    #[sql_name = "name"]
+    name_is_sync_update (id) {
+        id -> Text,
         is_sync_update -> Bool,
     }
 }
@@ -132,7 +139,6 @@ pub struct NameRow {
 
     pub is_deceased: bool,
     pub national_health_number: Option<String>,
-    pub is_sync_update: bool,
 }
 
 pub struct NameRowRepository<'a> {
@@ -145,7 +151,7 @@ impl<'a> NameRowRepository<'a> {
     }
 
     #[cfg(feature = "postgres")]
-    pub fn upsert_one(&self, name_row: &NameRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, name_row: &NameRow) -> Result<(), RepositoryError> {
         diesel::insert_into(name)
             .values(name_row)
             .on_conflict(id)
@@ -156,10 +162,28 @@ impl<'a> NameRowRepository<'a> {
     }
 
     #[cfg(not(feature = "postgres"))]
-    pub fn upsert_one(&self, name_row: &NameRow) -> Result<(), RepositoryError> {
+    fn _upsert_one(&self, name_row: &NameRow) -> Result<(), RepositoryError> {
         diesel::replace_into(name)
             .values(name_row)
             .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    fn toggle_is_sync_update(
+        &self,
+        name_id: &str,
+        is_sync_update: bool,
+    ) -> Result<(), RepositoryError> {
+        diesel::update(name_is_sync_update::table.find(name_id))
+            .set(name_is_sync_update::dsl::is_sync_update.eq(is_sync_update))
+            .execute(&self.connection.connection)?;
+
+        Ok(())
+    }
+
+    pub fn upsert_one(&self, row: &NameRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        self.toggle_is_sync_update(&row.id, false)?;
         Ok(())
     }
 
@@ -196,5 +220,69 @@ impl<'a> NameRowRepository<'a> {
             .filter(id.eq_any(ids))
             .load(&self.connection.connection)?;
         Ok(result)
+    }
+
+    pub fn sync_upsert_one(&self, row: &NameRow) -> Result<(), RepositoryError> {
+        self._upsert_one(row)?;
+        self.toggle_is_sync_update(&row.id, true)?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn find_is_sync_update_by_id(&self, name_id: &str) -> Result<Option<bool>, RepositoryError> {
+        let result = name_is_sync_update::table
+            .find(name_id)
+            .select(name_is_sync_update::dsl::is_sync_update)
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use util::uuid::uuid;
+
+    use crate::{mock::MockDataInserts, test_db::setup_all, NameRow, NameRowRepository};
+
+    #[actix_rt::test]
+    async fn name_is_sync_update() {
+        let (_, connection, _, _) = setup_all(
+            "name_is_sync_update",
+            MockDataInserts::none().items().units(),
+        )
+        .await;
+
+        let repo = NameRowRepository::new(&connection);
+
+        // Two rows, to make sure is_sync_update update only affects one row
+        let row = NameRow {
+            id: uuid(),
+            ..Default::default()
+        };
+        let row2 = NameRow {
+            id: uuid(),
+            ..Default::default()
+        };
+
+        // First insert
+        repo.upsert_one(&row).unwrap();
+        repo.upsert_one(&row2).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(false)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
+
+        // Synchronisation upsert
+        repo.sync_upsert_one(&row).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(true)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
+
+        // Normal upsert
+        repo.upsert_one(&row).unwrap();
+
+        assert_eq!(repo.find_is_sync_update_by_id(&row.id), Ok(Some(false)));
+        assert_eq!(repo.find_is_sync_update_by_id(&row2.id), Ok(Some(false)));
     }
 }

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -750,7 +750,7 @@ pub fn insert_mock_data(
         if inserts.documents {
             for row in &mock_data.documents {
                 let repo = DocumentRepository::new(connection);
-                repo.insert(row, false).unwrap();
+                repo.insert(row).unwrap();
             }
         }
         if inserts.sync_logs {

--- a/server/repository/src/mock/name_store_join.rs
+++ b/server/repository/src/mock/name_store_join.rs
@@ -9,7 +9,6 @@ pub fn mock_name_store_join_a() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: false,
-        is_sync_update: false,
     }
 }
 
@@ -20,7 +19,6 @@ pub fn mock_name_store_join_b() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: false,
-        is_sync_update: false,
     }
 }
 
@@ -31,7 +29,6 @@ pub fn mock_name_store_join_c() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -42,7 +39,6 @@ pub fn mock_name_store_join_d() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -53,7 +49,6 @@ pub fn mock_name_store_join_e() -> NameStoreJoinRow {
         store_id: String::from("store_c"),
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -64,7 +59,6 @@ pub fn mock_patient_store_join() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -75,7 +69,6 @@ pub fn mock_patient_store_join_b() -> NameStoreJoinRow {
         store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -86,7 +79,6 @@ pub fn name_store_join_program_a() -> NameStoreJoinRow {
         name_id: mock_name_store_a().id,
         name_is_customer: true,
         name_is_supplier: false,
-        is_sync_update: false,
     }
 }
 
@@ -97,7 +89,6 @@ pub fn name_store_join_program_b() -> NameStoreJoinRow {
         name_id: mock_name_store_b().id,
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -108,7 +99,6 @@ pub fn name_store_join_program_a_name_a() -> NameStoreJoinRow {
         name_id: mock_name_a().id,
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 

--- a/server/repository/src/mock/test_name_query.rs
+++ b/server/repository/src/mock/test_name_query.rs
@@ -52,7 +52,6 @@ pub fn mock_name_1_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_2().id,
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -72,7 +71,6 @@ pub fn mock_name_2_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -91,7 +89,6 @@ pub fn mock_name_3_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -102,7 +99,6 @@ pub fn mock_name_3_join2() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_2().id,
         name_is_customer: false,
         name_is_supplier: false,
-        is_sync_update: false,
     }
 }
 
@@ -121,6 +117,5 @@ pub fn name_a_umlaut_join() -> NameStoreJoinRow {
         store_id: mock_test_name_query_store_1().id,
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }

--- a/server/repository/src/mock/test_name_store_id.rs
+++ b/server/repository/src/mock/test_name_store_id.rs
@@ -57,7 +57,6 @@ pub fn mock_name_linked_to_store_join() -> NameStoreJoinRow {
         store_id: "store_a".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -86,7 +85,6 @@ pub fn mock_name_linked_to_store_join_a() -> NameStoreJoinRow {
         store_id: "store_c".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -107,7 +105,6 @@ pub fn mock_name_not_linked_to_store_join() -> NameStoreJoinRow {
         store_id: "store_a".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -128,7 +125,6 @@ pub fn mock_name_not_linked_to_store_join_a() -> NameStoreJoinRow {
         store_id: "store_c".to_owned(),
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 

--- a/server/service/src/document/document_service.rs
+++ b/server/service/src/document/document_service.rs
@@ -175,7 +175,7 @@ pub trait DocumentServiceTrait: Sync + Send {
                 let current_document = validate_document_delete(con, &input.id, allowed_ctx)?;
                 let document = generate_deleted_document(current_document, user_id)?;
 
-                match DocumentRepository::new(con).insert(&document, false) {
+                match DocumentRepository::new(con).insert(&document) {
                     Ok(_) => Ok(()),
                     Err(error) => Err(DocumentDeleteError::DatabaseError(error)),
                 }
@@ -197,7 +197,7 @@ pub trait DocumentServiceTrait: Sync + Send {
                 let parent_doc = validate_document_undelete(con, &input.id, allowed_ctx)?;
                 let document = generate_undeleted_document(&input.id, parent_doc, user_id)?;
 
-                match DocumentRepository::new(con).insert(&document, false) {
+                match DocumentRepository::new(con).insert(&document) {
                     Ok(_) => Ok(document),
                     Err(error) => Err(DocumentUndeleteError::DatabaseError(error)),
                 }
@@ -373,7 +373,7 @@ fn insert_document(
         .finalise()
         .map_err(|err| DocumentInsertError::InternalError(err))?;
     let repo = DocumentRepository::new(connection);
-    repo.insert(&doc, false)?;
+    repo.insert(&doc)?;
     Ok(doc)
 }
 

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -302,7 +302,6 @@ mod test {
                 id: "test_clinician_store_join".to_string(),
                 store_id: mock_store_a().id,
                 clinician_id: clinician().id,
-                is_sync_update: false,
             }
         }
 

--- a/server/service/src/invoice/prescription/update/validate.rs
+++ b/server/service/src/invoice/prescription/update/validate.rs
@@ -56,7 +56,7 @@ fn check_clinician_exists(
     let result = match clinician_id {
         None => true,
         Some(clinician_id) => ClinicianRowRepository::new(connection)
-            .find_one_by_id(&clinician_id)?
+            .find_one_by_id_option(&clinician_id)?
             .is_some(),
     };
 

--- a/server/service/src/programs/encounter/validate_misc.rs
+++ b/server/service/src/programs/encounter/validate_misc.rs
@@ -8,7 +8,7 @@ pub fn validate_clinician_exists(
     connection: &StorageConnection,
     clinician_id: &str,
 ) -> Result<Option<ClinicianRow>, RepositoryError> {
-    let result = ClinicianRowRepository::new(connection).find_one_by_id(clinician_id)?;
+    let result = ClinicianRowRepository::new(connection).find_one_by_id_option(clinician_id)?;
     Ok(result)
 }
 

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -29,7 +29,6 @@ pub fn create_patient_name_store_join(
             store_id: store_id.to_string(),
             name_is_customer: true,
             name_is_supplier: false,
-            is_sync_update: false,
         })?;
     }
     Ok(())
@@ -75,7 +74,8 @@ pub fn update_patient_row(
     let name_repo = NameRowRepository::new(con);
     let existing_name = name_repo.find_one_by_id(&id)?;
     let existing_name = existing_name.as_ref();
-    name_repo.upsert_one(&NameRow {
+
+    let name_upsert = NameRow {
         id: id.clone(),
         name: patient_name(&first_name, &last_name),
         code: code.unwrap_or("".to_string()),
@@ -111,8 +111,13 @@ pub fn update_patient_row(
             .or(Some(update_timestamp.naive_utc())), // assume there is no earlier doc version
         is_deceased: patient.is_deceased.unwrap_or(false),
         national_health_number: code_2,
-        is_sync_update,
-    })?;
+    };
+
+    if is_sync_update {
+        name_repo.sync_upsert_one(&name_upsert)?;
+    } else {
+        name_repo.upsert_one(&name_upsert)?;
+    }
 
     Ok(())
 }

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -12,12 +12,12 @@ use crate::programs::{
     program_enrolment::program_schema::SchemaProgramEnrolment,
 };
 
-pub(crate) fn upsert_document(
+pub(crate) fn sync_upsert_document(
     con: &StorageConnection,
     document: &Document,
-    is_sync_update: bool,
 ) -> Result<(), RepositoryError> {
-    DocumentRepository::new(con).insert(document, is_sync_update)?;
+    // TODO comment why only insert here
+    DocumentRepository::new(con).sync_insert(document)?;
 
     let Some(registry) = DocumentRegistryRepository::new(con)
         .query_by_filter(

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -115,28 +115,6 @@ pub(crate) async fn insert_all_extra_data(
     }
 }
 
-macro_rules! check_record_by_id_ignore_is_sync_update {
-    ($repository:ident, $connection:ident, $comparison_record:ident, $record_type:tt, $record_string:expr) => {{
-        let record = $repository::new(&$connection)
-            .find_one_by_id(&$comparison_record.id)
-            .unwrap()
-            .expect(&format!(
-                "{} row not found: {}",
-                $record_string, $comparison_record.id
-            ));
-        assert_eq!(
-            $record_type {
-                is_sync_update: false,
-                ..record
-            },
-            $record_type {
-                is_sync_update: false,
-                ..$comparison_record
-            }
-        )
-    }};
-}
-
 macro_rules! check_record_by_id {
     ($repository:ident, $connection:ident, $comparison_record:ident, $record_string:expr) => {{
         assert_eq!(
@@ -209,13 +187,7 @@ pub(crate) async fn check_records_against_database(
                 check_record_by_option_id!(StockLineRowRepository, con, record, "StockLine");
             }
             Name(record) => {
-                check_record_by_id_ignore_is_sync_update!(
-                    NameRowRepository,
-                    con,
-                    record,
-                    NameRow,
-                    "Name"
-                );
+                check_record_by_id!(NameRowRepository, con, record, "Name");
             }
             NameTag(record) => {
                 check_record_by_id!(NameTagRowRepository, con, record, "NameTag");
@@ -224,13 +196,7 @@ pub(crate) async fn check_records_against_database(
                 check_record_by_id!(NameTagJoinRepository, con, record, "NameTagJoin");
             }
             NameStoreJoin(record) => {
-                check_record_by_id_ignore_is_sync_update!(
-                    NameStoreJoinRepository,
-                    con,
-                    record,
-                    NameStoreJoinRow,
-                    "NameStoreJoin"
-                );
+                check_record_by_id!(NameStoreJoinRepository, con, record, "NameStoreJoin");
             }
             Invoice(record) => {
                 check_record_by_option_id!(InvoiceRowRepository, con, record, "Invoice");
@@ -312,21 +278,14 @@ pub(crate) async fn check_records_against_database(
             Barcode(record) => check_record_by_id!(BarcodeRowRepository, con, record, "Barcode"),
 
             Clinician(record) => {
-                check_record_by_id_ignore_is_sync_update!(
-                    ClinicianRowRepository,
-                    con,
-                    record,
-                    ClinicianRow,
-                    "Clinician"
-                )
+                check_record_by_option_id!(ClinicianRowRepository, con, record, "Clinician")
             }
 
             ClinicianStoreJoin(record) => {
-                check_record_by_id_ignore_is_sync_update!(
+                check_record_by_option_id!(
                     ClinicianStoreJoinRowRepository,
                     con,
                     record,
-                    ClinicianStoreJoinRow,
                     "ClinicianStoreJoin"
                 )
             }

--- a/server/service/src/sync/test/test_data/name.rs
+++ b/server/service/src/sync/test/test_data/name.rs
@@ -136,7 +136,6 @@ fn name_1() -> TestSyncPullRecord {
             on_hold: true,
             address1: Some("address1".to_string()),
             address2: Some("address2".to_string()),
-            is_sync_update: true,
             created_datetime: Some(
                 NaiveDate::from_ymd_opt(2022, 05, 22)
                     .unwrap()
@@ -274,7 +273,6 @@ fn name_2() -> TestSyncPullRecord {
             created_datetime: None,
             is_deceased: false,
             national_health_number: None,
-            is_sync_update: true,
         }),
     )
 }
@@ -406,7 +404,6 @@ fn name_3() -> TestSyncPullRecord {
             created_datetime: None,
             is_deceased: false,
             national_health_number: Some("NHN002".to_string()),
-            is_sync_update: true,
         }),
     )
 }
@@ -544,7 +541,6 @@ fn name_4() -> TestSyncPullRecord {
             ),
             is_deceased: true,
             national_health_number: Some("NHN003".to_string()),
-            is_sync_update: true,
         }),
     )
 }

--- a/server/service/src/sync/test/test_data/name_store_join.rs
+++ b/server/service/src/sync/test/test_data/name_store_join.rs
@@ -31,7 +31,6 @@ fn name_store_join_1_pull_record() -> TestSyncPullRecord {
             name_id: "name_store_c".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
-            is_sync_update: true,
         }),
     )
 }
@@ -70,7 +69,6 @@ fn name_store_join_2_pull_record() -> TestSyncPullRecord {
             name_id: "name_store_a".to_string(),
             name_is_customer: false,
             name_is_supplier: true,
-            is_sync_update: true,
         }),
     )
 }

--- a/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
+++ b/server/service/src/sync/test/test_data/special/name_to_name_store_join.rs
@@ -135,7 +135,6 @@ pub fn name_store_join1() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: false,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 
@@ -146,7 +145,6 @@ pub fn name_store_join2() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: false,
         name_is_supplier: false,
-        is_sync_update: false,
     }
 }
 
@@ -157,7 +155,6 @@ pub fn name_store_join3() -> NameStoreJoinRow {
         store_id: store().id,
         name_is_customer: true,
         name_is_supplier: true,
-        is_sync_update: false,
     }
 }
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -1,4 +1,4 @@
-use crate::sync::{integrate_document::upsert_document, translations::PullDeleteRecordTable};
+use crate::sync::{integrate_document::sync_upsert_document, translations::PullDeleteRecordTable};
 
 use super::{
     sync_buffer::SyncBuffer,
@@ -172,7 +172,7 @@ impl PullUpsertRecord {
         use PullUpsertRecord::*;
         match self {
             UserPermission(record) => UserPermissionRowRepository::new(con).upsert_one(record),
-            Name(record) => NameRowRepository::new(con).upsert_one(record),
+            Name(record) => NameRowRepository::new(con).sync_upsert_one(record),
             NameTag(record) => NameTagRowRepository::new(con).upsert_one(record),
             NameTagJoin(record) => NameTagJoinRepository::new(con).upsert_one(record),
             Unit(record) => UnitRowRepository::new(con).upsert_one(record),
@@ -194,7 +194,7 @@ impl PullUpsertRecord {
             Location(record) => LocationRowRepository::new(con).upsert_one(record),
             LocationMovement(record) => LocationMovementRowRepository::new(con).upsert_one(record),
             StockLine(record) => StockLineRowRepository::new(con).upsert_one(record),
-            NameStoreJoin(record) => NameStoreJoinRepository::new(con).upsert_one(record),
+            NameStoreJoin(record) => NameStoreJoinRepository::new(con).sync_upsert_one(record),
             Invoice(record) => InvoiceRowRepository::new(con).upsert_one(record),
             InvoiceLine(record) => InvoiceLineRowRepository::new(con).upsert_one(record),
             Stocktake(record) => StocktakeRowRepository::new(con).upsert_one(record),
@@ -209,13 +209,13 @@ impl PullUpsertRecord {
             }
             StorePreference(record) => StorePreferenceRowRepository::new(con).upsert_one(record),
             Barcode(record) => BarcodeRowRepository::new(con).sync_upsert_one(record),
-            Clinician(record) => ClinicianRowRepository::new(con).upsert_one(record),
+            Clinician(record) => ClinicianRowRepository::new(con).sync_upsert_one(record),
             ClinicianStoreJoin(record) => {
-                ClinicianStoreJoinRowRepository::new(con).upsert_one(record)
+                ClinicianStoreJoinRowRepository::new(con).sync_upsert_one(record)
             }
             FormSchema(record) => FormSchemaRowRepository::new(con).upsert_one(record),
             DocumentRegistry(record) => DocumentRegistryRowRepository::new(con).upsert_one(record),
-            Document(record) => upsert_document(con, record, false),
+            Document(record) => sync_upsert_document(con, record),
         }
     }
 }

--- a/server/service/src/sync/translations/clinician.rs
+++ b/server/service/src/sync/translations/clinician.rs
@@ -99,7 +99,6 @@ impl SyncTranslation for ClinicianTranslation {
                 Some(Gender::Male)
             },
             is_active,
-            is_sync_update: true,
         };
         Ok(Some(IntegrationRecords::from_upsert(
             PullUpsertRecord::Clinician(result),
@@ -128,9 +127,8 @@ impl SyncTranslation for ClinicianTranslation {
             email,
             gender,
             is_active,
-            is_sync_update: _,
         } = ClinicianRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
+            .find_one_by_id_option(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
                 "Clinician row ({}) not found",
                 changelog.record_id

--- a/server/service/src/sync/translations/clinician_store_join.rs
+++ b/server/service/src/sync/translations/clinician_store_join.rs
@@ -53,7 +53,6 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             id,
             store_id,
             clinician_id: prescriber_id,
-            is_sync_update: true,
         };
         Ok(Some(IntegrationRecords::from_upsert(
             PullUpsertRecord::ClinicianStoreJoin(result),
@@ -73,9 +72,8 @@ impl SyncTranslation for ClinicianStoreJoinTranslation {
             id,
             store_id,
             clinician_id,
-            is_sync_update: _,
         } = ClinicianStoreJoinRowRepository::new(connection)
-            .find_one_by_id(&changelog.record_id)?
+            .find_one_by_id_option(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
                 "Clinician row ({}) not found",
                 changelog.record_id

--- a/server/service/src/sync/translations/document.rs
+++ b/server/service/src/sync/translations/document.rs
@@ -133,8 +133,7 @@ impl SyncTranslation for DocumentTranslation {
             status,
             owner_name_id,
             context,
-            is_sync_update: _,
-        } = document.to_row(false)?;
+        } = document.to_row()?;
 
         let legacy_row = LegacyDocumentRow {
             id,

--- a/server/service/src/sync/translations/name.rs
+++ b/server/service/src/sync/translations/name.rs
@@ -196,7 +196,6 @@ impl SyncTranslation for NameTranslation {
             created_datetime: data.created_datetime.or(data
                 .created_date
                 .map(|date| date.and_hms_opt(0, 0, 0).unwrap())),
-            is_sync_update: true,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -251,7 +250,6 @@ impl SyncTranslation for NameTranslation {
             created_datetime,
             is_deceased,
             national_health_number,
-            is_sync_update: _,
         } = NameRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -96,7 +96,6 @@ impl SyncTranslation for NameStoreJoinTranslation {
             // remaining as null, for now always names properties for name_is_supplier/customer
             name_is_customer: name.is_customer,
             name_is_supplier: name.is_supplier,
-            is_sync_update: true,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -119,7 +118,6 @@ impl SyncTranslation for NameStoreJoinTranslation {
             store_id,
             name_is_customer,
             name_is_supplier,
-            is_sync_update: _,
         } = NameStoreJoinRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1933


# 👩🏻‍💻 What does this PR do? 

Issue descrbes the reason for this change.

For Clinician, ClinicianStoreJoin, Name, NameStoreJoin and Document, align with is_sync_update logic for Requisition and Barcode:
* Remove is_sync_update field from base row type
* Add another diesel type with just id and is_sync_update field
* Add a method that updates is_sync_update field for the record
* Have a seperate upsert and sync_upsert method in repository, the later is used during sync (`translation_and_integration.rs`) instead of toggling is_sync_update to false or true through the whole codebase.

* Document repo is slightly different, there is insert method instead upsert, for other repos basically copy paste chagnes from Requisition and Barcode repo.
* Also patient update was touched (the method that turns document to name record), since it had a toggle (I think ideally it would be a two step, generate name change and using repo for upsert, this way a boolean wouldn't be needed, btw I think the boolean might have cause and issue, see self review comment)

* Removed check_record_by_id_ignore_is_sync_update, it's not needed anymore since base type does not have is_sync_update

# 🧪 How has/should this change been tested? 

Unit tests. Can also try two instances of program functionality (two sites), both with the same patient, and try editing patient on both sites, sync both sites a few times (make sure sync record are not constaly bouncing from one site to the other)

## 💌 Any notes for the reviewer?

Part 2 to follow (fixing integration tests)

## 📃 Documentation
