### PR TITLE
2036 cached test db templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ server/report_builder/config.yaml
 
 # Temp export files
 server/data
+
+# test template DB marker
+___template_needs_update.marker

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2023,6 +2023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,6 +4069,7 @@ dependencies = [
  "diesel-derive-enum",
  "diesel_migrations",
  "futures-util",
+ "glob",
  "libsqlite3-sys",
  "log",
  "pretty_assertions",

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -44,3 +44,6 @@ default = ["sqlite"]
 sqlite = ["diesel/sqlite", "libsqlite3-sys", "diesel-derive-enum/sqlite"]
 memory = ["diesel/sqlite", "libsqlite3-sys", "diesel-derive-enum/sqlite"]
 postgres = ["diesel/postgres", "diesel-derive-enum/postgres"]
+
+[build-dependencies]
+glob = "0.3.1"

--- a/server/repository/build.rs
+++ b/server/repository/build.rs
@@ -1,0 +1,18 @@
+use glob::glob;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    // when migrations are changing mark the template DBs to be recreated
+    for entry in glob("../**/test_output").expect("Failed to read glob pattern") {
+        match entry {
+            Ok(path) => {
+                fs::File::create(Path::new(&path).join("___template_needs_update.marker")).unwrap();
+            }
+            Err(e) => println!("cargo:warning={:?}", e),
+        }
+    }
+    println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=src/migrations");
+    println!("cargo:rerun-if-changed=src/mock");
+}

--- a/server/repository/build.rs
+++ b/server/repository/build.rs
@@ -2,12 +2,16 @@ use glob::glob;
 use std::fs;
 use std::path::Path;
 
