### PR TITLE
2083 Fix sync with pre 7.7 version of msupply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.2.01",
+  "version": "1.2.02",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/service/src/sync/test/test_data/store_preference.rs
+++ b/server/service/src/sync/test/test_data/store_preference.rs
@@ -130,8 +130,7 @@ const STORE_PREFERENCE_2: (&'static str, &'static str) = (
         "monthsUnderstock": 3,
         "monthsItemsExpire": 3,
         "boxPrefix": "",
-        "boxPercentageSpace": 0,
-        "omSupplyUsesProgramModule": false
+        "boxPercentageSpace": 0
     }
 }"#,
 );
@@ -159,6 +158,7 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                 pack_to_one: false,
                 response_requisition_requires_authorisation: false,
                 request_requisition_requires_authorisation: true,
+                // This one is missing, should default to false
                 om_program_module: false,
             }),
         ),

--- a/server/service/src/sync/translations/store_preference.rs
+++ b/server/service/src/sync/translations/store_preference.rs
@@ -33,6 +33,8 @@ pub struct LegacyPrefData {
     pub response_requisition_requires_authorisation: bool,
     #[serde(rename = "includeRequisitionsInSuppliersRemoteAuthorisationProcesses")]
     pub request_requisition_requires_authorisation: bool,
+    #[serde(default)]
+    // In case preference is missing, use default
     #[serde(rename = "omSupplyUsesProgramModule")]
     pub om_program_module: bool,
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2083

# 👩🏻‍💻 What does this PR do? 

As per commit comment, also did re-export of reference data (that's how i found the original issue)

# 🧪 How has/should this change been tested? 

Open [this data file](https://github.com/openmsupply/open-msupply/files/12354644/2083-706.4DD.zip) with 7.6 version of mSupply. 

initialise omSupply, try to add inbound shipment with line of pack size > 1, pack size should be changed to 1 after ok is pressed. (this doesn't happen on current main)

## 💌 Any notes for the reviewer?


## 📃 Documentation
