### PR TITLE
Fix warnings

### DIFF
--- a/server/repository/src/test_db/constants.rs
+++ b/server/repository/src/test_db/constants.rs
@@ -1,2 +1,4 @@
+#[allow(dead_code)]
 pub(crate) const TEST_OUTPUT_DIR: &'static str = "test_output";
+#[allow(dead_code)]
 pub(crate) const TEMPLATE_MARKER_FILE: &'static str = "___template_needs_update.marker";


### PR DESCRIPTION
Fix warnings
    
[allow(dead_code)] is needed since this file is used in build.rs as well, i.e. we can't disable by feature.