+#[path = "src/test_db/constants.rs"]
+mod constants;
+use crate::constants::{TEMPLATE_MARKER_FILE, TEST_OUTPUT_DIR};
+
 fn main() {
     // when migrations are changing mark the template DBs to be recreated
-    for entry in glob("../**/test_output").expect("Failed to read glob pattern") {
+    for entry in glob(&format!("../**/{}", TEST_OUTPUT_DIR)).expect("Failed to read glob pattern") {
         match entry {
             Ok(path) => {
-                fs::File::create(Path::new(&path).join("___template_needs_update.marker")).unwrap();
+                fs::File::create(Path::new(&path).join(TEMPLATE_MARKER_FILE)).unwrap();
             }
             Err(e) => println!("cargo:warning={:?}", e),
         }

--- a/server/repository/src/mock/mod.rs
+++ b/server/repository/src/mock/mod.rs
@@ -163,7 +163,7 @@ impl MockData {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct MockDataInserts {
     pub user_accounts: bool,
     pub user_store_joins: bool,
@@ -454,7 +454,7 @@ impl Index<&str> for MockDataCollection {
     }
 }
 
-fn all_mock_data() -> MockDataCollection {
+pub(crate) fn all_mock_data() -> MockDataCollection {
     let mut data: MockDataCollection = Default::default();
     data.insert(
         "base",

--- a/server/repository/src/test_db/constants.rs
+++ b/server/repository/src/test_db/constants.rs
@@ -1,0 +1,2 @@
+pub(crate) const TEST_OUTPUT_DIR: &'static str = "test_output";
+pub(crate) const TEMPLATE_MARKER_FILE: &'static str = "___template_needs_update.marker";

--- a/server/repository/src/test_db/mod.rs
+++ b/server/repository/src/test_db/mod.rs
@@ -8,6 +8,8 @@ mod postgres;
 #[cfg(feature = "postgres")]
 pub use self::postgres::*;
 
+mod constants;
+
 use crate::{
     database_settings::DatabaseSettings,
     migrations::Version,

--- a/server/repository/src/test_db/mod.rs
+++ b/server/repository/src/test_db/mod.rs
@@ -11,9 +11,7 @@ pub use self::postgres::*;
 use crate::{
     database_settings::DatabaseSettings,
     migrations::Version,
-    mock::{
-        insert_all_mock_data, insert_extra_mock_data, MockData, MockDataCollection, MockDataInserts,
-    },
+    mock::{insert_extra_mock_data, MockData, MockDataCollection, MockDataInserts},
     StorageConnection, StorageConnectionManager,
 };
 
@@ -95,10 +93,9 @@ pub async fn setup_test<'a>(
     }: SetupOption<'a>,
 ) -> SetupResult {
     let db_settings = get_test_db_settings(db_name);
-    let connection_manager = setup_with_version(&db_settings, version).await;
+    let (connection_manager, core_data) = setup_with_version(&db_settings, version, inserts).await;
     let connection = connection_manager.connection().unwrap();
 
-    let core_data = insert_all_mock_data(&connection, inserts).await;
     insert_extra_mock_data(&connection, extra_mock_data);
     SetupResult {
         core_data,

--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -93,7 +93,7 @@ pub(crate) async fn setup_with_version(
 fn connection_manager(db_settings: &DatabaseSettings) -> StorageConnectionManager {
     let connection_manager =
         ConnectionManager::<DBBackendConnection>::new(&db_settings.connection_string());
-    const SQLITE_LOCKWAIT_MS: u32 = 5000; //5 second wait for test lock timeout
+    const SQLITE_LOCKWAIT_MS: u32 = 10 * 1000; // 10 second wait for test lock timeout
     let pool = Pool::builder()
         .min_idle(Some(1))
         .connection_customizer(Box::new(SqliteConnectionOptions {

--- a/server/repository/src/test_db/sqlite.rs
+++ b/server/repository/src/test_db/sqlite.rs
@@ -9,8 +9,7 @@ use crate::{
     DBBackendConnection, StorageConnectionManager,
 };
 
-const TEST_OUTPUT_DIR: &'static str = "test_output";
-const TEMPLATE_MARKER_FILE: &'static str = "___template_needs_update.marker";
+use super::constants::{TEMPLATE_MARKER_FILE, TEST_OUTPUT_DIR};
 
 pub fn get_test_db_settings(db_name: &str) -> DatabaseSettings {
     DatabaseSettings {

--- a/server/service/src/number.rs
+++ b/server/service/src/number.rs
@@ -70,6 +70,7 @@ mod test {
     };
     use util::inline_init;
 
+    #[cfg(not(feature = "memory"))]
     const TEST_SLEEP_TIME: u64 = 100;
     const MAX_CONCURRENCY: u64 = 10;
 

--- a/server/service/src/processors/transfer/requisition/mod.rs
+++ b/server/service/src/processors/transfer/requisition/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod link_request_requisition;
 pub(crate) mod update_request_requisition_status;
 
 #[cfg(test)]
+#[cfg(not(feature = "memory"))]
 pub(crate) mod test;
 
 use repository::{

--- a/server/service/src/processors/transfer/shipment/mod.rs
+++ b/server/service/src/processors/transfer/shipment/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod update_inbound_shipment;
 pub(crate) mod update_outbound_shipment_status;
 
 #[cfg(test)]
+#[cfg(not(feature = "memory"))]
 pub(crate) mod test;
 
 const CHANGELOG_BATCH_SIZE: u32 = 20;

--- a/server/service/src/requisition_line/response_line_stats/mod.rs
+++ b/server/service/src/requisition_line/response_line_stats/mod.rs
@@ -223,7 +223,7 @@ mod test {
     #[actix_rt::test]
     async fn get_response_requisition_line_stats_success() {
         let (_, _, connection_manager, _) = setup_all_with_data(
-            "get_requisition_line_chart_consumption",
+            "get_response_requisition_line_stats_success",
             MockDataInserts::all(),
             inline_init(|r: &mut MockData| {
                 r.requisitions = vec![

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -17,6 +17,7 @@ pub(crate) struct ServiceTestContext {
     #[allow(dead_code)]
     pub(crate) connection: StorageConnection,
     pub(crate) service_provider: Arc<ServiceProvider>,
+    #[allow(dead_code)]
     pub(crate) processors_task: JoinHandle<()>,
     pub(crate) connection_manager: StorageConnectionManager,
     #[allow(dead_code)]


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2036 

# 👩🏻‍💻 What does this PR do? 
- Caches sqlite DB for testing (DBs are cached by: migration version and if all mock data is used)
- Invalidates cache when migrations or mock data changes (using build.rs)
- Fixes sqlite memory tests
- Updates postgres tests

## Overview of the cache logic:
- When migration or mock filed have been changed, a marker file is put in all existing test_output directory indicating that the cache needs to be invalidated
- When creating a test DB: If marker file exists delete existing template DBs and the marker file
- If no template DB exists create a new one and use it for the test

# 🧪 How has/should this change been tested? 
- Run sqlite tests (should already be faster than before)
- Second run should be much faster since all DB are cached now
- touch a migration file or a mock file, the cache should be invalidated and template file deleted before running next tests (this can be seen by, for example, look at the repository test_output directory while the test is running)

# Future work:
- Do similar work for Postgres
- Make more tests use full mock data to make more use of the cache
- Remove memory feature(?) since it would be the slowed option...
