### PR TITLE
1982 Default sort for items when adding from master lists should be A--> Z rather than Z --> A 

### DIFF
--- a/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/line/useStocktakeRows.ts
@@ -13,7 +13,7 @@ export const useStocktakeRows = (isGrouped = true) => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'desc' } });
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const { data: lines } = useStocktakeLines();
   const { data: items } = useStocktakeItems();
   const { itemFilter, setItemFilter, matchItem } = useItemUtils();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -17,7 +17,7 @@ export const useRequestColumns = () => {
   const {
     updateSortQuery,
     queryParams: { sortBy },
-  } = useUrlQueryParams();
+  } = useUrlQueryParams({ initialSort: { key: 'itemName', dir: 'asc' } });
   const formatNumber = useFormatNumber();
   const { usesRemoteAuthorisation } = useRequest.utils.isRemoteAuthorisation();
 

--- a/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
@@ -230,7 +230,6 @@ mod test {
             "stockLineId": "n/a",
             "numberOfPacks": 0,
             "stockLineId": "n/a",
-            "totalBeforeTax": 0,
             "note": "n/a",
           }
         })
@@ -560,7 +559,7 @@ mod test {
                     item_id: "item input".to_string(),
                     stock_line_id: "stock line input".to_string(),
                     number_of_packs: 1.0,
-                    total_before_tax: Some(1.1),
+                    total_before_tax: None,
                     note: None,
                     tax: None,
                 }
@@ -579,8 +578,7 @@ mod test {
                 "invoiceId": "invoice input",
                 "itemId": "item input",
                 "stockLineId": "stock line input",
-                "numberOfPacks": 1.0,
-                "totalBeforeTax": 1.1,
+                "numberOfPacks": 1.0
             },
             "storeId": "store_a"
         });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1982

# 👩🏻‍💻 What does this PR do? 
Change the sort order for item names in stocktake view to ascending.

# 🧪 How has/should this change been tested? 
- [ ] Create a stocktake from master list
- [ ] All should show from A - Z