### PR TITLE
Combine simple string filter and string filter

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -437,16 +437,16 @@ export type ClinicianConnector = {
 };
 
 export type ClinicianFilterInput = {
-  address1?: InputMaybe<SimpleStringFilterInput>;
-  address2?: InputMaybe<SimpleStringFilterInput>;
-  code?: InputMaybe<SimpleStringFilterInput>;
-  email?: InputMaybe<SimpleStringFilterInput>;
-  firstName?: InputMaybe<SimpleStringFilterInput>;
+  address1?: InputMaybe<StringFilterInput>;
+  address2?: InputMaybe<StringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
+  email?: InputMaybe<StringFilterInput>;
+  firstName?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  initials?: InputMaybe<SimpleStringFilterInput>;
-  lastName?: InputMaybe<SimpleStringFilterInput>;
-  mobile?: InputMaybe<SimpleStringFilterInput>;
-  phone?: InputMaybe<SimpleStringFilterInput>;
+  initials?: InputMaybe<StringFilterInput>;
+  lastName?: InputMaybe<StringFilterInput>;
+  mobile?: InputMaybe<StringFilterInput>;
+  phone?: InputMaybe<StringFilterInput>;
 };
 
 export type ClinicianNode = {
@@ -873,7 +873,7 @@ export type DocumentFilterInput = {
    * 	This filter makes it possible to search the raw text json data.
    * Be beware of potential performance issues.
    */
-  data?: InputMaybe<SimpleStringFilterInput>;
+  data?: InputMaybe<StringFilterInput>;
   datetime?: InputMaybe<DatetimeFilterInput>;
   name?: InputMaybe<EqualFilterStringInput>;
   owner?: InputMaybe<EqualFilterStringInput>;
@@ -1006,7 +1006,7 @@ export type EncounterFieldsResponse = EncounterFieldsConnector;
 export type EncounterFilterInput = {
   clinicianId?: InputMaybe<EqualFilterStringInput>;
   createdDatetime?: InputMaybe<DatetimeFilterInput>;
-  documentData?: InputMaybe<SimpleStringFilterInput>;
+  documentData?: InputMaybe<StringFilterInput>;
   documentName?: InputMaybe<EqualFilterStringInput>;
   endDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
@@ -1815,7 +1815,7 @@ export type InvoiceCountsSummary = {
 export type InvoiceFilterInput = {
   allocatedDatetime?: InputMaybe<DatetimeFilterInput>;
   colour?: InputMaybe<EqualFilterStringInput>;
-  comment?: InputMaybe<SimpleStringFilterInput>;
+  comment?: InputMaybe<StringFilterInput>;
   createdDatetime?: InputMaybe<DatetimeFilterInput>;
   deliveredDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
@@ -1824,7 +1824,7 @@ export type InvoiceFilterInput = {
   nameId?: InputMaybe<EqualFilterStringInput>;
   onHold?: InputMaybe<Scalars['Boolean']>;
   otherPartyId?: InputMaybe<EqualFilterStringInput>;
-  otherPartyName?: InputMaybe<SimpleStringFilterInput>;
+  otherPartyName?: InputMaybe<StringFilterInput>;
   pickedDatetime?: InputMaybe<DatetimeFilterInput>;
   requisitionId?: InputMaybe<EqualFilterStringInput>;
   shippedDatetime?: InputMaybe<DatetimeFilterInput>;
@@ -2001,11 +2001,11 @@ export type ItemCountsResponse = {
 };
 
 export type ItemFilterInput = {
-  code?: InputMaybe<SimpleStringFilterInput>;
-  codeOrName?: InputMaybe<SimpleStringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
+  codeOrName?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isVisible?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<SimpleStringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
   type?: InputMaybe<EqualFilterItemTypeInput>;
 };
 
@@ -2199,14 +2199,14 @@ export type MasterListConnector = {
 };
 
 export type MasterListFilterInput = {
-  code?: InputMaybe<SimpleStringFilterInput>;
-  description?: InputMaybe<SimpleStringFilterInput>;
-  existsForName?: InputMaybe<SimpleStringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
+  description?: InputMaybe<StringFilterInput>;
+  existsForName?: InputMaybe<StringFilterInput>;
   existsForNameId?: InputMaybe<EqualFilterStringInput>;
   existsForStoreId?: InputMaybe<EqualFilterStringInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isProgram?: InputMaybe<Scalars['Boolean']>;
-  name?: InputMaybe<SimpleStringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
 };
 
 export type MasterListLineConnector = {
@@ -2838,12 +2838,12 @@ export type NameConnector = {
 };
 
 export type NameFilterInput = {
-  address1?: InputMaybe<SimpleStringFilterInput>;
-  address2?: InputMaybe<SimpleStringFilterInput>;
+  address1?: InputMaybe<StringFilterInput>;
+  address2?: InputMaybe<StringFilterInput>;
   /** Filter by code */
-  code?: InputMaybe<SimpleStringFilterInput>;
-  country?: InputMaybe<SimpleStringFilterInput>;
-  email?: InputMaybe<SimpleStringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
+  country?: InputMaybe<StringFilterInput>;
+  email?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   /** Filter by customer property */
   isCustomer?: InputMaybe<Scalars['Boolean']>;
@@ -2861,10 +2861,10 @@ export type NameFilterInput = {
   /** Visibility in current store (based on store_id parameter and existence of name_store_join record) */
   isVisible?: InputMaybe<Scalars['Boolean']>;
   /** Filter by name */
-  name?: InputMaybe<SimpleStringFilterInput>;
-  phone?: InputMaybe<SimpleStringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
+  phone?: InputMaybe<StringFilterInput>;
   /** Code of the store if store is linked to name */
-  storeCode?: InputMaybe<SimpleStringFilterInput>;
+  storeCode?: InputMaybe<StringFilterInput>;
   /** Filter by the name type */
   type?: InputMaybe<EqualFilterTypeInput>;
 };
@@ -3025,20 +3025,20 @@ export type PatientConnector = {
 };
 
 export type PatientFilterInput = {
-  address1?: InputMaybe<SimpleStringFilterInput>;
-  address2?: InputMaybe<SimpleStringFilterInput>;
-  code?: InputMaybe<SimpleStringFilterInput>;
-  code2?: InputMaybe<SimpleStringFilterInput>;
-  country?: InputMaybe<SimpleStringFilterInput>;
+  address1?: InputMaybe<StringFilterInput>;
+  address2?: InputMaybe<StringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
+  code2?: InputMaybe<StringFilterInput>;
+  country?: InputMaybe<StringFilterInput>;
   dateOfBirth?: InputMaybe<DateFilterInput>;
-  email?: InputMaybe<SimpleStringFilterInput>;
-  firstName?: InputMaybe<SimpleStringFilterInput>;
+  email?: InputMaybe<StringFilterInput>;
+  firstName?: InputMaybe<StringFilterInput>;
   gender?: InputMaybe<EqualFilterGenderInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  identifier?: InputMaybe<SimpleStringFilterInput>;
-  lastName?: InputMaybe<SimpleStringFilterInput>;
-  name?: InputMaybe<SimpleStringFilterInput>;
-  phone?: InputMaybe<SimpleStringFilterInput>;
+  identifier?: InputMaybe<StringFilterInput>;
+  lastName?: InputMaybe<StringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
+  phone?: InputMaybe<StringFilterInput>;
 };
 
 export type PatientNode = {
@@ -3836,7 +3836,7 @@ export enum ReportContext {
 export type ReportFilterInput = {
   context?: InputMaybe<EqualFilterReportContextInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  name?: InputMaybe<SimpleStringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
   subContext?: InputMaybe<EqualFilterStringInput>;
 };
 
@@ -3894,18 +3894,18 @@ export type RequisitionCounts = {
 
 export type RequisitionFilterInput = {
   colour?: InputMaybe<EqualFilterStringInput>;
-  comment?: InputMaybe<SimpleStringFilterInput>;
+  comment?: InputMaybe<StringFilterInput>;
   createdDatetime?: InputMaybe<DatetimeFilterInput>;
   expectedDeliveryDate?: InputMaybe<DateFilterInput>;
   finalisedDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   orderType?: InputMaybe<EqualFilterStringInput>;
   otherPartyId?: InputMaybe<EqualFilterStringInput>;
-  otherPartyName?: InputMaybe<SimpleStringFilterInput>;
+  otherPartyName?: InputMaybe<StringFilterInput>;
   requisitionNumber?: InputMaybe<EqualFilterBigNumberInput>;
   sentDatetime?: InputMaybe<DatetimeFilterInput>;
   status?: InputMaybe<EqualFilterRequisitionStatusInput>;
-  theirReference?: InputMaybe<SimpleStringFilterInput>;
+  theirReference?: InputMaybe<StringFilterInput>;
   type?: InputMaybe<EqualFilterRequisitionTypeInput>;
   userId?: InputMaybe<EqualFilterStringInput>;
 };
@@ -4108,15 +4108,6 @@ export type ResponseStoreStatsNode = {
   stockOnOrder: Scalars['Int'];
 };
 
-export type SimpleStringFilterInput = {
-  /** Search term must be an exact match (case sensitive) */
-  equalTo?: InputMaybe<Scalars['String']>;
-  /** Search term must be an exact match, but case insensitive */
-  insensitiveEqualTo?: InputMaybe<Scalars['String']>;
-  /** Search term must be included in search candidate (case insensitive) */
-  like?: InputMaybe<Scalars['String']>;
-};
-
 export type SnapshotCountCurrentCountMismatch = UpdateStocktakeErrorInterface & {
   __typename: 'SnapshotCountCurrentCountMismatch';
   description: Scalars['String'];
@@ -4169,7 +4160,7 @@ export type StockLineFilterInput = {
   hasPacksInStore?: InputMaybe<Scalars['Boolean']>;
   id?: InputMaybe<EqualFilterStringInput>;
   isAvailable?: InputMaybe<Scalars['Boolean']>;
-  itemCodeOrName?: InputMaybe<SimpleStringFilterInput>;
+  itemCodeOrName?: InputMaybe<StringFilterInput>;
   itemId?: InputMaybe<EqualFilterStringInput>;
   locationId?: InputMaybe<EqualFilterStringInput>;
   storeId?: InputMaybe<EqualFilterStringInput>;
@@ -4245,9 +4236,9 @@ export type StocktakeConnector = {
 };
 
 export type StocktakeFilterInput = {
-  comment?: InputMaybe<SimpleStringFilterInput>;
+  comment?: InputMaybe<StringFilterInput>;
   createdDatetime?: InputMaybe<DatetimeFilterInput>;
-  description?: InputMaybe<SimpleStringFilterInput>;
+  description?: InputMaybe<StringFilterInput>;
   finalisedDatetime?: InputMaybe<DatetimeFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
   isLocked?: InputMaybe<Scalars['Boolean']>;
@@ -4346,10 +4337,10 @@ export type StoreConnector = {
 };
 
 export type StoreFilterInput = {
-  code?: InputMaybe<SimpleStringFilterInput>;
+  code?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<EqualFilterStringInput>;
-  name?: InputMaybe<SimpleStringFilterInput>;
-  nameCode?: InputMaybe<SimpleStringFilterInput>;
+  name?: InputMaybe<StringFilterInput>;
+  nameCode?: InputMaybe<StringFilterInput>;
   siteId?: InputMaybe<EqualFilterNumberInput>;
 };
 
@@ -4405,6 +4396,13 @@ export type StoreSortInput = {
 };
 
 export type StoresResponse = StoreConnector;
+
+export type StringFilterInput = {
+  /** Search term must be an exact match (case sensitive) */
+  equalTo?: InputMaybe<Scalars['String']>;
+  /** Search term must be included in search candidate (case insensitive) */
+  like?: InputMaybe<Scalars['String']>;
+};
 
 export type SuggestedQuantityCalculationNode = {
   __typename: 'SuggestedQuantityCalculationNode';
@@ -4842,7 +4840,6 @@ export type UpdatePrescriptionLineInput = {
   note?: InputMaybe<Scalars['String']>;
   numberOfPacks?: InputMaybe<Scalars['Float']>;
   stockLineId?: InputMaybe<Scalars['String']>;
-  totalBeforeTax?: InputMaybe<Scalars['Float']>;
 };
 
 export type UpdatePrescriptionLineResponse = InvoiceLineNode | UpdatePrescriptionLineError;

--- a/server/graphql/clinician/src/query.rs
+++ b/server/graphql/clinician/src/query.rs
@@ -1,6 +1,6 @@
 use async_graphql::{Context, Enum, InputObject, Result, SimpleObject, Union};
 use graphql_core::{
-    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{EqualFilterStringInput, StringFilterInput},
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
@@ -8,7 +8,7 @@ use graphql_core::{
 use graphql_types::types::ClinicianNode;
 use repository::{
     Clinician, ClinicianFilter, ClinicianSort, ClinicianSortField, EqualFilter, PaginationOption,
-    SimpleStringFilter,
+    StringFilter,
 };
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -42,15 +42,15 @@ pub struct ClinicianSortInput {
 pub struct ClinicianFilterInput {
     pub id: Option<EqualFilterStringInput>,
 
-    pub code: Option<SimpleStringFilterInput>,
-    pub first_name: Option<SimpleStringFilterInput>,
-    pub last_name: Option<SimpleStringFilterInput>,
-    pub initials: Option<SimpleStringFilterInput>,
-    pub address1: Option<SimpleStringFilterInput>,
-    pub address2: Option<SimpleStringFilterInput>,
-    pub phone: Option<SimpleStringFilterInput>,
-    pub mobile: Option<SimpleStringFilterInput>,
-    pub email: Option<SimpleStringFilterInput>,
+    pub code: Option<StringFilterInput>,
+    pub first_name: Option<StringFilterInput>,
+    pub last_name: Option<StringFilterInput>,
+    pub initials: Option<StringFilterInput>,
+    pub address1: Option<StringFilterInput>,
+    pub address2: Option<StringFilterInput>,
+    pub phone: Option<StringFilterInput>,
+    pub mobile: Option<StringFilterInput>,
+    pub email: Option<StringFilterInput>,
 }
 
 #[derive(SimpleObject)]
@@ -118,15 +118,15 @@ impl ClinicianFilterInput {
 
         ClinicianFilter {
             id: id.map(EqualFilter::from),
-            code: code.map(SimpleStringFilter::from),
-            first_name: first_name.map(SimpleStringFilter::from),
-            last_name: last_name.map(SimpleStringFilter::from),
-            initials: initials.map(SimpleStringFilter::from),
-            address1: address1.map(SimpleStringFilter::from),
-            address2: address2.map(SimpleStringFilter::from),
-            phone: phone.map(SimpleStringFilter::from),
-            mobile: mobile.map(SimpleStringFilter::from),
-            email: email.map(SimpleStringFilter::from),
+            code: code.map(StringFilter::from),
+            first_name: first_name.map(StringFilter::from),
+            last_name: last_name.map(StringFilter::from),
+            initials: initials.map(StringFilter::from),
+            address1: address1.map(StringFilter::from),
+            address2: address2.map(StringFilter::from),
+            phone: phone.map(StringFilter::from),
+            mobile: mobile.map(StringFilter::from),
+            email: email.map(StringFilter::from),
         }
     }
 }

--- a/server/graphql/core/src/generic_filters.rs
+++ b/server/graphql/core/src/generic_filters.rs
@@ -1,24 +1,26 @@
 use async_graphql::{InputObject, InputType};
 use chrono::{DateTime, NaiveDate, Utc};
-use repository::{DateFilter, DatetimeFilter, EqualFilter, SimpleStringFilter};
+use repository::{DateFilter, DatetimeFilter, EqualFilter, StringFilter};
 
 // simple string filter
 #[derive(InputObject, Clone)]
-pub struct SimpleStringFilterInput {
+pub struct StringFilterInput {
     /// Search term must be an exact match (case sensitive)
     equal_to: Option<String>,
-    /// Search term must be an exact match, but case insensitive
-    insensitive_equal_to: Option<String>,
     /// Search term must be included in search candidate (case insensitive)
     like: Option<String>,
 }
 
-impl From<SimpleStringFilterInput> for SimpleStringFilter {
-    fn from(f: SimpleStringFilterInput) -> Self {
-        SimpleStringFilter {
+impl From<StringFilterInput> for StringFilter {
+    fn from(f: StringFilterInput) -> Self {
+        StringFilter {
             equal_to: f.equal_to,
-            insensitive_equal_to: f.insensitive_equal_to,
             like: f.like,
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+            starts_with: None,
+            ends_with: None,
         }
     }
 }

--- a/server/graphql/general/src/queries/item.rs
+++ b/server/graphql/general/src/queries/item.rs
@@ -1,13 +1,13 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{EqualFilterStringInput, StringFilterInput},
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use graphql_types::types::{ItemConnector, ItemNodeType};
-use repository::{EqualFilter, PaginationOption, SimpleStringFilter};
+use repository::{EqualFilter, PaginationOption, StringFilter};
 use repository::{ItemFilter, ItemSort, ItemSortField};
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -42,11 +42,11 @@ pub struct EqualFilterItemTypeInput {
 #[derive(InputObject, Clone)]
 pub struct ItemFilterInput {
     pub id: Option<EqualFilterStringInput>,
-    pub name: Option<SimpleStringFilterInput>,
+    pub name: Option<StringFilterInput>,
     pub r#type: Option<EqualFilterItemTypeInput>,
-    pub code: Option<SimpleStringFilterInput>,
+    pub code: Option<StringFilterInput>,
     pub is_visible: Option<bool>,
-    pub code_or_name: Option<SimpleStringFilterInput>,
+    pub code_or_name: Option<StringFilterInput>,
 }
 
 #[derive(Union)]
@@ -97,11 +97,11 @@ impl ItemFilterInput {
 
         ItemFilter {
             id: id.map(EqualFilter::from),
-            name: name.map(SimpleStringFilter::from),
-            code: code.map(SimpleStringFilter::from),
+            name: name.map(StringFilter::from),
+            code: code.map(StringFilter::from),
             r#type: r#type.map(|t| map_filter!(t, ItemNodeType::to_domain)),
             is_visible,
-            code_or_name: code_or_name.map(SimpleStringFilter::from),
+            code_or_name: code_or_name.map(StringFilter::from),
         }
     }
 }

--- a/server/graphql/general/src/queries/master_list.rs
+++ b/server/graphql/general/src/queries/master_list.rs
@@ -1,12 +1,12 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{EqualFilterStringInput, StringFilterInput},
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use graphql_types::types::MasterListNode;
-use repository::{EqualFilter, PaginationOption, SimpleStringFilter};
+use repository::{EqualFilter, PaginationOption, StringFilter};
 use repository::{MasterList, MasterListFilter, MasterListSort};
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -43,10 +43,10 @@ impl MasterListSortInput {
 #[derive(InputObject, Clone)]
 pub struct MasterListFilterInput {
     pub id: Option<EqualFilterStringInput>,
-    pub name: Option<SimpleStringFilterInput>,
-    pub code: Option<SimpleStringFilterInput>,
-    pub description: Option<SimpleStringFilterInput>,
-    pub exists_for_name: Option<SimpleStringFilterInput>,
+    pub name: Option<StringFilterInput>,
+    pub code: Option<StringFilterInput>,
+    pub description: Option<StringFilterInput>,
+    pub exists_for_name: Option<StringFilterInput>,
     pub exists_for_name_id: Option<EqualFilterStringInput>,
     pub exists_for_store_id: Option<EqualFilterStringInput>,
     pub is_program: Option<bool>,
@@ -56,10 +56,10 @@ impl MasterListFilterInput {
     pub fn to_domain(self) -> MasterListFilter {
         MasterListFilter {
             id: self.id.map(EqualFilter::from),
-            name: self.name.map(SimpleStringFilter::from),
-            code: self.code.map(SimpleStringFilter::from),
-            description: self.description.map(SimpleStringFilter::from),
-            exists_for_name: self.exists_for_name.map(SimpleStringFilter::from),
+            name: self.name.map(StringFilter::from),
+            code: self.code.map(StringFilter::from),
+            description: self.description.map(StringFilter::from),
+            exists_for_name: self.exists_for_name.map(StringFilter::from),
             exists_for_name_id: self.exists_for_name_id.map(EqualFilter::from),
             exists_for_store_id: self.exists_for_store_id.map(EqualFilter::from),
             is_program: self.is_program,

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -1,13 +1,13 @@
 use async_graphql::{Context, Enum, InputObject, Result, SimpleObject, Union};
 use graphql_core::{
-    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{EqualFilterStringInput, StringFilterInput},
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use graphql_types::types::{NameNode, NameNodeType};
-use repository::{EqualFilter, Gender, PaginationOption, SimpleStringFilter};
+use repository::{EqualFilter, Gender, PaginationOption, StringFilter};
 use repository::{Name, NameFilter, NameSort, NameSortField};
 use serde::Serialize;
 use service::{
@@ -81,9 +81,9 @@ pub struct EqualFilterGenderInput {
 pub struct NameFilterInput {
     pub id: Option<EqualFilterStringInput>,
     /// Filter by name
-    pub name: Option<SimpleStringFilterInput>,
+    pub name: Option<StringFilterInput>,
     /// Filter by code
-    pub code: Option<SimpleStringFilterInput>,
+    pub code: Option<StringFilterInput>,
     /// Filter by customer property
     pub is_customer: Option<bool>,
     /// Filter by supplier property
@@ -92,7 +92,7 @@ pub struct NameFilterInput {
     /// Is this name a store
     pub is_store: Option<bool>,
     /// Code of the store if store is linked to name
-    pub store_code: Option<SimpleStringFilterInput>,
+    pub store_code: Option<StringFilterInput>,
     /// Visibility in current store (based on store_id parameter and existence of name_store_join record)
     pub is_visible: Option<bool>,
     /// Show system names (defaults to false)
@@ -102,11 +102,11 @@ pub struct NameFilterInput {
     /// Filter by the name type
     pub r#type: Option<EqualFilterTypeInput>,
 
-    pub phone: Option<SimpleStringFilterInput>,
-    pub address1: Option<SimpleStringFilterInput>,
-    pub address2: Option<SimpleStringFilterInput>,
-    pub country: Option<SimpleStringFilterInput>,
-    pub email: Option<SimpleStringFilterInput>,
+    pub phone: Option<StringFilterInput>,
+    pub address1: Option<StringFilterInput>,
+    pub address2: Option<StringFilterInput>,
+    pub country: Option<StringFilterInput>,
+    pub email: Option<StringFilterInput>,
 }
 
 #[derive(SimpleObject)]
@@ -185,20 +185,20 @@ impl NameFilterInput {
 
         NameFilter {
             id: id.map(EqualFilter::from),
-            name: name.map(SimpleStringFilter::from),
-            code: code.map(SimpleStringFilter::from),
-            store_code: store_code.map(SimpleStringFilter::from),
+            name: name.map(StringFilter::from),
+            code: code.map(StringFilter::from),
+            store_code: store_code.map(StringFilter::from),
             is_customer,
             is_supplier,
             is_store,
             is_visible,
             is_system_name: is_system_name.or(Some(false)),
             r#type: r#type.map(|t| map_filter!(t, NameNodeType::to_domain)),
-            phone: phone.map(SimpleStringFilter::from),
-            address1: address1.map(SimpleStringFilter::from),
-            address2: address2.map(SimpleStringFilter::from),
-            country: country.map(SimpleStringFilter::from),
-            email: email.map(SimpleStringFilter::from),
+            phone: phone.map(StringFilter::from),
+            address1: address1.map(StringFilter::from),
+            address2: address2.map(StringFilter::from),
+            country: country.map(StringFilter::from),
+            email: email.map(StringFilter::from),
             is_patient,
         }
     }

--- a/server/graphql/general/src/queries/store.rs
+++ b/server/graphql/general/src/queries/store.rs
@@ -3,20 +3,20 @@ use graphql_core::generic_filters::{EqualFilterInput, EqualFilterStringInput};
 use graphql_core::simple_generic_errors::{NodeError, NodeErrorInterface};
 use graphql_core::standard_graphql_error::validate_auth;
 use graphql_core::{
-    generic_filters::SimpleStringFilterInput, pagination::PaginationInput,
+    generic_filters::StringFilterInput, pagination::PaginationInput,
     standard_graphql_error::list_error_to_gql_err, ContextExt,
 };
 use graphql_types::types::StoreNode;
 use repository::{EqualFilter, StoreFilter, StoreSort, StoreSortField};
-use repository::{PaginationOption, SimpleStringFilter};
+use repository::{PaginationOption, StringFilter};
 use service::auth::{Resource, ResourceAccessRequest};
 
 #[derive(InputObject, Clone)]
 pub struct StoreFilterInput {
     pub id: Option<EqualFilterStringInput>,
-    pub code: Option<SimpleStringFilterInput>,
-    pub name: Option<SimpleStringFilterInput>,
-    pub name_code: Option<SimpleStringFilterInput>,
+    pub code: Option<StringFilterInput>,
+    pub name: Option<StringFilterInput>,
+    pub name_code: Option<StringFilterInput>,
     pub site_id: Option<EqualFilterInput<i32>>,
 }
 
@@ -137,9 +137,9 @@ impl StoreFilterInput {
 
         StoreFilter {
             id: id.map(EqualFilter::from),
-            code: code.map(SimpleStringFilter::from),
-            name: name.map(SimpleStringFilter::from),
-            name_code: name_code.map(SimpleStringFilter::from),
+            code: code.map(StringFilter::from),
+            name: name.map(StringFilter::from),
+            name_code: name_code.map(StringFilter::from),
             site_id: site_id.map(EqualFilter::from),
         }
     }

--- a/server/graphql/general/src/queries/tests/master_lists.rs
+++ b/server/graphql/general/src/queries/tests/master_lists.rs
@@ -6,7 +6,7 @@ mod graphql {
         mock::{mock_master_list_master_list_line_filter_test, MockDataInserts},
         MasterList, MasterListFilter, MasterListSort, StorageConnectionManager,
     };
-    use repository::{EqualFilter, PaginationOption, SimpleStringFilter};
+    use repository::{EqualFilter, PaginationOption, StringFilter};
     use serde_json::{json, Value};
 
     use service::{
@@ -204,14 +204,14 @@ mod graphql {
                 Some(
                     MasterListFilter::new()
                         .id(EqualFilter::equal_to("test_id_filter"))
-                        .name(SimpleStringFilter::equal_to("name_filter"))
-                        .code(SimpleStringFilter::equal_to("code_filter"))
-                        .description(SimpleStringFilter {
+                        .name(StringFilter::equal_to("name_filter"))
+                        .code(StringFilter::equal_to("code_filter"))
+                        .description(StringFilter {
                             equal_to: Some("description_filter_1".to_owned()),
-                            insensitive_equal_to: None,
                             like: Some("description_filter_2".to_owned()),
+                            ..Default::default()
                         })
-                        .exists_for_name(SimpleStringFilter::like("exists_for_name_filter"))
+                        .exists_for_name(StringFilter::like("exists_for_name_filter"))
                         .exists_for_name_id(EqualFilter::not_equal_to("test_name_id_filter"))
                         .exists_for_store_id(EqualFilter::equal_to("store_a"))
                         .is_program(false)

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -10,7 +10,7 @@ mod graphql {
             mock_store_linked_to_name, MockDataInserts,
         },
         EqualFilter, Name, NameFilter, NameSort, NameSortField, NameType, PaginationOption,
-        SimpleStringFilter, StorageConnectionManager,
+        StorageConnectionManager, StringFilter,
     };
     use serde_json::json;
     use service::{
@@ -188,16 +188,13 @@ mod graphql {
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
-            assert_eq!(name, Some(SimpleStringFilter::like("name like")));
-            assert_eq!(code, Some(SimpleStringFilter::equal_to("code equal to")));
+            assert_eq!(name, Some(StringFilter::like("name like")));
+            assert_eq!(code, Some(StringFilter::equal_to("code equal to")));
 
             assert_eq!(is_customer, Some(true));
             assert_eq!(is_supplier, Some(false));
             assert_eq!(is_store, Some(true));
-            assert_eq!(
-                store_code,
-                Some(SimpleStringFilter::like("store code like"))
-            );
+            assert_eq!(store_code, Some(StringFilter::like("store code like")));
             assert_eq!(is_visible, Some(false));
             assert_eq!(is_system_name, Some(true));
             assert_eq!(
@@ -205,11 +202,11 @@ mod graphql {
                 Some(EqualFilter::equal_to_name_type(&NameType::Store))
             );
 
-            assert_eq!(phone, Some(SimpleStringFilter::equal_to("01234")));
-            assert_eq!(address1, Some(SimpleStringFilter::equal_to("address1")));
-            assert_eq!(address2, Some(SimpleStringFilter::equal_to("address2")));
-            assert_eq!(country, Some(SimpleStringFilter::equal_to("country")));
-            assert_eq!(email, Some(SimpleStringFilter::equal_to("email")));
+            assert_eq!(phone, Some(StringFilter::equal_to("01234")));
+            assert_eq!(address1, Some(StringFilter::equal_to("address1")));
+            assert_eq!(address2, Some(StringFilter::equal_to("address2")));
+            assert_eq!(country, Some(StringFilter::equal_to("country")));
+            assert_eq!(email, Some(StringFilter::equal_to("email")));
 
             Ok(ListResult {
                 rows: vec![Name {

--- a/server/graphql/invoice/src/invoice_queries.rs
+++ b/server/graphql/invoice/src/invoice_queries.rs
@@ -1,8 +1,7 @@
 use async_graphql::*;
 use graphql_core::{
     generic_filters::{
-        DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput,
-        SimpleStringFilterInput,
+        DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput, StringFilterInput,
     },
     map_filter,
     pagination::PaginationInput,
@@ -13,7 +12,7 @@ use graphql_core::{
 use graphql_types::types::{InvoiceConnector, InvoiceNode, InvoiceNodeStatus, InvoiceNodeType};
 use repository::{
     DatetimeFilter, EqualFilter, InvoiceFilter, InvoiceSort, InvoiceSortField, PaginationOption,
-    SimpleStringFilter,
+    StringFilter,
 };
 use service::auth::{Resource, ResourceAccessRequest};
 
@@ -74,14 +73,14 @@ pub struct InvoiceFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub name_id: Option<EqualFilterStringInput>,
     pub invoice_number: Option<EqualFilterBigNumberInput>,
-    pub other_party_name: Option<SimpleStringFilterInput>,
+    pub other_party_name: Option<StringFilterInput>,
     pub other_party_id: Option<EqualFilterStringInput>,
     pub store_id: Option<EqualFilterStringInput>,
     pub user_id: Option<EqualFilterStringInput>,
     pub r#type: Option<EqualFilterInvoiceTypeInput>,
     pub status: Option<EqualFilterInvoiceStatusInput>,
     pub on_hold: Option<bool>,
-    pub comment: Option<SimpleStringFilterInput>,
+    pub comment: Option<StringFilterInput>,
     pub their_reference: Option<EqualFilterStringInput>,
     pub transport_reference: Option<EqualFilterStringInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
@@ -202,7 +201,7 @@ impl InvoiceFilterInput {
             id: self.id.map(EqualFilter::from),
             invoice_number: self.invoice_number.map(EqualFilter::from),
             name_id: self.other_party_id.map(EqualFilter::from),
-            name: self.other_party_name.map(SimpleStringFilter::from),
+            name: self.other_party_name.map(StringFilter::from),
             store_id: self.store_id.map(EqualFilter::from),
             user_id: self.user_id.map(EqualFilter::from),
             r#type: self
@@ -212,7 +211,7 @@ impl InvoiceFilterInput {
                 .status
                 .map(|t| map_filter!(t, InvoiceNodeStatus::to_domain)),
             on_hold: self.on_hold,
-            comment: self.comment.map(SimpleStringFilter::from),
+            comment: self.comment.map(StringFilter::from),
             their_reference: self.their_reference.map(EqualFilter::from),
             transport_reference: self.transport_reference.map(EqualFilter::from),
             created_datetime: self.created_datetime.map(DatetimeFilter::from),

--- a/server/graphql/programs/src/queries/document.rs
+++ b/server/graphql/programs/src/queries/document.rs
@@ -1,13 +1,13 @@
 use async_graphql::*;
 use graphql_core::generic_filters::{
-    DatetimeFilterInput, EqualFilterStringInput, SimpleStringFilterInput,
+    DatetimeFilterInput, EqualFilterStringInput, StringFilterInput,
 };
 use graphql_core::pagination::PaginationInput;
 use graphql_core::standard_graphql_error::StandardGraphqlError;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use repository::{
     DatetimeFilter, DocumentFilter, DocumentSort, DocumentSortField, EqualFilter, PaginationOption,
-    SimpleStringFilter,
+    StringFilter,
 };
 use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
@@ -27,7 +27,7 @@ pub struct DocumentFilterInput {
     pub context: Option<EqualFilterStringInput>,
     /// This filter makes it possible to search the raw text json data.
     /// Be beware of potential performance issues.
-    pub data: Option<SimpleStringFilterInput>,
+    pub data: Option<StringFilterInput>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -65,7 +65,7 @@ impl DocumentFilterInput {
             datetime: self.datetime.map(DatetimeFilter::from),
             owner: self.owner.map(EqualFilter::from),
             context: self.context.map(EqualFilter::from),
-            data: self.data.map(SimpleStringFilter::from),
+            data: self.data.map(StringFilter::from),
         }
     }
 }

--- a/server/graphql/programs/src/queries/encounter.rs
+++ b/server/graphql/programs/src/queries/encounter.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{DatetimeFilterInput, EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{DatetimeFilterInput, EqualFilterStringInput, StringFilterInput},
     map_filter,
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
@@ -8,7 +8,7 @@ use graphql_core::{
 };
 use repository::{
     DatetimeFilter, EncounterFilter, EncounterSort, EncounterSortField, EqualFilter,
-    PaginationOption, SimpleStringFilter,
+    PaginationOption, StringFilter,
 };
 use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
@@ -66,7 +66,7 @@ pub struct EncounterFilterInput {
     pub status: Option<EqualFilterEncounterStatusInput>,
     pub clinician_id: Option<EqualFilterStringInput>,
     pub document_name: Option<EqualFilterStringInput>,
-    pub document_data: Option<SimpleStringFilterInput>,
+    pub document_data: Option<StringFilterInput>,
 }
 
 impl EncounterFilterInput {
@@ -84,7 +84,7 @@ impl EncounterFilterInput {
             clinician_id: self.clinician_id.map(EqualFilter::from),
             document_type: self.r#type.map(EqualFilter::from),
             document_name: self.document_name.map(EqualFilter::from),
-            document_data: self.document_data.map(SimpleStringFilter::from),
+            document_data: self.document_data.map(StringFilter::from),
         }
     }
 }

--- a/server/graphql/programs/src/queries/patient.rs
+++ b/server/graphql/programs/src/queries/patient.rs
@@ -1,14 +1,12 @@
 use async_graphql::*;
-use graphql_core::generic_filters::{
-    DateFilterInput, EqualFilterStringInput, SimpleStringFilterInput,
-};
+use graphql_core::generic_filters::{DateFilterInput, EqualFilterStringInput, StringFilterInput};
 use graphql_core::map_filter;
 use graphql_core::pagination::PaginationInput;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
 use graphql_general::{EqualFilterGenderInput, GenderInput};
 use repository::{
     DateFilter, EqualFilter, PaginationOption, PatientFilter, PatientSort, PatientSortField,
-    SimpleStringFilter,
+    StringFilter,
 };
 use service::auth::{CapabilityTag, Resource, ResourceAccessRequest};
 
@@ -28,19 +26,19 @@ pub enum PatientResponse {
 #[derive(InputObject, Clone)]
 pub struct PatientFilterInput {
     pub id: Option<EqualFilterStringInput>,
-    pub name: Option<SimpleStringFilterInput>,
-    pub code: Option<SimpleStringFilterInput>,
-    pub code_2: Option<SimpleStringFilterInput>,
-    pub first_name: Option<SimpleStringFilterInput>,
-    pub last_name: Option<SimpleStringFilterInput>,
+    pub name: Option<StringFilterInput>,
+    pub code: Option<StringFilterInput>,
+    pub code_2: Option<StringFilterInput>,
+    pub first_name: Option<StringFilterInput>,
+    pub last_name: Option<StringFilterInput>,
     pub gender: Option<EqualFilterGenderInput>,
     pub date_of_birth: Option<DateFilterInput>,
-    pub phone: Option<SimpleStringFilterInput>,
-    pub address1: Option<SimpleStringFilterInput>,
-    pub address2: Option<SimpleStringFilterInput>,
-    pub country: Option<SimpleStringFilterInput>,
-    pub email: Option<SimpleStringFilterInput>,
-    pub identifier: Option<SimpleStringFilterInput>,
+    pub phone: Option<StringFilterInput>,
+    pub address1: Option<StringFilterInput>,
+    pub address2: Option<StringFilterInput>,
+    pub country: Option<StringFilterInput>,
+    pub email: Option<StringFilterInput>,
+    pub identifier: Option<StringFilterInput>,
 }
 
 impl PatientFilterInput {
@@ -63,19 +61,19 @@ impl PatientFilterInput {
         } = self;
         PatientFilter {
             id: id.map(EqualFilter::from),
-            name: name.map(SimpleStringFilter::from),
-            code: code.map(SimpleStringFilter::from),
-            code_2: code_2.map(SimpleStringFilter::from),
-            first_name: first_name.map(SimpleStringFilter::from),
-            last_name: last_name.map(SimpleStringFilter::from),
+            name: name.map(StringFilter::from),
+            code: code.map(StringFilter::from),
+            code_2: code_2.map(StringFilter::from),
+            first_name: first_name.map(StringFilter::from),
+            last_name: last_name.map(StringFilter::from),
             gender: gender.map(|t| map_filter!(t, GenderInput::to_domain)),
             date_of_birth: date_of_birth.map(DateFilter::from),
-            phone: phone.map(SimpleStringFilter::from),
-            address1: address1.map(SimpleStringFilter::from),
-            address2: address2.map(SimpleStringFilter::from),
-            country: country.map(SimpleStringFilter::from),
-            email: email.map(SimpleStringFilter::from),
-            identifier: identifier.map(SimpleStringFilter::from),
+            phone: phone.map(StringFilter::from),
+            address1: address1.map(StringFilter::from),
+            address2: address2.map(StringFilter::from),
+            country: country.map(StringFilter::from),
+            email: email.map(StringFilter::from),
+            identifier: identifier.map(StringFilter::from),
         }
     }
 }

--- a/server/graphql/reports/src/reports.rs
+++ b/server/graphql/reports/src/reports.rs
@@ -2,7 +2,7 @@ use ::serde::Serialize;
 use async_graphql::*;
 use graphql_core::standard_graphql_error::StandardGraphqlError;
 use graphql_core::{
-    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{EqualFilterStringInput, StringFilterInput},
     pagination::PaginationInput,
     standard_graphql_error::validate_auth,
 };
@@ -10,7 +10,7 @@ use graphql_core::{map_filter, ContextExt};
 use graphql_types::types::FormSchemaNode;
 use repository::{
     EqualFilter, PaginationOption, Report, ReportContext as ReportContextDomain, ReportFilter,
-    ReportSort, ReportSortField, SimpleStringFilter,
+    ReportSort, ReportSortField, StringFilter,
 };
 use service::auth::{Resource, ResourceAccessRequest};
 
@@ -53,7 +53,7 @@ pub struct EqualFilterReportContextInput {
 #[derive(InputObject, Clone)]
 pub struct ReportFilterInput {
     pub id: Option<EqualFilterStringInput>,
-    pub name: Option<SimpleStringFilterInput>,
+    pub name: Option<StringFilterInput>,
     pub context: Option<EqualFilterReportContextInput>,
     pub sub_context: Option<EqualFilterStringInput>,
 }
@@ -139,7 +139,7 @@ impl ReportFilterInput {
     pub fn to_domain(self) -> ReportFilter {
         ReportFilter {
             id: self.id.map(EqualFilter::from),
-            name: self.name.map(SimpleStringFilter::from),
+            name: self.name.map(StringFilter::from),
             r#type: None,
             context: self
                 .context

--- a/server/graphql/requisition/src/query_tests/requisition.rs
+++ b/server/graphql/requisition/src/query_tests/requisition.rs
@@ -10,7 +10,7 @@ mod graphql {
         DateFilter, Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
         StorageConnectionManager,
     };
-    use repository::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
+    use repository::{DatetimeFilter, EqualFilter, PaginationOption, StringFilter};
     use serde_json::json;
 
     use service::{
@@ -232,10 +232,7 @@ mod graphql {
                     NaiveDate::from_ymd_opt(2021, 01, 04).unwrap()
                 ))
             );
-            assert_eq!(
-                name,
-                Some(SimpleStringFilter::like("like_other_party_name"))
-            );
+            assert_eq!(name, Some(StringFilter::like("like_other_party_name")));
             assert_eq!(
                 name_id,
                 Some(EqualFilter::equal_any(vec![
@@ -246,12 +243,9 @@ mod graphql {
             assert_eq!(colour, Some(EqualFilter::equal_to("equal_to_color")));
             assert_eq!(
                 their_reference,
-                Some(SimpleStringFilter::like("like_their_reference"))
+                Some(StringFilter::like("like_their_reference"))
             );
-            assert_eq!(
-                comment,
-                Some(SimpleStringFilter::equal_to("equal_to_comment"))
-            );
+            assert_eq!(comment, Some(StringFilter::equal_to("equal_to_comment")));
 
             Ok(ListResult {
                 rows: vec![inline_init(|r: &mut Requisition| {

--- a/server/graphql/requisition/src/query_tests/requisitions.rs
+++ b/server/graphql/requisition/src/query_tests/requisitions.rs
@@ -10,7 +10,7 @@ mod graphql {
         DateFilter, Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
         StorageConnectionManager,
     };
-    use repository::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
+    use repository::{DatetimeFilter, EqualFilter, PaginationOption, StringFilter};
     use serde_json::json;
     use service::{
         requisition::RequisitionServiceTrait,
@@ -231,10 +231,7 @@ mod graphql {
                     NaiveDate::from_ymd_opt(2021, 01, 04).unwrap()
                 ))
             );
-            assert_eq!(
-                name,
-                Some(SimpleStringFilter::like("like_other_party_name"))
-            );
+            assert_eq!(name, Some(StringFilter::like("like_other_party_name")));
             assert_eq!(
                 name_id,
                 Some(EqualFilter::equal_any(vec![
@@ -245,12 +242,9 @@ mod graphql {
             assert_eq!(colour, Some(EqualFilter::equal_to("equal_to_color")));
             assert_eq!(
                 their_reference,
-                Some(SimpleStringFilter::like("like_their_reference"))
+                Some(StringFilter::like("like_their_reference"))
             );
-            assert_eq!(
-                comment,
-                Some(SimpleStringFilter::equal_to("equal_to_comment"))
-            );
+            assert_eq!(comment, Some(StringFilter::equal_to("equal_to_comment")));
 
             Ok(ListResult {
                 rows: vec![inline_init(|r: &mut Requisition| {

--- a/server/graphql/requisition/src/requisition_queries.rs
+++ b/server/graphql/requisition/src/requisition_queries.rs
@@ -2,7 +2,7 @@ use async_graphql::*;
 use graphql_core::{
     generic_filters::{
         DateFilterInput, DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput,
-        SimpleStringFilterInput,
+        StringFilterInput,
     },
     map_filter,
     pagination::PaginationInput,
@@ -13,7 +13,7 @@ use graphql_core::{
 use graphql_types::types::{
     RequisitionConnector, RequisitionNode, RequisitionNodeStatus, RequisitionNodeType,
 };
-use repository::{DateFilter, DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
+use repository::{DateFilter, DatetimeFilter, EqualFilter, PaginationOption, StringFilter};
 use repository::{RequisitionFilter, RequisitionSort, RequisitionSortField};
 use service::auth::{Resource, ResourceAccessRequest};
 
@@ -69,11 +69,11 @@ pub struct RequisitionFilterInput {
     pub sent_datetime: Option<DatetimeFilterInput>,
     pub finalised_datetime: Option<DatetimeFilterInput>,
     pub expected_delivery_date: Option<DateFilterInput>,
-    pub other_party_name: Option<SimpleStringFilterInput>,
+    pub other_party_name: Option<StringFilterInput>,
     pub other_party_id: Option<EqualFilterStringInput>,
     pub colour: Option<EqualFilterStringInput>,
-    pub their_reference: Option<SimpleStringFilterInput>,
-    pub comment: Option<SimpleStringFilterInput>,
+    pub their_reference: Option<StringFilterInput>,
+    pub comment: Option<StringFilterInput>,
     pub order_type: Option<EqualFilterStringInput>,
 }
 
@@ -231,11 +231,11 @@ impl RequisitionFilterInput {
             sent_datetime: self.sent_datetime.map(DatetimeFilter::from),
             finalised_datetime: self.finalised_datetime.map(DatetimeFilter::from),
             expected_delivery_date: self.expected_delivery_date.map(DateFilter::from),
-            name: self.other_party_name.map(SimpleStringFilter::from),
+            name: self.other_party_name.map(StringFilter::from),
             name_id: self.other_party_id.map(EqualFilter::from),
             colour: self.colour.map(EqualFilter::from),
-            their_reference: self.their_reference.map(SimpleStringFilter::from),
-            comment: self.comment.map(SimpleStringFilter::from),
+            their_reference: self.their_reference.map(StringFilter::from),
+            comment: self.comment.map(StringFilter::from),
             linked_requisition_id: None,
             store_id: None,
             order_type: self.order_type.map(EqualFilter::from),

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod mutations;
 use async_graphql::*;
 use graphql_core::{
-    generic_filters::{DateFilterInput, EqualFilterStringInput, SimpleStringFilterInput},
+    generic_filters::{DateFilterInput, EqualFilterStringInput, StringFilterInput},
     pagination::PaginationInput,
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
@@ -40,7 +40,7 @@ pub struct StockLineFilterInput {
     pub expiry_date: Option<DateFilterInput>,
     pub id: Option<EqualFilterStringInput>,
     pub is_available: Option<bool>,
-    pub item_code_or_name: Option<SimpleStringFilterInput>,
+    pub item_code_or_name: Option<StringFilterInput>,
     pub item_id: Option<EqualFilterStringInput>,
     pub location_id: Option<EqualFilterStringInput>,
     pub store_id: Option<EqualFilterStringInput>,
@@ -53,7 +53,7 @@ impl From<StockLineFilterInput> for StockLineFilter {
             expiry_date: f.expiry_date.map(DateFilter::from),
             id: f.id.map(EqualFilter::from),
             is_available: f.is_available,
-            item_code_or_name: f.item_code_or_name.map(SimpleStringFilterInput::into),
+            item_code_or_name: f.item_code_or_name.map(StringFilterInput::into),
             item_id: f.item_id.map(EqualFilter::from),
             location_id: f.location_id.map(EqualFilter::from),
             store_id: None,

--- a/server/graphql/stocktake/src/stocktake_queries.rs
+++ b/server/graphql/stocktake/src/stocktake_queries.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use graphql_core::generic_filters::{
     DateFilterInput, DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput,
-    SimpleStringFilterInput,
+    StringFilterInput,
 };
 use graphql_core::pagination::PaginationInput;
 use graphql_core::simple_generic_errors::{
@@ -52,8 +52,8 @@ pub struct StocktakeFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub user_id: Option<EqualFilterStringInput>,
     pub stocktake_number: Option<EqualFilterBigNumberInput>,
-    pub comment: Option<SimpleStringFilterInput>,
-    pub description: Option<SimpleStringFilterInput>,
+    pub comment: Option<StringFilterInput>,
+    pub description: Option<StringFilterInput>,
     pub status: Option<EqualFilterStocktakeStatusInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
     pub stocktake_date: Option<DateFilterInput>,
@@ -226,8 +226,8 @@ impl From<StocktakeFilterInput> for StocktakeFilter {
             store_id: None,
             user_id: f.user_id.map(EqualFilter::from),
             stocktake_number: f.stocktake_number.map(EqualFilter::from),
-            comment: f.comment.map(SimpleStringFilter::from),
-            description: f.description.map(SimpleStringFilter::from),
+            comment: f.comment.map(StringFilter::from),
+            description: f.description.map(StringFilter::from),
             status: f
                 .status
                 .map(|t| map_filter!(t, StocktakeNodeStatus::to_domain)),

--- a/server/repository/src/db_diesel/clinician.rs
+++ b/server/repository/src/db_diesel/clinician.rs
@@ -5,9 +5,9 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
+    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
-    ClinicianRow, EqualFilter, Pagination, SimpleStringFilter, Sort,
+    ClinicianRow, EqualFilter, Pagination, Sort, StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -15,15 +15,15 @@ use diesel::{dsl::IntoBoxed, prelude::*};
 #[derive(Clone, Default)]
 pub struct ClinicianFilter {
     pub id: Option<EqualFilter<String>>,
-    pub code: Option<SimpleStringFilter>,
-    pub first_name: Option<SimpleStringFilter>,
-    pub last_name: Option<SimpleStringFilter>,
-    pub initials: Option<SimpleStringFilter>,
-    pub address1: Option<SimpleStringFilter>,
-    pub address2: Option<SimpleStringFilter>,
-    pub phone: Option<SimpleStringFilter>,
-    pub mobile: Option<SimpleStringFilter>,
-    pub email: Option<SimpleStringFilter>,
+    pub code: Option<StringFilter>,
+    pub first_name: Option<StringFilter>,
+    pub last_name: Option<StringFilter>,
+    pub initials: Option<StringFilter>,
+    pub address1: Option<StringFilter>,
+    pub address2: Option<StringFilter>,
+    pub phone: Option<StringFilter>,
+    pub mobile: Option<StringFilter>,
+    pub email: Option<StringFilter>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -151,15 +151,15 @@ fn create_filtered_query(store_id: String, filter: Option<ClinicianFilter>) -> B
         } = f;
 
         apply_equal_filter!(query, id, clinician_dsl::id);
-        apply_simple_string_filter!(query, code, clinician_dsl::code);
-        apply_simple_string_filter!(query, first_name, clinician_dsl::first_name);
-        apply_simple_string_filter!(query, last_name, clinician_dsl::last_name);
-        apply_simple_string_filter!(query, initials, clinician_dsl::initials);
-        apply_simple_string_filter!(query, address1, clinician_dsl::address1);
-        apply_simple_string_filter!(query, address2, clinician_dsl::address2);
-        apply_simple_string_filter!(query, phone, clinician_dsl::phone);
-        apply_simple_string_filter!(query, mobile, clinician_dsl::mobile);
-        apply_simple_string_filter!(query, email, clinician_dsl::email);
+        apply_string_filter!(query, code, clinician_dsl::code);
+        apply_string_filter!(query, first_name, clinician_dsl::first_name);
+        apply_string_filter!(query, last_name, clinician_dsl::last_name);
+        apply_string_filter!(query, initials, clinician_dsl::initials);
+        apply_string_filter!(query, address1, clinician_dsl::address1);
+        apply_string_filter!(query, address2, clinician_dsl::address2);
+        apply_string_filter!(query, phone, clinician_dsl::phone);
+        apply_string_filter!(query, mobile, clinician_dsl::mobile);
+        apply_string_filter!(query, email, clinician_dsl::email);
     };
 
     // Restrict results to clinicians belonging to the store as specified in the
@@ -183,47 +183,47 @@ impl ClinicianFilter {
         self
     }
 
-    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
         self
     }
 
-    pub fn first_name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn first_name(mut self, filter: StringFilter) -> Self {
         self.first_name = Some(filter);
         self
     }
 
-    pub fn last_name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn last_name(mut self, filter: StringFilter) -> Self {
         self.last_name = Some(filter);
         self
     }
 
-    pub fn initials(mut self, value: SimpleStringFilter) -> Self {
+    pub fn initials(mut self, value: StringFilter) -> Self {
         self.initials = Some(value);
         self
     }
 
-    pub fn address1(mut self, value: SimpleStringFilter) -> Self {
+    pub fn address1(mut self, value: StringFilter) -> Self {
         self.address1 = Some(value);
         self
     }
 
-    pub fn address2(mut self, value: SimpleStringFilter) -> Self {
+    pub fn address2(mut self, value: StringFilter) -> Self {
         self.address2 = Some(value);
         self
     }
 
-    pub fn phone(mut self, value: SimpleStringFilter) -> Self {
+    pub fn phone(mut self, value: StringFilter) -> Self {
         self.phone = Some(value);
         self
     }
 
-    pub fn mobile(mut self, value: SimpleStringFilter) -> Self {
+    pub fn mobile(mut self, value: StringFilter) -> Self {
         self.mobile = Some(value);
         self
     }
 
-    pub fn email(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn email(mut self, filter: StringFilter) -> Self {
         self.email = Some(filter);
         self
     }
@@ -234,7 +234,7 @@ mod tests {
     use crate::{
         mock::{mock_store_a, MockDataInserts},
         test_db, ClinicianFilter, ClinicianRepository, ClinicianRow, ClinicianRowRepository,
-        ClinicianStoreJoinRow, ClinicianStoreJoinRowRepository, SimpleStringFilter,
+        ClinicianStoreJoinRow, ClinicianStoreJoinRowRepository, StringFilter,
     };
     use util::inline_init;
 
@@ -265,7 +265,7 @@ mod tests {
         let result = repository
             .query_by_filter(
                 &mock_store_a().id,
-                ClinicianFilter::new().first_name(SimpleStringFilter::equal_to("First")),
+                ClinicianFilter::new().first_name(StringFilter::equal_to("First")),
             )
             .unwrap();
         assert!(result.is_empty());
@@ -283,7 +283,7 @@ mod tests {
         let result = repository
             .query_by_filter(
                 &mock_store_a().id,
-                ClinicianFilter::new().first_name(SimpleStringFilter::equal_to("First")),
+                ClinicianFilter::new().first_name(StringFilter::equal_to("First")),
             )
             .unwrap();
         assert_eq!(result[0].id, "clinician_store_a");

--- a/server/repository/src/db_diesel/document.rs
+++ b/server/repository/src/db_diesel/document.rs
@@ -3,13 +3,9 @@ use super::StorageConnection;
 use crate::db_diesel::form_schema_row::form_schema;
 use crate::db_diesel::name_row::name;
 use crate::diesel_macros::{
-    apply_date_time_filter, apply_equal_filter, apply_simple_string_filter, apply_sort,
-    apply_string_filter,
+    apply_date_time_filter, apply_equal_filter, apply_sort, apply_string_filter,
 };
-use crate::{
-    DBType, DatetimeFilter, EqualFilter, Pagination, RepositoryError, SimpleStringFilter, Sort,
-    StringFilter,
-};
+use crate::{DBType, DatetimeFilter, EqualFilter, Pagination, RepositoryError, Sort, StringFilter};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::helper_types::IntoBoxed;
@@ -123,7 +119,7 @@ pub struct DocumentFilter {
     pub datetime: Option<DatetimeFilter>,
     pub owner: Option<EqualFilter<String>>,
     pub context: Option<EqualFilter<String>>,
-    pub data: Option<SimpleStringFilter>,
+    pub data: Option<StringFilter>,
 }
 
 impl DocumentFilter {
@@ -163,7 +159,7 @@ impl DocumentFilter {
         self
     }
 
-    pub fn data(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn data(mut self, filter: StringFilter) -> Self {
         self.data = Some(filter);
         self
     }
@@ -199,7 +195,7 @@ fn create_latest_filtered_query<'a>(filter: Option<DocumentFilter>) -> BoxedDocu
         apply_date_time_filter!(query, datetime, latest_document::dsl::datetime);
         apply_equal_filter!(query, owner, latest_document::dsl::owner_name_id);
         apply_equal_filter!(query, context, latest_document::dsl::context);
-        apply_simple_string_filter!(query, data, latest_document::dsl::data);
+        apply_string_filter!(query, data, latest_document::dsl::data);
     }
     query
 }
@@ -307,7 +303,7 @@ impl<'a> DocumentRepository<'a> {
             apply_date_time_filter!(query, datetime, document::dsl::datetime);
             apply_equal_filter!(query, owner, document::dsl::owner_name_id);
             apply_equal_filter!(query, context, document::dsl::context);
-            apply_simple_string_filter!(query, data, document::dsl::data);
+            apply_string_filter!(query, data, document::dsl::data);
         }
         let rows: Vec<DocumentRow> = query
             .order(document::dsl::datetime.desc())

--- a/server/repository/src/db_diesel/encounter.rs
+++ b/server/repository/src/db_diesel/encounter.rs
@@ -1,15 +1,13 @@
 use super::{
-    document::{latest_document, latest_document::dsl as latest_document_dsl},
+    document::latest_document::dsl as latest_document_dsl,
     encounter_row::encounter::{self, dsl as encounter_dsl},
     StorageConnection,
 };
 
 use crate::{
-    diesel_macros::{
-        apply_date_time_filter, apply_equal_filter, apply_simple_string_filter, apply_sort,
-    },
-    DBType, DatetimeFilter, EncounterRow, EncounterStatus, EqualFilter, Pagination,
-    RepositoryError, SimpleStringFilter, Sort,
+    diesel_macros::{apply_date_time_filter, apply_equal_filter, apply_sort, apply_string_filter},
+    latest_document, DBType, DatetimeFilter, EncounterRow, EncounterStatus, EqualFilter,
+    Pagination, RepositoryError, Sort, StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -27,7 +25,7 @@ pub struct EncounterFilter {
     pub status: Option<EqualFilter<EncounterStatus>>,
     pub clinician_id: Option<EqualFilter<String>>,
     /// Filter by encounter data
-    pub document_data: Option<SimpleStringFilter>,
+    pub document_data: Option<StringFilter>,
 }
 
 impl EncounterFilter {
@@ -85,7 +83,7 @@ impl EncounterFilter {
         self
     }
 
-    pub fn document_data(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn document_data(mut self, filter: StringFilter) -> Self {
         self.document_data = Some(filter);
         self
     }
@@ -140,7 +138,7 @@ fn create_filtered_query<'a>(filter: Option<EncounterFilter>) -> BoxedProgramQue
             let mut sub_query = latest_document_dsl::latest_document
                 .select(latest_document_dsl::name)
                 .into_boxed();
-            apply_simple_string_filter!(sub_query, document_data, latest_document::data);
+            apply_string_filter!(sub_query, document_data, latest_document::data);
             query = query.filter(encounter_dsl::document_name.eq_any(sub_query));
         }
     }

--- a/server/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/server/repository/src/db_diesel/filter_sort_pagination.rs
@@ -1,40 +1,7 @@
 use chrono::{NaiveDate, NaiveDateTime};
 use util::inline_init;
 
-#[derive(Clone, PartialEq, Debug)]
-pub struct SimpleStringFilter {
-    pub equal_to: Option<String>,
-    pub insensitive_equal_to: Option<String>,
-    pub like: Option<String>,
-}
-
-impl SimpleStringFilter {
-    pub fn equal_to(value: &str) -> Self {
-        SimpleStringFilter {
-            equal_to: Some(value.to_owned()),
-            insensitive_equal_to: None,
-            like: None,
-        }
-    }
-
-    pub fn like(value: &str) -> Self {
-        SimpleStringFilter {
-            equal_to: None,
-            insensitive_equal_to: None,
-            like: Some(value.to_owned()),
-        }
-    }
-
-    pub fn insensitive_equal_to(value: &str) -> Self {
-        SimpleStringFilter {
-            equal_to: None,
-            insensitive_equal_to: Some(value.to_owned()),
-            like: None,
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct StringFilter {
     pub equal_to: Option<String>,
     pub not_equal_to: Option<String>,

--- a/server/repository/src/db_diesel/invoice.rs
+++ b/server/repository/src/db_diesel/invoice.rs
@@ -8,11 +8,10 @@ use super::{
 };
 
 use crate::diesel_macros::{
-    apply_date_time_filter, apply_equal_filter, apply_simple_string_filter, apply_sort,
-    apply_sort_no_case,
+    apply_date_time_filter, apply_equal_filter, apply_sort, apply_sort_no_case, apply_string_filter,
 };
 
-use crate::{DatetimeFilter, EqualFilter, Pagination, SimpleStringFilter, Sort};
+use crate::{DatetimeFilter, EqualFilter, Pagination, Sort, StringFilter};
 
 use diesel::{
     dsl::{InnerJoin, IntoBoxed},
@@ -31,13 +30,13 @@ pub struct InvoiceFilter {
     pub id: Option<EqualFilter<String>>,
     pub invoice_number: Option<EqualFilter<i64>>,
     pub name_id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
     pub store_id: Option<EqualFilter<String>>,
     pub user_id: Option<EqualFilter<String>>,
     pub r#type: Option<EqualFilter<InvoiceRowType>>,
     pub status: Option<EqualFilter<InvoiceRowStatus>>,
     pub on_hold: Option<bool>,
-    pub comment: Option<SimpleStringFilter>,
+    pub comment: Option<StringFilter>,
     pub their_reference: Option<EqualFilter<String>>,
     pub transport_reference: Option<EqualFilter<String>>,
     pub created_datetime: Option<DatetimeFilter>,
@@ -214,11 +213,11 @@ fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery
         apply_equal_filter!(query, id, invoice_dsl::id);
         apply_equal_filter!(query, invoice_number, invoice_dsl::invoice_number);
         apply_equal_filter!(query, name_id, invoice_dsl::name_id);
-        apply_simple_string_filter!(query, name, name_dsl::name_);
+        apply_string_filter!(query, name, name_dsl::name_);
         apply_equal_filter!(query, store_id, invoice_dsl::store_id);
         apply_equal_filter!(query, their_reference, invoice_dsl::their_reference);
         apply_equal_filter!(query, requisition_id, invoice_dsl::requisition_id);
-        apply_simple_string_filter!(query, comment, invoice_dsl::comment);
+        apply_string_filter!(query, comment, invoice_dsl::comment);
         apply_equal_filter!(query, linked_invoice_id, invoice_dsl::linked_invoice_id);
         apply_equal_filter!(query, user_id, invoice_dsl::user_id);
         apply_equal_filter!(query, transport_reference, invoice_dsl::transport_reference);
@@ -372,7 +371,7 @@ impl InvoiceFilter {
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -8,11 +8,11 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
+    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
 };
 
-use crate::{EqualFilter, Pagination, SimpleStringFilter, Sort};
+use crate::{EqualFilter, Pagination, Sort, StringFilter};
 
 use diesel::prelude::*;
 
@@ -25,10 +25,10 @@ pub struct MasterListRepository<'a> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct MasterListFilter {
     pub id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
-    pub code: Option<SimpleStringFilter>,
-    pub description: Option<SimpleStringFilter>,
-    pub exists_for_name: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
+    pub code: Option<StringFilter>,
+    pub description: Option<StringFilter>,
+    pub exists_for_name: Option<StringFilter>,
     pub exists_for_name_id: Option<EqualFilter<String>>,
     pub exists_for_store_id: Option<EqualFilter<String>>,
     pub is_program: Option<bool>,
@@ -66,9 +66,9 @@ impl<'a> MasterListRepository<'a> {
 
         if let Some(f) = filter {
             apply_equal_filter!(query, f.id, master_list_dsl::id);
-            apply_simple_string_filter!(query, f.name, master_list_dsl::name);
-            apply_simple_string_filter!(query, f.code, master_list_dsl::code);
-            apply_simple_string_filter!(query, f.description, master_list_dsl::description);
+            apply_string_filter!(query, f.name, master_list_dsl::name);
+            apply_string_filter!(query, f.code, master_list_dsl::code);
+            apply_string_filter!(query, f.description, master_list_dsl::description);
 
             // Result master list should be unique, which would need extra logic if we were to join
             // name table through master_list_name_join, thus use a sub query to restrict the resulting
@@ -83,7 +83,7 @@ impl<'a> MasterListRepository<'a> {
                     .left_join(name_dsl::name.left_join(store_dsl::store))
                     .into_boxed();
 
-                apply_simple_string_filter!(name_join_query, f.exists_for_name, name_dsl::name_);
+                apply_string_filter!(name_join_query, f.exists_for_name, name_dsl::name_);
                 apply_equal_filter!(name_join_query, f.exists_for_name_id, name_dsl::id);
                 apply_equal_filter!(name_join_query, f.exists_for_store_id, store_dsl::id);
 
@@ -162,22 +162,22 @@ impl MasterListFilter {
         self
     }
 
-    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
 
-    pub fn description(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn description(mut self, filter: StringFilter) -> Self {
         self.description = Some(filter);
         self
     }
 
-    pub fn exists_for_name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn exists_for_name(mut self, filter: StringFilter) -> Self {
         self.exists_for_name = Some(filter);
         self
     }

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -6,9 +6,9 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
+    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
-    EqualFilter, NameType, Pagination, SimpleStringFilter, Sort,
+    EqualFilter, NameType, Pagination, Sort, StringFilter,
 };
 
 use diesel::{
@@ -28,22 +28,22 @@ pub struct Name {
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct NameFilter {
     pub id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
-    pub code: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
+    pub code: Option<StringFilter>,
     pub is_customer: Option<bool>,
     pub is_supplier: Option<bool>,
     pub is_patient: Option<bool>,
     pub is_store: Option<bool>,
-    pub store_code: Option<SimpleStringFilter>,
+    pub store_code: Option<StringFilter>,
     pub is_visible: Option<bool>,
     pub is_system_name: Option<bool>,
     pub r#type: Option<EqualFilter<NameType>>,
 
-    pub phone: Option<SimpleStringFilter>,
-    pub address1: Option<SimpleStringFilter>,
-    pub address2: Option<SimpleStringFilter>,
-    pub country: Option<SimpleStringFilter>,
-    pub email: Option<SimpleStringFilter>,
+    pub phone: Option<StringFilter>,
+    pub address1: Option<StringFilter>,
+    pub address2: Option<StringFilter>,
+    pub country: Option<StringFilter>,
+    pub email: Option<StringFilter>,
 }
 
 impl EqualFilter<NameType> {
@@ -178,17 +178,17 @@ impl<'a> NameRepository<'a> {
             } = f;
 
             apply_equal_filter!(query, id, name_dsl::id);
-            apply_simple_string_filter!(query, code, name_dsl::code);
+            apply_string_filter!(query, code, name_dsl::code);
 
-            apply_simple_string_filter!(query, name, name_dsl::name_);
-            apply_simple_string_filter!(query, store_code, store_dsl::code);
+            apply_string_filter!(query, name, name_dsl::name_);
+            apply_string_filter!(query, store_code, store_dsl::code);
             apply_equal_filter!(query, r#type, name_dsl::type_);
 
-            apply_simple_string_filter!(query, phone, name_dsl::phone);
-            apply_simple_string_filter!(query, address1, name_dsl::address1);
-            apply_simple_string_filter!(query, address2, name_dsl::address2);
-            apply_simple_string_filter!(query, country, name_dsl::country);
-            apply_simple_string_filter!(query, email, name_dsl::email);
+            apply_string_filter!(query, phone, name_dsl::phone);
+            apply_string_filter!(query, address1, name_dsl::address1);
+            apply_string_filter!(query, address2, name_dsl::address2);
+            apply_string_filter!(query, country, name_dsl::country);
+            apply_string_filter!(query, email, name_dsl::email);
 
             if let Some(is_customer) = is_customer {
                 query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
@@ -265,12 +265,12 @@ impl NameFilter {
         self
     }
 
-    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
@@ -295,7 +295,7 @@ impl NameFilter {
         self
     }
 
-    pub fn store_code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn store_code(mut self, filter: StringFilter) -> Self {
         self.store_code = Some(filter);
         self
     }
@@ -373,8 +373,8 @@ mod tests {
     use crate::{
         mock::MockDataInserts,
         mock::{mock_name_1, mock_test_name_query_store_1, mock_test_name_query_store_2},
-        test_db, NameFilter, NameRepository, NameRow, NameRowRepository, Pagination,
-        SimpleStringFilter, DEFAULT_PAGINATION_LIMIT,
+        test_db, NameFilter, NameRepository, NameRow, NameRowRepository, Pagination, StringFilter,
+        DEFAULT_PAGINATION_LIMIT,
     };
 
     use std::convert::TryFrom;
@@ -580,7 +580,7 @@ mod tests {
                 store_id,
                 NameFilter::new()
                     .is_visible(true)
-                    .name(SimpleStringFilter::like("me_")),
+                    .name(StringFilter::like("me_")),
             )
             .unwrap();
         assert_eq!(result.len(), 2);
@@ -593,7 +593,7 @@ mod tests {
                 store_id,
                 NameFilter::new()
                     .is_visible(true)
-                    .name(SimpleStringFilter::like("mE_")),
+                    .name(StringFilter::like("mE_")),
             )
             .unwrap();
         assert_eq!(result.len(), 2);
@@ -605,7 +605,7 @@ mod tests {
             let result = repo
                 .query_by_filter(
                     store_id,
-                    NameFilter::new().name(SimpleStringFilter::like("T_Ää_N")),
+                    NameFilter::new().name(StringFilter::like("T_Ää_N")),
                 )
                 .unwrap();
             assert_eq!(result.len(), 1);
@@ -618,7 +618,7 @@ mod tests {
                 store_id,
                 NameFilter::new()
                     .is_system_name(true)
-                    .code(SimpleStringFilter::equal_to(INVENTORY_ADJUSTMENT_NAME_CODE)),
+                    .code(StringFilter::equal_to(INVENTORY_ADJUSTMENT_NAME_CODE)),
             )
             .unwrap();
         assert_eq!(result.len(), 1);
@@ -633,7 +633,7 @@ mod tests {
                 NameFilter::new()
                     .is_visible(true)
                     .is_system_name(true)
-                    .code(SimpleStringFilter::equal_to(INVENTORY_ADJUSTMENT_NAME_CODE)),
+                    .code(StringFilter::equal_to(INVENTORY_ADJUSTMENT_NAME_CODE)),
             )
             .unwrap();
         assert_eq!(result.len(), 0);

--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -6,11 +6,11 @@ use super::{
 
 use crate::{
     diesel_macros::{
-        apply_date_filter, apply_equal_filter, apply_simple_string_filter,
-        apply_simple_string_or_filter, apply_sort_no_case,
+        apply_date_filter, apply_equal_filter, apply_sort_no_case, apply_string_filter,
+        apply_string_or_filter,
     },
     repository_error::RepositoryError,
-    DateFilter, EqualFilter, Gender, NameType, Pagination, SimpleStringFilter, Sort,
+    DateFilter, EqualFilter, Gender, NameType, Pagination, Sort, StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -20,25 +20,25 @@ pub type Patient = NameRow;
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct PatientFilter {
     pub id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
-    pub code: Option<SimpleStringFilter>,
-    pub code_2: Option<SimpleStringFilter>,
-    pub first_name: Option<SimpleStringFilter>,
-    pub last_name: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
+    pub code: Option<StringFilter>,
+    pub code_2: Option<StringFilter>,
+    pub first_name: Option<StringFilter>,
+    pub last_name: Option<StringFilter>,
     pub gender: Option<EqualFilter<Gender>>,
     pub date_of_birth: Option<DateFilter>,
-    pub phone: Option<SimpleStringFilter>,
-    pub address1: Option<SimpleStringFilter>,
-    pub address2: Option<SimpleStringFilter>,
-    pub country: Option<SimpleStringFilter>,
-    pub email: Option<SimpleStringFilter>,
+    pub phone: Option<StringFilter>,
+    pub address1: Option<StringFilter>,
+    pub address2: Option<StringFilter>,
+    pub country: Option<StringFilter>,
+    pub email: Option<StringFilter>,
 
     /// Filter for any identifier associated with a name entry.
     /// Currently:
     /// - name::code
     /// - name::national_health_number
     /// - program_enrolment::program_enrolment_id
-    pub identifier: Option<SimpleStringFilter>,
+    pub identifier: Option<StringFilter>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -176,8 +176,8 @@ impl<'a> PatientRepository<'a> {
 
             // or filters need to be applied first
             if identifier.is_some() {
-                apply_simple_string_filter!(query, identifier.clone(), name_dsl::code);
-                apply_simple_string_or_filter!(
+                apply_string_filter!(query, identifier.clone(), name_dsl::code);
+                apply_string_or_filter!(
                     query,
                     identifier.clone(),
                     name_dsl::national_health_number
@@ -186,7 +186,7 @@ impl<'a> PatientRepository<'a> {
                 let mut sub_query = program_enrolment_dsl::program_enrolment
                     .select(program_enrolment_dsl::patient_id)
                     .into_boxed();
-                apply_simple_string_filter!(
+                apply_string_filter!(
                     sub_query,
                     identifier,
                     program_enrolment_dsl::program_enrolment_id
@@ -202,23 +202,23 @@ impl<'a> PatientRepository<'a> {
             }
 
             apply_equal_filter!(query, id, name_dsl::id);
-            apply_simple_string_filter!(query, code, name_dsl::code);
-            apply_simple_string_filter!(
+            apply_string_filter!(query, code, name_dsl::code);
+            apply_string_filter!(
                 query,
                 national_health_number,
                 name_dsl::national_health_number
             );
-            apply_simple_string_filter!(query, name, name_dsl::name_);
+            apply_string_filter!(query, name, name_dsl::name_);
 
-            apply_simple_string_filter!(query, first_name, name_dsl::first_name);
-            apply_simple_string_filter!(query, last_name, name_dsl::last_name);
+            apply_string_filter!(query, first_name, name_dsl::first_name);
+            apply_string_filter!(query, last_name, name_dsl::last_name);
             apply_equal_filter!(query, gender, name_dsl::gender);
             apply_date_filter!(query, date_of_birth, name_dsl::date_of_birth);
-            apply_simple_string_filter!(query, phone, name_dsl::phone);
-            apply_simple_string_filter!(query, address1, name_dsl::address1);
-            apply_simple_string_filter!(query, address2, name_dsl::address2);
-            apply_simple_string_filter!(query, country, name_dsl::country);
-            apply_simple_string_filter!(query, email, name_dsl::email);
+            apply_string_filter!(query, phone, name_dsl::phone);
+            apply_string_filter!(query, address1, name_dsl::address1);
+            apply_string_filter!(query, address2, name_dsl::address2);
+            apply_string_filter!(query, country, name_dsl::country);
+            apply_string_filter!(query, email, name_dsl::email);
         };
 
         apply_equal_filter!(
@@ -242,32 +242,32 @@ impl PatientFilter {
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
 
-    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
         self
     }
 
-    pub fn code_2(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code_2(mut self, filter: StringFilter) -> Self {
         self.code_2 = Some(filter);
         self
     }
 
-    pub fn identifier(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn identifier(mut self, filter: StringFilter) -> Self {
         self.identifier = Some(filter);
         self
     }
 
-    pub fn first_name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn first_name(mut self, filter: StringFilter) -> Self {
         self.first_name = Some(filter);
         self
     }
 
-    pub fn last_name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn last_name(mut self, filter: StringFilter) -> Self {
         self.last_name = Some(filter);
         self
     }
@@ -282,25 +282,25 @@ impl PatientFilter {
         self
     }
 
-    pub fn phone(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn phone(mut self, filter: StringFilter) -> Self {
         self.phone = Some(filter);
         self
     }
 
-    pub fn address1(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn address1(mut self, filter: StringFilter) -> Self {
         self.address1 = Some(filter);
         self
     }
-    pub fn address2(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn address2(mut self, filter: StringFilter) -> Self {
         self.address2 = Some(filter);
         self
     }
-    pub fn country(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn country(mut self, filter: StringFilter) -> Self {
         self.country = Some(filter);
         self
     }
 
-    pub fn email(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn email(mut self, filter: StringFilter) -> Self {
         self.email = Some(filter);
         self
     }
@@ -314,7 +314,7 @@ mod tests {
     use crate::{
         mock::MockDataInserts, test_db, EqualFilter, NameRow, NameRowRepository, NameType,
         PatientFilter, PatientRepository, ProgramEnrolmentRow, ProgramEnrolmentRowRepository,
-        ProgramEnrolmentStatus, SimpleStringFilter,
+        ProgramEnrolmentStatus, StringFilter,
     };
 
     #[actix_rt::test]
@@ -328,7 +328,7 @@ mod tests {
         // Make sure we don't return names that are not patients
         let result = repo
             .query_by_filter(
-                PatientFilter::new().identifier(SimpleStringFilter::equal_to("code2")),
+                PatientFilter::new().identifier(StringFilter::equal_to("code2")),
                 None,
             )
             .unwrap();
@@ -386,14 +386,21 @@ mod tests {
             .unwrap();
         let result = repo
             .query_by_filter(
-                PatientFilter::new().identifier(SimpleStringFilter::equal_to("codePatient")),
+                PatientFilter::new().identifier(StringFilter::equal_to("codePatient")),
                 None,
             )
             .unwrap();
         assert_eq!(result.get(0).unwrap().id, patient_row.id);
         let result = repo
             .query_by_filter(
-                PatientFilter::new().identifier(SimpleStringFilter::equal_to("nhnPatient")),
+                PatientFilter::new().identifier(StringFilter::equal_to("nhnPatient")),
+                None,
+            )
+            .unwrap();
+        assert_eq!(result.get(0).unwrap().id, patient_row.id);
+        let result = repo
+            .query_by_filter(
+                PatientFilter::new().identifier(StringFilter::equal_to("program_enrolment_id")),
                 None,
             )
             .unwrap();
@@ -401,16 +408,8 @@ mod tests {
         let result = repo
             .query_by_filter(
                 PatientFilter::new()
-                    .identifier(SimpleStringFilter::equal_to("program_enrolment_id")),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.get(0).unwrap().id, patient_row.id);
-        let result = repo
-            .query_by_filter(
-                PatientFilter::new()
-                    .code(SimpleStringFilter::equal_to("codePatient"))
-                    .identifier(SimpleStringFilter::equal_to("program_enrolment_id")),
+                    .code(StringFilter::equal_to("codePatient"))
+                    .identifier(StringFilter::equal_to("program_enrolment_id")),
                 None,
             )
             .unwrap();
@@ -419,8 +418,8 @@ mod tests {
         let result = repo
             .query_by_filter(
                 PatientFilter::new()
-                    .code(SimpleStringFilter::equal_to("code does not exist"))
-                    .identifier(SimpleStringFilter::equal_to("program_enrolment_id")),
+                    .code(StringFilter::equal_to("code does not exist"))
+                    .identifier(StringFilter::equal_to("program_enrolment_id")),
                 None,
             )
             .unwrap();
@@ -428,7 +427,7 @@ mod tests {
         let result = repo
             .query_by_filter(
                 PatientFilter::new()
-                    .identifier(SimpleStringFilter::equal_to("identifier does not exist")),
+                    .identifier(StringFilter::equal_to("identifier does not exist")),
                 None,
             )
             .unwrap();
@@ -469,16 +468,14 @@ mod tests {
             .unwrap();
         let result = repo
             .query_by_filter(
-                PatientFilter::new()
-                    .identifier(SimpleStringFilter::equal_to("program_enrolment_id")),
+                PatientFilter::new().identifier(StringFilter::equal_to("program_enrolment_id")),
                 Some(&["WrongContext".to_string()]),
             )
             .unwrap();
         assert!(result.is_empty());
         let result = repo
             .query_by_filter(
-                PatientFilter::new()
-                    .identifier(SimpleStringFilter::equal_to("program_enrolment_id")),
+                PatientFilter::new().identifier(StringFilter::equal_to("program_enrolment_id")),
                 Some(&["ProgramType".to_string()]),
             )
             .unwrap();

--- a/server/repository/src/db_diesel/program_requisition/requisitions_in_period.rs
+++ b/server/repository/src/db_diesel/program_requisition/requisitions_in_period.rs
@@ -1,9 +1,9 @@
 use diesel::prelude::*;
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter},
+    diesel_macros::{apply_equal_filter, apply_string_filter},
     repository_error::RepositoryError,
-    EqualFilter, RequisitionRowType, SimpleStringFilter, StorageConnection,
+    EqualFilter, RequisitionRowType, StorageConnection, StringFilter,
 };
 
 table! {
@@ -23,7 +23,7 @@ pub struct RequisitionsInPeriodFilter {
     pub program_id: Option<EqualFilter<String>>,
     pub period_id: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
-    pub order_type: Option<SimpleStringFilter>,
+    pub order_type: Option<StringFilter>,
     pub r#type: Option<EqualFilter<RequisitionRowType>>,
 }
 
@@ -82,7 +82,7 @@ impl<'a> RequisitionsInPeriodRepository<'a> {
         apply_equal_filter!(query, period_id, requisitions_in_period_dsl::period_id);
         apply_equal_filter!(query, store_id, requisitions_in_period_dsl::store_id);
         apply_equal_filter!(query, r#type, requisitions_in_period_dsl::type_);
-        apply_simple_string_filter!(query, order_type, requisitions_in_period_dsl::order_type);
+        apply_string_filter!(query, order_type, requisitions_in_period_dsl::order_type);
 
         //  Debug diesel query
         // println!(
@@ -116,7 +116,7 @@ impl RequisitionsInPeriodFilter {
         self
     }
 
-    pub fn order_type(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn order_type(mut self, filter: StringFilter) -> Self {
         self.order_type = Some(filter);
         self
     }

--- a/server/repository/src/db_diesel/report.rs
+++ b/server/repository/src/db_diesel/report.rs
@@ -9,9 +9,9 @@ use crate::{
     diesel_macros::{apply_equal_filter, apply_sort_no_case},
     schema_from_row, FormSchema, FormSchemaRow,
 };
-use crate::{EqualFilter, Pagination, SimpleStringFilter, Sort};
+use crate::{EqualFilter, Pagination, Sort, StringFilter};
 
-use crate::{diesel_macros::apply_simple_string_filter, DBType, RepositoryError};
+use crate::{diesel_macros::apply_string_filter, DBType, RepositoryError};
 
 use diesel::{dsl::IntoBoxed, helper_types::LeftJoin, prelude::*};
 use util::inline_init;
@@ -25,7 +25,7 @@ pub struct Report {
 #[derive(Debug, Clone, Default)]
 pub struct ReportFilter {
     pub id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
     pub r#type: Option<EqualFilter<ReportType>>,
     pub context: Option<EqualFilter<ReportContext>>,
     pub sub_context: Option<EqualFilter<String>>,
@@ -49,7 +49,7 @@ impl ReportFilter {
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
@@ -146,7 +146,7 @@ fn create_filtered_query(filter: Option<ReportFilter>) -> BoxedStoreQuery {
         } = f;
 
         apply_equal_filter!(query, id, report_dsl::id);
-        apply_simple_string_filter!(query, name, report_dsl::name);
+        apply_string_filter!(query, name, report_dsl::name);
         apply_equal_filter!(query, r#type, report_dsl::type_);
         apply_equal_filter!(query, context, report_dsl::context);
         apply_equal_filter!(query, sub_context, report_dsl::sub_context);

--- a/server/repository/src/db_diesel/requisition/mod.rs
+++ b/server/repository/src/db_diesel/requisition/mod.rs
@@ -1,6 +1,6 @@
 use util::inline_init;
 
-use crate::{DateFilter, DatetimeFilter, EqualFilter, SimpleStringFilter, Sort};
+use crate::{DateFilter, DatetimeFilter, EqualFilter, Sort, StringFilter};
 
 mod requisition;
 pub mod requisition_row;
@@ -20,10 +20,10 @@ pub struct RequisitionFilter {
     pub finalised_datetime: Option<DatetimeFilter>,
     pub expected_delivery_date: Option<DateFilter>,
     pub name_id: Option<EqualFilter<String>>,
-    pub name: Option<SimpleStringFilter>,
+    pub name: Option<StringFilter>,
     pub colour: Option<EqualFilter<String>>,
-    pub their_reference: Option<SimpleStringFilter>,
-    pub comment: Option<SimpleStringFilter>,
+    pub their_reference: Option<StringFilter>,
+    pub comment: Option<StringFilter>,
     pub store_id: Option<EqualFilter<String>>,
     pub linked_requisition_id: Option<EqualFilter<String>>,
     pub order_type: Option<EqualFilter<String>>,
@@ -81,7 +81,7 @@ impl RequisitionFilter {
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
@@ -91,7 +91,7 @@ impl RequisitionFilter {
         self
     }
 
-    pub fn comment(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn comment(mut self, filter: StringFilter) -> Self {
         self.comment = Some(filter);
         self
     }
@@ -146,7 +146,7 @@ impl RequisitionFilter {
         self
     }
 
-    pub fn their_reference(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn their_reference(mut self, filter: StringFilter) -> Self {
         self.their_reference = Some(filter);
         self
     }

--- a/server/repository/src/db_diesel/requisition/requisition.rs
+++ b/server/repository/src/db_diesel/requisition/requisition.rs
@@ -12,8 +12,8 @@ use crate::{
         store_row::{store, store::dsl as store_dsl},
     },
     diesel_macros::{
-        apply_date_filter, apply_date_time_filter, apply_equal_filter, apply_simple_string_filter,
-        apply_sort, apply_sort_no_case,
+        apply_date_filter, apply_date_time_filter, apply_equal_filter, apply_sort,
+        apply_sort_no_case, apply_string_filter,
     },
     repository_error::RepositoryError,
     DBType, NameRow, PeriodRow, ProgramRow, StorageConnection, StoreRow,
@@ -205,10 +205,10 @@ fn create_filtered_query(
         );
 
         apply_equal_filter!(query, name_id, requisition_dsl::name_id);
-        apply_simple_string_filter!(query, name, name_dsl::name_);
+        apply_string_filter!(query, name, name_dsl::name_);
         apply_equal_filter!(query, colour, requisition_dsl::colour);
-        apply_simple_string_filter!(query, their_reference, requisition_dsl::their_reference);
-        apply_simple_string_filter!(query, comment, requisition_dsl::comment);
+        apply_string_filter!(query, their_reference, requisition_dsl::their_reference);
+        apply_string_filter!(query, comment, requisition_dsl::comment);
 
         apply_equal_filter!(query, store_id, requisition_dsl::store_id);
         apply_equal_filter!(query, order_type, requisition_dsl::order_type)

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     repository_error::RepositoryError,
     BarcodeRow, DateFilter, EqualFilter, ItemFilter, ItemRepository, ItemRow, NameRow, Pagination,
-    SimpleStringFilter, Sort,
+    Sort, StringFilter,
 };
 
 use diesel::{
@@ -44,7 +44,7 @@ pub enum StockLineSortField {
 #[derive(Debug, Clone)]
 pub struct StockLineFilter {
     pub id: Option<EqualFilter<String>>,
-    pub item_code_or_name: Option<SimpleStringFilter>,
+    pub item_code_or_name: Option<StringFilter>,
     pub item_id: Option<EqualFilter<String>>,
     pub location_id: Option<EqualFilter<String>>,
     pub is_available: Option<bool>,

--- a/server/repository/src/db_diesel/stocktake.rs
+++ b/server/repository/src/db_diesel/stocktake.rs
@@ -5,11 +5,11 @@ use super::{
 
 use crate::{
     diesel_macros::{
-        apply_date_filter, apply_date_time_filter, apply_equal_filter, apply_simple_string_filter,
-        apply_sort, apply_sort_no_case,
+        apply_date_filter, apply_date_time_filter, apply_equal_filter, apply_sort,
+        apply_sort_no_case, apply_string_filter,
     },
-    DBType, DateFilter, DatetimeFilter, EqualFilter, Pagination, RepositoryError,
-    SimpleStringFilter, Sort,
+    DBType, DateFilter, DatetimeFilter, EqualFilter, Pagination, RepositoryError, Sort,
+    StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -20,8 +20,8 @@ pub struct StocktakeFilter {
     pub store_id: Option<EqualFilter<String>>,
     pub user_id: Option<EqualFilter<String>>,
     pub stocktake_number: Option<EqualFilter<i64>>,
-    pub comment: Option<SimpleStringFilter>,
-    pub description: Option<SimpleStringFilter>,
+    pub comment: Option<StringFilter>,
+    pub description: Option<StringFilter>,
     pub status: Option<EqualFilter<StocktakeStatus>>,
     pub created_datetime: Option<DatetimeFilter>,
     pub stocktake_date: Option<DateFilter>,
@@ -66,12 +66,12 @@ impl StocktakeFilter {
         self
     }
 
-    pub fn comment(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn comment(mut self, filter: StringFilter) -> Self {
         self.comment = Some(filter);
         self
     }
 
-    pub fn description(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn description(mut self, filter: StringFilter) -> Self {
         self.description = Some(filter);
         self
     }
@@ -126,8 +126,8 @@ fn create_filtered_query<'a>(filter: Option<StocktakeFilter>) -> BoxedStocktakeQ
         apply_equal_filter!(query, f.store_id, stocktake::store_id);
         apply_equal_filter!(query, f.user_id, stocktake::user_id);
         apply_equal_filter!(query, f.stocktake_number, stocktake::stocktake_number);
-        apply_simple_string_filter!(query, f.comment, stocktake::comment);
-        apply_simple_string_filter!(query, f.description, stocktake::description);
+        apply_string_filter!(query, f.comment, stocktake::comment);
+        apply_string_filter!(query, f.description, stocktake::description);
 
         if let Some(value) = f.status {
             if let Some(eq) = value.equal_to {

--- a/server/repository/src/db_diesel/store.rs
+++ b/server/repository/src/db_diesel/store.rs
@@ -5,8 +5,8 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
-    DBType, EqualFilter, Pagination, RepositoryError, SimpleStringFilter, Sort,
+    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
+    DBType, EqualFilter, Pagination, RepositoryError, Sort, StringFilter,
 };
 
 use diesel::dsl::InnerJoin;
@@ -21,9 +21,9 @@ pub struct Store {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct StoreFilter {
     pub id: Option<EqualFilter<String>>,
-    pub code: Option<SimpleStringFilter>,
-    pub name: Option<SimpleStringFilter>,
-    pub name_code: Option<SimpleStringFilter>,
+    pub code: Option<StringFilter>,
+    pub name: Option<StringFilter>,
+    pub name_code: Option<StringFilter>,
     pub site_id: Option<EqualFilter<i32>>,
 }
 
@@ -48,17 +48,17 @@ impl StoreFilter {
         self
     }
 
-    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn code(mut self, filter: StringFilter) -> Self {
         self.code = Some(filter);
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.name = Some(filter);
         self
     }
 
-    pub fn name_code(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name_code(mut self, filter: StringFilter) -> Self {
         self.name_code = Some(filter);
         self
     }
@@ -134,13 +134,13 @@ fn create_filtered_query(filter: Option<StoreFilter>) -> BoxedStoreQuery {
             code,
             name,
             name_code,
-            site_id
+            site_id,
         } = f;
 
         apply_equal_filter!(query, id, store_dsl::id);
-        apply_simple_string_filter!(query, code, store_dsl::code);
-        apply_simple_string_filter!(query, name, name_dsl::name_);
-        apply_simple_string_filter!(query, name_code, name_dsl::code);
+        apply_string_filter!(query, code, store_dsl::code);
+        apply_string_filter!(query, name, name_dsl::name_);
+        apply_string_filter!(query, name_code, name_dsl::code);
         apply_equal_filter!(query, site_id, store_dsl::site_id);
     }
 

--- a/server/repository/src/db_diesel/user.rs
+++ b/server/repository/src/db_diesel/user.rs
@@ -8,9 +8,9 @@ use super::{
     DBType, StorageConnection, StoreRow, UserAccountRow, UserStoreJoinRow,
 };
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
+    diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
-    store_preference, EqualFilter, Pagination, SimpleStringFilter, Sort, StorePreferenceRow,
+    store_preference, EqualFilter, Pagination, Sort, StorePreferenceRow, StringFilter,
 };
 
 use diesel::{
@@ -41,7 +41,7 @@ impl User {
 #[derive(Clone, Default)]
 pub struct UserFilter {
     pub id: Option<EqualFilter<String>>,
-    pub username: Option<SimpleStringFilter>,
+    pub username: Option<StringFilter>,
     pub store_id: Option<EqualFilter<String>>,
     pub site_id: Option<EqualFilter<i32>>,
 }
@@ -183,7 +183,7 @@ fn create_filtered_query(filter: Option<UserFilter>) -> BoxedUserQuery {
         } = f;
 
         apply_equal_filter!(query, id, user_dsl::id);
-        apply_simple_string_filter!(query, username, user_dsl::username);
+        apply_string_filter!(query, username, user_dsl::username);
         apply_equal_filter!(query, store_id, user_store_join_dsl::store_id);
         apply_equal_filter!(query, site_id, store_dsl::site_id);
     }
@@ -201,7 +201,7 @@ impl UserFilter {
         self
     }
 
-    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+    pub fn name(mut self, filter: StringFilter) -> Self {
         self.username = Some(filter);
         self
     }

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -113,19 +113,36 @@ macro_rules! apply_string_filter_method {
 /// Example expand, when called with:
 ///
 /// ```
-/// apply_string_filter!(query, filter.comment, invoice_dsl::comment)
+/// apply_string_filter!(query, code, clinician_dsl::code)
 /// ```
 ///
 /// ```
-/// if let Some(string_filter) = filter.comment {
-///     if let Some(value) = equal_filter.equal_to {
-///         query = query.filter(invoice_dsl::comment.eq(value));
-///     }
-///
-///     if let Some(value) = equal_filter.like {
-///         query = query.filter(invoice_dsl::comment.like(format!("%{}%", value)));
-///     }
-/// }
+//  if let Some(code) = filter_field {
+//     if let Some(value) = filter.equal_to {
+//         query = query.filter(clinician_dsl::code.eq(value));
+//     }
+//     if let Some(value) = filter.not_equal_to {
+//         query = query.filter(clinician_dsl::code.ne(value));
+//     }
+//     if let Some(value) = filter.equal_any {
+//         query = query.filter(clinician_dsl::code.eq_any(value));
+//     }
+//     if let Some(value) = filter.not_equal_all {
+//         query = query.filter(clinician_dsl::code.ne_all(value));
+//     }
+//     if let Some(value) = filter.like {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.filter(clinician_dsl::code.like(format!("%{}%", value)));
+//     }
+//     if let Some(value) = filter.starts_with {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.filter(clinician_dsl::code.like(format!("{}%", value)));
+//     }
+//     if let Some(value) = filter.ends_with {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.filter(clinician_dsl::code.like(format!("%{}", value)));
+//     }
+// }
 /// ```
 macro_rules! apply_string_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
@@ -143,19 +160,36 @@ macro_rules! apply_string_filter {
 /// Example expand, when called with:
 ///
 /// ```
-/// apply_string_or_filter!(query, filter.comment, invoice_dsl::comment)
+/// apply_string_or_filter!(query, code, clinician_dsl::code)
 /// ```
 ///
 /// ```
-/// if let Some(string_filter) = filter.comment {
-///     if let Some(value) = equal_filter.equal_to {
-///         query = query.or_filter(invoice_dsl::comment.eq(value));
-///     }
-///
-///     if let Some(value) = equal_filter.like {
-///         query = query.or_filter(invoice_dsl::comment.like(format!("%{}%", value)));
-///     }
-/// }
+//  if let Some(code) = filter_field {
+//     if let Some(value) = filter.equal_to {
+//         query = query.or_filter(clinician_dsl::code.eq(value));
+//     }
+//     if let Some(value) = filter.not_equal_to {
+//         query = query.or_filter(clinician_dsl::code.ne(value));
+//     }
+//     if let Some(value) = filter.equal_any {
+//         query = query.or_filter(clinician_dsl::code.eq_any(value));
+//     }
+//     if let Some(value) = filter.not_equal_all {
+//         query = query.or_filter(clinician_dsl::code.ne_all(value));
+//     }
+//     if let Some(value) = filter.like {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.or_filter(clinician_dsl::code.like(format!("%{}%", value)));
+//     }
+//     if let Some(value) = filter.starts_with {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.or_filter(clinician_dsl::code.like(format!("{}%", value)));
+//     }
+//     if let Some(value) = filter.ends_with {
+//         // in sqlite like is case insensitive (but on only works with ASCII chars)
+//         query = query.or_filter(clinician_dsl::code.like(format!("%{}", value)));
+//     }
+// }
 /// ```
 macro_rules! apply_string_or_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -48,104 +48,63 @@ macro_rules! apply_equal_filter {
 }
 
 #[cfg(not(feature = "postgres"))]
-macro_rules! apply_string_filter {
-    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(filter) = $filter_field {
-            if let Some(value) = filter.equal_to {
-                $query = $query.filter($dsl_field.eq(value));
-            }
-            if let Some(value) = filter.not_equal_to {
-                $query = $query.filter($dsl_field.ne(value));
-            }
-            if let Some(value) = filter.equal_any {
-                $query = $query.filter($dsl_field.eq_any(value));
-            }
-            if let Some(value) = filter.not_equal_all {
-                $query = $query.filter($dsl_field.ne_all(value));
-            }
-            if let Some(value) = filter.like {
-                // in sqlite like is case insensitive (but on only works with ASCII chars)
-                $query = $query.filter($dsl_field.like(format!("%{}%", value)));
-            }
-            if let Some(value) = filter.starts_with {
-                // in sqlite like is case insensitive (but on only works with ASCII chars)
-                $query = $query.filter($dsl_field.like(format!("{}%", value)));
-            }
-            if let Some(value) = filter.ends_with {
-                // in sqlite like is case insensitive (but on only works with ASCII chars)
-                $query = $query.filter($dsl_field.like(format!("%{}", value)));
-            }
-        }
-    }};
-}
-#[cfg(feature = "postgres")]
-macro_rules! apply_string_filter {
-    ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(filter) = $filter_field {
-            if let Some(value) = filter.equal_to {
-                $query = $query.filter($dsl_field.eq(value));
-            }
-            if let Some(value) = filter.not_equal_to {
-                $query = $query.filter($dsl_field.ne(value));
-            }
-            if let Some(value) = filter.equal_any {
-                $query = $query.filter($dsl_field.eq_any(value));
-            }
-            if let Some(value) = filter.not_equal_all {
-                $query = $query.filter($dsl_field.ne_all(value));
-            }
-            if let Some(value) = filter.like {
-                // Use case insensitive like
-                $query = $query.filter($dsl_field.ilike(format!("%{}%", value)));
-            }
-            if let Some(value) = filter.starts_with {
-                // Use case insensitive like
-                $query = $query.filter($dsl_field.ilike(format!("{}%", value)));
-            }
-            if let Some(value) = filter.ends_with {
-                // Use case insensitive like
-                $query = $query.filter($dsl_field.ilike(format!("%{}", value)));
-            }
-        }
-    }};
-}
-
-#[cfg(not(feature = "postgres"))]
-#[macro_export]
-macro_rules! apply_simple_string_filter_method {
+macro_rules! apply_string_filter_method {
     ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
+        if let Some(filter) = $filter_field {
+            if let Some(value) = filter.equal_to {
                 $query = $query.$filter_method($dsl_field.eq(value));
             }
-
-            if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.$filter_method($dsl_field.like(value.replace("%", "")));
+            if let Some(value) = filter.not_equal_to {
+                $query = $query.$filter_method($dsl_field.ne(value));
             }
-
-            if let Some(value) = string_filter.like {
+            if let Some(value) = filter.equal_any {
+                $query = $query.$filter_method($dsl_field.eq_any(value));
+            }
+            if let Some(value) = filter.not_equal_all {
+                $query = $query.$filter_method($dsl_field.ne_all(value));
+            }
+            if let Some(value) = filter.like {
                 // in sqlite like is case insensitive (but on only works with ASCII chars)
                 $query = $query.$filter_method($dsl_field.like(format!("%{}%", value)));
             }
+            if let Some(value) = filter.starts_with {
+                // in sqlite like is case insensitive (but on only works with ASCII chars)
+                $query = $query.$filter_method($dsl_field.like(format!("{}%", value)));
+            }
+            if let Some(value) = filter.ends_with {
+                // in sqlite like is case insensitive (but on only works with ASCII chars)
+                $query = $query.$filter_method($dsl_field.like(format!("%{}", value)));
+            }
         }
     }};
 }
 #[cfg(feature = "postgres")]
-#[macro_export]
-macro_rules! apply_simple_string_filter_method {
-    ($query:ident, $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        if let Some(string_filter) = $filter_field {
-            if let Some(value) = string_filter.equal_to {
+macro_rules! apply_string_filter_method {
+    ($query:ident,  $filter_method:ident, $filter_field:expr, $dsl_field:expr ) => {{
+        if let Some(filter) = $filter_field {
+            if let Some(value) = filter.equal_to {
                 $query = $query.$filter_method($dsl_field.eq(value));
             }
-
-            if let Some(value) = string_filter.insensitive_equal_to {
-                $query = $query.$filter_method($dsl_field.ilike(value.replace("%", "")));
+            if let Some(value) = filter.not_equal_to {
+                $query = $query.$filter_method($dsl_field.ne(value));
             }
-
-            if let Some(value) = string_filter.like {
+            if let Some(value) = filter.equal_any {
+                $query = $query.$filter_method($dsl_field.eq_any(value));
+            }
+            if let Some(value) = filter.not_equal_all {
+                $query = $query.$filter_method($dsl_field.ne_all(value));
+            }
+            if let Some(value) = filter.like {
                 // Use case insensitive like
                 $query = $query.$filter_method($dsl_field.ilike(format!("%{}%", value)));
+            }
+            if let Some(value) = filter.starts_with {
+                // Use case insensitive like
+                $query = $query.$filter_method($dsl_field.ilike(format!("{}%", value)));
+            }
+            if let Some(value) = filter.ends_with {
+                // Use case insensitive like
+                $query = $query.$filter_method($dsl_field.ilike(format!("%{}", value)));
             }
         }
     }};
@@ -154,7 +113,7 @@ macro_rules! apply_simple_string_filter_method {
 /// Example expand, when called with:
 ///
 /// ```
-/// apply_simple_string_filter!(query, filter.comment, invoice_dsl::comment)
+/// apply_string_filter!(query, filter.comment, invoice_dsl::comment)
 /// ```
 ///
 /// ```
@@ -168,9 +127,14 @@ macro_rules! apply_simple_string_filter_method {
 ///     }
 /// }
 /// ```
-macro_rules! apply_simple_string_filter {
+macro_rules! apply_string_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        $crate::apply_simple_string_filter_method!($query, filter, $filter_field, $dsl_field);
+        crate::diesel_macros::apply_string_filter_method!(
+            $query,
+            filter,
+            $filter_field,
+            $dsl_field
+        );
     }};
 }
 
@@ -179,7 +143,7 @@ macro_rules! apply_simple_string_filter {
 /// Example expand, when called with:
 ///
 /// ```
-/// apply_simple_string_or_filter!(query, filter.comment, invoice_dsl::comment)
+/// apply_string_or_filter!(query, filter.comment, invoice_dsl::comment)
 /// ```
 ///
 /// ```
@@ -193,9 +157,14 @@ macro_rules! apply_simple_string_filter {
 ///     }
 /// }
 /// ```
-macro_rules! apply_simple_string_or_filter {
+macro_rules! apply_string_or_filter {
     ($query:ident, $filter_field:expr, $dsl_field:expr ) => {{
-        $crate::apply_simple_string_filter_method!($query, or_filter, $filter_field, $dsl_field);
+        crate::diesel_macros::apply_string_filter_method!(
+            $query,
+            or_filter,
+            $filter_field,
+            $dsl_field
+        );
     }};
 }
 
@@ -360,10 +329,10 @@ macro_rules! apply_sort_asc_nulls_first {
 pub(crate) use apply_date_filter;
 pub(crate) use apply_date_time_filter;
 pub(crate) use apply_equal_filter;
-pub(crate) use apply_simple_string_filter;
-pub(crate) use apply_simple_string_or_filter;
 pub(crate) use apply_sort;
 pub(crate) use apply_sort_asc_nulls_first;
 pub(crate) use apply_sort_asc_nulls_last;
 pub(crate) use apply_sort_no_case;
 pub(crate) use apply_string_filter;
+pub(crate) use apply_string_filter_method;
+pub(crate) use apply_string_or_filter;

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -288,7 +288,7 @@ mod repository_test {
         RequisitionRowRepository, StockLineFilter, StockLineRepository, StockLineRowRepository,
         StoreRowRepository, UserAccountRowRepository,
     };
-    use crate::{DateFilter, EqualFilter, SimpleStringFilter};
+    use crate::{DateFilter, EqualFilter, StringFilter};
     use chrono::Duration;
     use diesel::{sql_query, sql_types::Text, RunQueryDsl};
     use util::inline_edit;
@@ -493,7 +493,7 @@ mod repository_test {
         let id_rows: Vec<String> = repo
             .query_by_filter(
                 MasterListFilter::new()
-                    .exists_for_name(SimpleStringFilter::like("test_master_list_name")),
+                    .exists_for_name(StringFilter::like("test_master_list_name")),
             )
             .unwrap()
             .into_iter()
@@ -821,7 +821,7 @@ mod repository_test {
 
         // Test query by name
         let result = repo
-            .query_by_filter(RequisitionFilter::new().name(SimpleStringFilter::equal_to("name_a")))
+            .query_by_filter(RequisitionFilter::new().name(StringFilter::equal_to("name_a")))
             .unwrap();
 
         let raw_result = sql_query(
@@ -850,7 +850,7 @@ mod repository_test {
             .query_by_filter(
                 RequisitionFilter::new()
                     .status(RequisitionRowStatus::Draft.equal_to())
-                    .comment(SimpleStringFilter::like("iquE_coMme")),
+                    .comment(StringFilter::like("iquE_coMme")),
             )
             .unwrap();
 

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/mod.rs
@@ -81,7 +81,7 @@ mod test {
             mock_outbound_shipment_c, mock_store_a, mock_store_c, MockDataInserts,
         },
         test_db::setup_all,
-        InvoiceLineRowRepository, ItemFilter, ItemRepository, SimpleStringFilter,
+        InvoiceLineRowRepository, ItemFilter, ItemRepository, StringFilter,
     };
     use util::{constants::DEFAULT_SERVICE_ITEM_CODE, inline_edit, inline_init};
 
@@ -224,7 +224,7 @@ mod test {
         let default_service_item = ItemRepository::new(&connection)
             .query_one(
                 None,
-                ItemFilter::new().code(SimpleStringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
+                ItemFilter::new().code(StringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
             )
             .unwrap()
             .unwrap();

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
@@ -1,6 +1,6 @@
 use repository::{
     InvoiceRow, InvoiceRowType, ItemFilter, ItemRepository, ItemRow, ItemRowType, RepositoryError,
-    SimpleStringFilter, StorageConnection,
+    StorageConnection, StringFilter,
 };
 use util::constants::DEFAULT_SERVICE_ITEM_CODE;
 
@@ -56,7 +56,7 @@ fn get_default_service_item(
     let item_row = ItemRepository::new(connection)
         .query_one(
             None,
-            ItemFilter::new().code(SimpleStringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
+            ItemFilter::new().code(StringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
         )?
         .map(|item| item.item_row);
 

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/mod.rs
@@ -81,7 +81,7 @@ mod test {
             MockDataInserts,
         },
         test_db::setup_all,
-        InvoiceLineRowRepository, ItemFilter, ItemRepository, SimpleStringFilter,
+        InvoiceLineRowRepository, ItemFilter, ItemRepository, StringFilter,
     };
     use util::{constants::DEFAULT_SERVICE_ITEM_CODE, inline_edit, inline_init};
 
@@ -213,7 +213,7 @@ mod test {
         let default_service_item = ItemRepository::new(&connection)
             .query_one(
                 None,
-                ItemFilter::new().code(SimpleStringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
+                ItemFilter::new().code(StringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
             )
             .unwrap()
             .unwrap();

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/validate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/validate.rs
@@ -1,6 +1,6 @@
 use repository::{
     InvoiceRow, InvoiceRowType, ItemFilter, ItemRepository, ItemRow, ItemRowType, RepositoryError,
-    SimpleStringFilter, StorageConnection,
+    StorageConnection, StringFilter,
 };
 use util::constants::DEFAULT_SERVICE_ITEM_CODE;
 
@@ -56,7 +56,7 @@ fn get_default_service_item(
     let item_row = ItemRepository::new(connection)
         .query_one(
             None,
-            ItemFilter::new().code(SimpleStringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
+            ItemFilter::new().code(StringFilter::equal_to(DEFAULT_SERVICE_ITEM_CODE)),
         )?
         .map(|item| item.item_row);
 

--- a/server/service/src/master_list/tests/query.rs
+++ b/server/service/src/master_list/tests/query.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod query {
     use repository::{mock::MockDataInserts, test_db::setup_all, MasterListFilter};
-    use repository::{EqualFilter, SimpleStringFilter};
+    use repository::{EqualFilter, StringFilter};
 
     use crate::service_provider::ServiceProvider;
 
@@ -35,7 +35,7 @@ mod query {
                 None,
                 Some(
                     MasterListFilter::new()
-                        .exists_for_name(SimpleStringFilter::like("e_master_list_filter_te")),
+                        .exists_for_name(StringFilter::like("e_master_list_filter_te")),
                 ),
                 None,
             )

--- a/server/service/src/programs/patient/search.rs
+++ b/server/service/src/programs/patient/search.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use repository::{DateFilter, EqualFilter, Gender, RepositoryError, SimpleStringFilter};
+use repository::{DateFilter, EqualFilter, Gender, RepositoryError, StringFilter};
 
 use crate::service_provider::{ServiceContext, ServiceProvider};
 
@@ -37,16 +37,16 @@ pub fn patient_search(
     } = input;
 
     if let Some(code) = code {
-        filter = filter.code(SimpleStringFilter::equal_to(&code));
+        filter = filter.code(StringFilter::equal_to(&code));
     }
     if let Some(code_2) = code_2 {
-        filter = filter.code_2(SimpleStringFilter::equal_to(&code_2));
+        filter = filter.code_2(StringFilter::equal_to(&code_2));
     }
     if let Some(first_name) = first_name {
-        filter = filter.first_name(SimpleStringFilter::insensitive_equal_to(&first_name));
+        filter = filter.first_name(StringFilter::like(&first_name));
     }
     if let Some(last_name) = last_name {
-        filter = filter.last_name(SimpleStringFilter::insensitive_equal_to(&last_name));
+        filter = filter.last_name(StringFilter::like(&last_name));
     }
     if let Some(date_of_birth) = date_of_birth {
         filter = filter.date_of_birth(DateFilter::equal_to(date_of_birth));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1932

# 👩🏻‍💻 What does this PR do? 

Use one common string filter type, most changes are find and replace apart from (see self review comment in code changes for those):

server/repository/src/diesel_macros.rs
server/graphql/core/src/generic_filters.rs
server/repository/src/db_diesel/filter_sort_pagination.rs
server/service/src/programs/patient/search.rs


# 🧪 How has/should this change been tested? 

Not entirely sure which areas might be affected, I did unit test, seem to pass. Also strict typing should pretty much that these changes are safe. 

Perhaps it's worth checking that case insensitive filter still work (searching patient by first/last name is the same as it was)

## 💌 Any notes for the reviewer?

## 📃 Documentation