### PR TITLE
2093 keyed item array fix

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Array/FirstItemArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/FirstItemArray.tsx
@@ -69,8 +69,8 @@ const FirstItemArrayComponent = (props: FirstItemArrayControlCustomProps) => {
 
   // If there are definitions they need to be added to the child schema
   const schemaWithDefs = {
-    ...(schema as JsonSchema7),
     definitions: rootSchema.definitions as Record<string, JsonSchema7>,
+    ...(schema as JsonSchema7),
   };
 
   if (!visible) return null;

--- a/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/KeyedItemArray.tsx
@@ -98,8 +98,8 @@ const KeyedItemArrayComponent: ComponentType<
   const childPath = composePaths(path, `${index}`);
   // If there are definitions they need to be added to the child schema
   const schemaWithDefs = {
-    ...(schema as JsonSchema7),
     definitions: rootSchema.definitions as Record<string, JsonSchema7>,
+    ...(schema as JsonSchema7),
   };
 
   if (zErrors) {

--- a/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/common.tsx
@@ -109,7 +109,7 @@ export const ArrayCommonComponent = (props: ArrayControlCustomProps) => {
     new Array(inputData?.length ?? 0).fill(defaultExpanded)
   );
 
-  const getItemLabelCommon = (child: any, index: number) => {
+  const getItemLabelCommon = (child: JsonData, index: number) => {
     return (
       <Typography
         sx={{


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2093 

I also added a workaround that avoid creating empty array entries for FirstItemArray and KeyedItemArray. This avoids data editing without user input, e.g. user visits the form and data is modified because an empty object had been added to the array.

# Testing
- Create a new patient with minimal details
- Check in the history that contacts and contactDetails arrays are empty.
- Re-visit patient, data shouldn't be automatically modified.
- Update contact details and enter next of kin details
- Check that changes are made correctly (history view)