### PR TITLE
Add user-data-dir to chrome debugging settings

### DIFF
--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -8,7 +8,8 @@
       "url": "http://localhost:3003",
       "sourceMapPathOverrides": {
         "webpack://@openmsupply-client/host/..": "${workspaceRoot}/packages"
-      }
+      },
+      "runtimeArgs": ["-user-data-dir=${userHome}/ChromeDevProfile"]
     }
   ]
 }


### PR DESCRIPTION
Don't know if anybody else had this problem but this fixes the problem that I can't debug using chrome.

This would add a ChromeDevProfile into the home directory though. Happy to choose a different name or location...