### PR TITLE
Fix integration tests

### DIFF
--- a/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/central/name_and_store_and_name_store_join.rs
@@ -47,7 +47,6 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
                 .and_hms_opt(0, 0, 0),
             is_deceased: false,
             national_health_number: None,
-            is_sync_update: true,
         };
         let name_json1 = json!({
             "ID": name_row1.id,
@@ -80,7 +79,6 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             r.r#type = NameType::Facility;
             r.is_customer = true;
             r.is_supplier = false;
-            r.is_sync_update = true;
         });
         let mut name_json2 = json!({
             "ID": name_row2.id,
@@ -123,7 +121,6 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             store_id: new_site_properties.store_id.clone(),
             name_is_customer: true,
             name_is_supplier: false,
-            is_sync_update: true,
         };
         let name_store_join_json1 = json!({
             "ID": name_store_join_row1.id,
@@ -138,7 +135,6 @@ impl SyncRecordTester for NameAndStoreAndNameStoreJoinTester {
             store_id: store_row.id.clone(),
             name_is_customer: true,
             name_is_supplier: false,
-            is_sync_update: true,
         };
         let name_store_join_json2 = json!({
             "ID": name_store_join_row2.id,

--- a/server/service/src/sync/test/integration/remote/clinician.rs
+++ b/server/service/src/sync/test/integration/remote/clinician.rs
@@ -45,7 +45,6 @@ impl SyncRecordTester for ClinicianRecordTester {
             email: None,
             gender: Some(Gender::Male),
             is_active: true,
-            is_sync_update: true,
         };
 
         let clinician_json = json!({
@@ -62,7 +61,6 @@ impl SyncRecordTester for ClinicianRecordTester {
             id: uuid(),
             store_id: store_row.id.clone(),
             clinician_id: clinician_row.id.clone(),
-            is_sync_update: true,
         };
         let join_json = json!({
             "ID": join_row.id,
@@ -96,7 +94,6 @@ impl SyncRecordTester for ClinicianRecordTester {
             d.mobile = Some("mobile".to_string());
             d.email = Some("email".to_string());
             d.gender = Some(Gender::Female);
-            d.is_sync_update = false;
             d
         });
 

--- a/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
+++ b/server/service/src/sync/test/integration/remote/patient_name_and_store_and_name_store_join.rs
@@ -24,7 +24,6 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
             r.name = "facility".to_string();
             r.is_customer = true;
             r.is_supplier = true;
-            r.is_sync_update = true;
         });
         let facility_name_json = json!({
             "ID": facility_name_row.id,
@@ -58,7 +57,6 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
             r.is_supplier = false;
             r.gender = Some(Gender::Male);
             r.supplying_store_id = Some(store_row.id.clone());
-            r.is_sync_update = true;
         });
         let patient_name_json = json!({
             "ID": patient_name_row.id,
@@ -77,7 +75,6 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
             store_id: store_row.id.clone(),
             name_is_customer: true,
             name_is_supplier: false,
-            is_sync_update: true,
         };
         let patient_name_store_join_json = json!({
             "ID": patient_name_store_join_row.id,
@@ -104,7 +101,6 @@ impl SyncRecordTester for PatientNameAndStoreAndNameStoreJoinTester {
         let patient_row = inline_edit(&patient_name_row, |mut p| {
             p.first_name = Some("Rebeus".to_string());
             p.last_name = Some("Hagrid".to_string());
-            p.is_sync_update = false;
             p
         });
 

--- a/server/service/src/sync/test/mod.rs
+++ b/server/service/src/sync/test/mod.rs
@@ -340,17 +340,15 @@ pub(crate) async fn check_records_against_database(
             InventoryAdjustmentReason => {
                 check_delete_record_by_id!(InventoryAdjustmentReasonRowRepository, con, id)
             }
-            #[cfg(feature = "integration_test")]
+            #[cfg(all(test, feature = "integration_test"))]
             Location => check_delete_record_by_id!(LocationRowRepository, con, id),
-            #[cfg(feature = "integration_test")]
-            LocationMovement => check_delete_record_by_id!(LocationMovementRowRepository, con, id),
-            #[cfg(feature = "integration_test")]
+            #[cfg(all(test, feature = "integration_test"))]
             StockLine => check_delete_record_by_id_option!(StockLineRowRepository, con, id),
-            #[cfg(feature = "integration_test")]
+            #[cfg(all(test, feature = "integration_test"))]
             Stocktake => check_delete_record_by_id!(StocktakeRowRepository, con, id),
-            #[cfg(feature = "integration_test")]
+            #[cfg(all(test, feature = "integration_test"))]
             StocktakeLine => check_delete_record_by_id!(StocktakeLineRowRepository, con, id),
-            #[cfg(feature = "integration_test")]
+            #[cfg(all(test, feature = "integration_test"))]
             ActivityLog => check_delete_record_by_id!(ActivityLogRowRepository, con, id),
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1933

Need branch in this PR: https://github.com/openmsupply/msupply/pull/13364

# 👩🏻‍💻 What does this PR do? 

Integration test fixes. Don't need to set is_sync_update anymore. Also fix compilation warning.

# 🧪 How has/should this change been tested? 

As per: https://github.com/openmsupply/open-msupply/blob/cf9131dfa99a27f7c407a0f99d4eba9ca2622110/server/service/src/sync/test/integration/README.MD#L47

Run: 
```bash
SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test integration_sync  --features integration_test && SYNC_SITE_PASSWORD="pass" SYNC_SITE_NAME="demo" SYNC_URL="http://localhost:2048" cargo test integration_sync  --features integration_test, postgres
```
## 💌 Any notes for the reviewer?

Integration tests pass for me

## 📃 Documentation
