### PR TITLE
2046 Patient created in oms are not syncing well to mSupply Desktop

### DIFF
--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -83,6 +83,7 @@ pub fn update_patient_row(
         r#type: NameType::Patient,
         is_customer: existing_name.map(|n| n.is_customer).unwrap_or(true),
         is_supplier: existing_name.map(|n| n.is_supplier).unwrap_or(false),
+        // supplying_store_id is the home store for a patient and is needed for mSupply compatibility
         supplying_store_id: existing_name
             .and_then(|n| n.supplying_store_id.clone())
             .or(store_id),

--- a/server/service/src/programs/patient/patient_updated.rs
+++ b/server/service/src/programs/patient/patient_updated.rs
@@ -38,6 +38,7 @@ pub fn create_patient_name_store_join(
 /// Updates the names table for the updated patient.
 pub fn update_patient_row(
     con: &StorageConnection,
+    store_id: Option<String>,
     update_timestamp: &DateTime<Utc>,
     patient: SchemaPatient,
     is_sync_update: bool,
@@ -82,9 +83,11 @@ pub fn update_patient_row(
         r#type: NameType::Patient,
         is_customer: existing_name.map(|n| n.is_customer).unwrap_or(true),
         is_supplier: existing_name.map(|n| n.is_supplier).unwrap_or(false),
-        supplying_store_id: existing_name.and_then(|n| n.supplying_store_id.clone()),
-        first_name: first_name,
-        last_name: last_name,
+        supplying_store_id: existing_name
+            .and_then(|n| n.supplying_store_id.clone())
+            .or(store_id),
+        first_name,
+        last_name,
         gender: gender.and_then(|g| match g {
             SchemaGender::Female => Some(Gender::Female),
             SchemaGender::Male => Some(Gender::Male),

--- a/server/service/src/programs/patient/upsert.rs
+++ b/server/service/src/programs/patient/upsert.rs
@@ -55,7 +55,13 @@ pub fn upsert_patient(
             if is_latest_doc(&ctx.connection, &doc.name, doc.datetime)
                 .map_err(UpdatePatientError::DatabaseError)?
             {
-                update_patient_row(&ctx.connection, &doc_timestamp, patient, false)?;
+                update_patient_row(
+                    &ctx.connection,
+                    Some(store_id.to_string()),
+                    &doc_timestamp,
+                    patient,
+                    false,
+                )?;
                 create_patient_name_store_join(&ctx.connection, store_id, &patient_id)?;
             }
 

--- a/server/service/src/sync/integrate_document.rs
+++ b/server/service/src/sync/integrate_document.rs
@@ -54,7 +54,7 @@ fn update_patient(con: &StorageConnection, document: &Document) -> Result<(), Re
         RepositoryError::as_db_error(&format!("Invalid patient data: {}", err), "")
     })?;
 
-    update_patient_row(con, &document.datetime, patient, true)
+    update_patient_row(con, None, &document.datetime, patient, true)
         .map_err(|err| RepositoryError::as_db_error(&format!("{:?}", err), ""))?;
     Ok(())
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2046

# 👩🏻‍💻 What does this PR do? 
Saves supplying store for patients when created on omSupply so that it shows/hides the patients if the `Patients created in other stores not visible in this store` pref is ON/OFF

# 🧪 How has/should this change been tested? 
Make sure both stores are `dispensaries`
- [ ] Create a patient in om in Store A(need to run programs 4dInit script to create patients)
- [ ] Log in to Store B in central and turn ON `Patients created in other stores not visible in this store` pref
- [ ] Newly created patient should not show up in the patient list of Store B
- [ ] Turn `Patients created in other stores not visible in this store` OFF
- [ ] Should see newly created patient