### PR TITLE
Provide y-axis defaults

### DIFF
--- a/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
+++ b/client/packages/programs/src/JsonForms/components/EncounterLineChart.tsx
@@ -141,6 +141,10 @@ const UIComponent = (props: ControlProps) => {
   if (!visible || !option) {
     return null;
   }
+
+  // with no valid data, the y-axis label cannot be shown, so we provide some defaults
+  const domain = (data.every(value => value.y === null) || data.length === 0) ? [0, 100] : undefined;
+
   return (
     <Box
       display="flex"
@@ -164,7 +168,7 @@ const UIComponent = (props: ControlProps) => {
           tickFormatter={dayMonthShort}
           domain={['auto', 'auto']}
         />
-        <YAxis>
+        <YAxis domain={domain}>
           <Label
             value={`${option.label ?? '-'} [${option.unit ?? '?'}]`}
             angle={-90}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1844

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds the default domain when the data is unable to provide the y-axis domain values.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Create a new encounter for a patient who has only just enrolled. Then add some data and ensure that the y axis shows correctly when data is available.

I've used the range 0-100 for the defaults, even though this won't be sensible for all charts.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
