### PR TITLE
1984 I can change the Supplier on an Inbound Shipment created as part of a stock transfer 

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -49,6 +49,7 @@ export const Toolbar: FC = () => {
   ]);
   const { isGrouped, toggleIsGrouped } = useInbound.lines.rows();
   const t = useTranslation('replenishment');
+  const isTransfer = !!shipment?.linkedShipment?.id;
 
   if (!data) return null;
 
@@ -68,7 +69,7 @@ export const Toolbar: FC = () => {
                 label={t('label.supplier-name')}
                 Input={
                   <SupplierSearchInput
-                    disabled={isDisabled}
+                    disabled={isDisabled || isTransfer}
                     value={otherParty}
                     onChange={name => {
                       update({ otherParty: name });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1984

# 👩🏻‍💻 What does this PR do? 
Don't allow user to change suppliers if the inbound shipment was created from an outbound shipment.

# 🧪 How has/should this change been tested? 
- [ ] Send an Outbound Shipment from `Store A` to `Store B`
- [ ] Go to `Store B` and click on the newly created Inbound Shipment
- [ ] Supplier should be disabled