### PR TITLE
User should be logged in to their default store

### DIFF
--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -104,13 +104,12 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
     login,
     isLoggingIn,
     upsertMostRecentCredential,
-    mostRecentlyUsedCredentials,
+    mostRecentCredentials,
   } = useLogin(setCookie);
   const getUserPermissions = useGetUserPermissions();
   const { refreshToken } = useRefreshToken();
   const { setHeader } = useGql();
-  const mostRecentUsername =
-    mostRecentlyUsedCredentials?.[0]?.username ?? undefined;
+  const mostRecentUsername = mostRecentCredentials[0]?.username ?? undefined;
 
   // initialise the auth header with the cookie value i.e. on page refresh
   setHeader('Authorization', `Bearer ${authCookie?.token}`);

--- a/client/packages/common/src/authentication/AuthContext.tsx
+++ b/client/packages/common/src/authentication/AuthContext.tsx
@@ -42,11 +42,6 @@ type User = {
   jobTitle?: string | null;
 };
 
-type MRUCredentials = {
-  store?: UserStoreNodeFragment;
-  username?: string;
-};
-
 interface AuthControl {
   error?: AuthError | null;
   isLoggingIn: boolean;
@@ -55,7 +50,7 @@ interface AuthControl {
     password: string
   ) => Promise<AuthenticationResponse>;
   logout: () => void;
-  mostRecentlyUsedCredentials?: MRUCredentials | null;
+  mostRecentUsername?: string;
   setError?: (error: AuthError) => void;
   setStore: (store: UserStoreNodeFragment) => Promise<void>;
   store?: UserStoreNodeFragment;
@@ -101,27 +96,29 @@ const AuthContext = createContext<AuthControl>(authControl);
 const { Provider } = AuthContext;
 
 export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
-  const [mostRecentlyUsedCredentials, setMRUCredentials] =
-    useLocalStorage('/mru/credentials');
   const authCookie = getAuthCookie();
   const [cookie, setCookie] = useState<AuthCookie | undefined>(authCookie);
   const [error, setError] = useLocalStorage('/auth/error');
   const storeId = cookie?.store?.id ?? '';
-  const { login, isLoggingIn } = useLogin(setCookie);
+  const {
+    login,
+    isLoggingIn,
+    upsertMostRecentCredential,
+    mostRecentlyUsedCredentials,
+  } = useLogin(setCookie);
   const getUserPermissions = useGetUserPermissions();
   const { refreshToken } = useRefreshToken();
   const { setHeader } = useGql();
+  const mostRecentUsername =
+    mostRecentlyUsedCredentials?.[0]?.username ?? undefined;
 
   // initialise the auth header with the cookie value i.e. on page refresh
   setHeader('Authorization', `Bearer ${authCookie?.token}`);
-
   const setStore = async (store: UserStoreNodeFragment) => {
     if (!cookie?.token) return;
 
-    setMRUCredentials({
-      username: mostRecentlyUsedCredentials?.username ?? '',
-      store,
-    });
+    upsertMostRecentCredential(mostRecentUsername ?? '', store);
+
     const permissions = await getUserPermissions(cookie?.token, store);
     const user = {
       id: cookie.user?.id ?? '',
@@ -152,7 +149,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       token: cookie?.token || '',
       user: cookie?.user,
       store: cookie?.store,
-      mostRecentlyUsedCredentials,
+      mostRecentUsername,
       setStore,
       setError,
       userHasPermission,
@@ -161,7 +158,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       login,
       cookie,
       error,
-      mostRecentlyUsedCredentials,
+      mostRecentUsername,
       isLoggingIn,
       setStore,
       setError,

--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -62,7 +62,10 @@ export const useLogin = (
 
     if (
       mostRecentlyUsedCredentials?.store &&
-      stores?.some(store => store.id === mostRecentlyUsedCredentials?.store?.id)
+      stores?.some(
+        store => store.id === mostRecentlyUsedCredentials?.store?.id
+      ) &&
+      mostRecentlyUsedCredentials?.username === userDetails?.username
     ) {
       return (
         stores.find(

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -8,7 +8,7 @@ export type GroupByItem = {
   inboundShipment?: boolean;
   stocktake?: boolean;
 };
-type AuthenticationCredentials = {
+export type AuthenticationCredentials = {
   store?: UserStoreNodeFragment | undefined;
   username: string;
 };
@@ -22,7 +22,7 @@ export type LocalStorageRecord = {
   '/theme/customhash': string;
   '/theme/logo': string;
   '/theme/logohash': string;
-  '/mru/credentials': AuthenticationCredentials[];
+  '/mru/credentials': AuthenticationCredentials | AuthenticationCredentials[];
   '/auth/error': AuthError | undefined;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -22,7 +22,7 @@ export type LocalStorageRecord = {
   '/theme/customhash': string;
   '/theme/logo': string;
   '/theme/logohash': string;
-  '/mru/credentials': AuthenticationCredentials;
+  '/mru/credentials': AuthenticationCredentials[];
   '/auth/error': AuthError | undefined;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;

--- a/client/packages/host/src/components/Login/hooks.ts
+++ b/client/packages/host/src/components/Login/hooks.ts
@@ -41,7 +41,7 @@ export const useLoginForm = (
   const { data: initStatus } = useInitialisationStatus();
   const navigate = useNavigate();
   const location = useLocation();
-  const { mostRecentlyUsedCredentials, login, isLoggingIn } = useAuthContext();
+  const { mostRecentUsername, login, isLoggingIn } = useAuthContext();
   const { password, setPassword, setUsername, username, error, setError } =
     state;
 
@@ -62,11 +62,11 @@ export const useLoginForm = (
   const isValid = !!username && !!password;
 
   React.useEffect(() => {
-    if (mostRecentlyUsedCredentials?.username && !username) {
-      setUsername(mostRecentlyUsedCredentials.username);
+    if (mostRecentUsername && !username) {
+      setUsername(mostRecentUsername);
       setTimeout(() => passwordRef.current?.focus(), 100);
     }
-  }, [mostRecentlyUsedCredentials]);
+  }, [mostRecentUsername]);
 
   useEffect(() => {
     if (!initStatus) return;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2099

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The issue raised is due to the most recent credentials being a single object. If you are switching users then the previous user's store was being set as the current store. This overrides the user's default store - which is only used when the user hasn't previously logged in.

The change is to store every user's store when they login, and then match the username when setting the current store. If the user does not have a recent entry, then their default store is used.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
You'll need at least two users, with one of them having multiple stores available.
- Clear local storage: `localStorage.removeItem('@openmsupply-client/mru/credentials');`
- Login as user_a, see that they are assigned their default store
- logout, login as user_b, see that they are assigned their default store
- change the store (store_b), logout and login. You should be in store_b
- login as user_a: they'll be in user_a::default_store

etc..

Basically - the first time a user logs in, the store should be their default.
If a user changes stores, then logs out and in again, the store should be the most recently used store.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
