### PR TITLE
Improve debouncing

### DIFF
--- a/client/packages/common/src/hooks/useDebounce/index.ts
+++ b/client/packages/common/src/hooks/useDebounce/index.ts
@@ -1,2 +1,3 @@
 export * from './useDebouncedValue';
 export * from './useDebounceCallback';
+export * from './useDebouncedValueCallback';

--- a/client/packages/common/src/hooks/useDebounce/useDebounceCallback.ts
+++ b/client/packages/common/src/hooks/useDebounce/useDebounceCallback.ts
@@ -7,8 +7,7 @@ export const useDebounceCallback = <T extends (...args: any[]) => any>(
   depsArray: DependencyList,
   wait = 500
 ): ((...args: Parameters<T>) => Promise<ReturnType<T>>) => {
-  const memoizedCallback = useCallback(FnUtils.debounce(callback, wait), []);
-  const debounced = useCallback(memoizedCallback, depsArray);
+  const debounced = useCallback(FnUtils.debounce(callback, wait), depsArray);
 
   return debounced;
 };

--- a/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.test.tsx
+++ b/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { useDebouncedValueCallback } from './useDebouncedValueCallback';
+
+describe('useDebouncedValueCallback', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('returns a function which debounces consecutive calls', async () => {
+    // Setting up a simple value for incrementing and a function which is a closure
+    // over the value which will be incremented. The side effect makes this  somewhat flakey
+    // when creating tests, but allows us to access the real state (i) to compare against
+    // returned values from the callback to ensure they're the same.
+    let i = 0;
+    const func = () => {
+      i = i + 1;
+      return i;
+    };
+
+    const { result } = renderHook(() => {
+      const cb = useDebouncedValueCallback(func, [], 1000);
+
+      return cb;
+    });
+
+    result.current();
+    result.current();
+    result.current();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(i).toBe(1);
+  });
+
+  it('calls the function only once when re-rendered', async () => {
+    let value = '';
+    let deps = [''];
+
+    const func = (str: string) => {
+      value += str;
+    };
+
+    const { result, rerender } = renderHook(() => {
+      const cb = useDebouncedValueCallback(func, deps, 10);
+      return cb;
+    });
+
+    result.current('a');
+    deps = ['a'];
+    rerender();
+    act(() => {
+      jest.advanceTimersByTime(5);
+    });
+
+    result.current('b');
+    deps = ['b'];
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(5);
+    });
+
+    result.current('c');
+    deps = ['c'];
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+
+    expect(value).toBe('c');
+  });
+});

--- a/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
+++ b/client/packages/common/src/hooks/useDebounce/useDebouncedValueCallback.ts
@@ -1,0 +1,18 @@
+import { useCallback, DependencyList } from 'react';
+import { FnUtils } from '@common/utils';
+
+/**
+ * Executes a callback once only - after the deps have not changed for the specified wait time
+ * Warning: this memoizes the provided callback function
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useDebouncedValueCallback = <T extends (...args: any[]) => any>(
+  callback: T,
+  depsArray: DependencyList,
+  wait = 500
+): ((...args: Parameters<T>) => Promise<ReturnType<T>>) => {
+  const memoizedCallback = useCallback(FnUtils.debounce(callback, wait), []);
+  const debounced = useCallback(memoizedCallback, depsArray);
+
+  return debounced;
+};

--- a/client/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
+++ b/client/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { BasicTextInput } from '../TextInput';
 import { CloseIcon, SearchIcon } from '@common/icons';
-import { useDebounceCallback } from '@common/hooks';
+import { useDebouncedValueCallback } from '@common/hooks';
 import { InlineSpinner } from '../../loading';
 import { Box } from '@mui/material';
 import { IconButton } from '@common/components';
@@ -54,7 +54,7 @@ export const SearchBar: FC<SearchBarProps> = ({
     setBuffer(value);
   }, [value]);
 
-  const debouncedOnChange = useDebounceCallback(
+  const debouncedOnChange = useDebouncedValueCallback(
     value => {
       onChange(value);
       setLoading(false);

--- a/client/packages/system/src/Patient/Components/utils.ts
+++ b/client/packages/system/src/Patient/Components/utils.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { usePatient } from '../api';
-import { useDebounceCallback } from '@common/hooks';
+import { useDebouncedValueCallback } from '@common/hooks';
 
 export const searchPatient = () => {
   const [searchText, setSearchText] = useState('');
   const { mutate, isLoading, data, isSuccess } = usePatient.utils.search();
 
-  const debounced = useDebounceCallback(
+  const debounced = useDebouncedValueCallback(
     value => mutate({ nameOrCode: value }),
     [searchText],
     500


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2116 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
My previous fix to 'correct' the debounceCallback hook has caused trouble.
I've reverted that change, which fixes this issue. 
Then I've implemented a new hook, which debounces the callback function in a way that I would expect it to - so that the search functions can use it. The trouble with the original hook is that it is recreated when the dependencies change, which resulted in a search being called on every keystroke. The new hook will wait for a time to elapse and execute the callback once, with the final value. This is better when calling a search api.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Follow the steps in the issue, when changing values in stock lines for outbound shipments and prescriptions.
Then try to search for a patient in the create prescription modal. The search api endpoint should only be called once, after a small pause and not once per keystroke.

I've created a test which passes, but fails if you use the original hook.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2