### PR TITLE
Add (some) react-hooks/recommended lint rules + fixes

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   extends: [
     'plugin:jest-dom/recommended',
     'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
     'plugin:@typescript-eslint/recommended',
     'google',
     'prettier',
@@ -27,7 +28,7 @@ module.exports = {
   },
 
   settings: { react: { version: 'detect' } },
-  plugins: ['react', , '@typescript-eslint'],
+  plugins: ['react', '@typescript-eslint'],
   rules: {
     camelcase: ['error', { allow: ['_ONLY_FOR_TESTING'] }],
     'require-jsdoc': 'off',
@@ -48,5 +49,8 @@ module.exports = {
       'always',
       { markers: ['#', '/'], exceptions: ['-'] },
     ],
+    'react-hooks/exhaustive-deps': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
   },
+  ignorePatterns: ['**/operations.generated.ts', '**/types/schema.ts'],
 };

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,8 @@
     "electron:build": "lerna run --scope @openmsupply-client/electron make",
     "i18n-unused-display": "i18n-unused display-unused",
     "i18n-unused-remove": "i18n-unused remove-unused",
-    "i18n-missing": "i18n-unused display-missed"
+    "i18n-missing": "i18n-unused display-missed",
+    "eslint": "lerna run --scope @openmsupply-client/* --parallel eslint"
   },
   "workspaces": {
     "packages": [
@@ -81,6 +82,7 @@
     "eslint-plugin-jest-dom": "^5.0.1",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-storybook": "^0.6.11",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "i18n-unused": "^0.13.0",
     "jest": "^29.6.2",

--- a/client/packages/common/package.json
+++ b/client/packages/common/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "main": "./src/index.ts",
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -139,8 +139,3 @@ export const useFormatCurrency = (dp?: number) => {
   const { c } = useCurrency(dp);
   return (value: currency.Any) => c(value).format();
 };
-
-export const useCurrencyFormat = (value: currency.Any) => {
-  const { c } = useCurrency();
-  return c(value).format();
-};

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -85,7 +85,8 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const drawer = useDrawer();
 
   const selected = useSelectedNavMenuItem(to, !!end, drawer.isOpen);
-  const isSelectedParentItem = inactive && !!useMatch({ path: `${to}/*` });
+  const match = useMatch({ path: `${to}/*` });
+  const isSelectedParentItem = inactive && !!match;
   const showMenuSectionIcon = inactive && drawer.isOpen;
   const handleClick = () => {
     // reset the clicked nav path when navigating

--- a/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
+++ b/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
@@ -67,7 +67,7 @@ export const usePopover = ({
         right: e.clientX,
         width: 25,
         height: 25,
-      } as DOMRect);
+      }) as DOMRect;
 
     setAnchorElCallback.current?.({ getBoundingClientRect });
     isOpenCallback.current?.(true);
@@ -80,13 +80,12 @@ export const usePopover = ({
   const show = useDebounceCallback(showCallback, [], showDebounceDelay);
   const hide = useDebounceCallback(hideCallback, [], hideDebounceDelay);
 
+  const [internalAnchorEl, setInternalAnchorEl] =
+    useState<VirtualElement | null>(null);
+  const [internalIsOpen, internalSetOpen] = useState(false);
+
   const Popover: FC<Partial<PropsWithChildren<BasePopoverProps>>> =
     React.useCallback(props => {
-      const [internalAnchorEl, setInternalAnchorEl] =
-        useState<VirtualElement | null>(null);
-
-      const [internalIsOpen, internalSetOpen] = useState(false);
-
       isOpenCallback.current = internalSetOpen;
       setAnchorElCallback.current = setInternalAnchorEl;
 

--- a/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
+++ b/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
@@ -85,18 +85,21 @@ export const usePopover = ({
   const [internalIsOpen, internalSetOpen] = useState(false);
 
   const Popover: FC<Partial<PropsWithChildren<BasePopoverProps>>> =
-    React.useCallback(props => {
-      isOpenCallback.current = internalSetOpen;
-      setAnchorElCallback.current = setInternalAnchorEl;
+    React.useCallback(
+      props => {
+        isOpenCallback.current = internalSetOpen;
+        setAnchorElCallback.current = setInternalAnchorEl;
 
-      return (
-        <BasePopover
-          {...props}
-          anchorEl={internalAnchorEl}
-          isOpen={internalIsOpen}
-        />
-      );
-    }, []);
+        return (
+          <BasePopover
+            {...props}
+            anchorEl={internalAnchorEl}
+            isOpen={internalIsOpen}
+          />
+        );
+      },
+      [internalAnchorEl, internalIsOpen]
+    );
 
   return {
     Popover,

--- a/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
+++ b/client/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
@@ -80,26 +80,27 @@ export const usePopover = ({
   const show = useDebounceCallback(showCallback, [], showDebounceDelay);
   const hide = useDebounceCallback(hideCallback, [], hideDebounceDelay);
 
-  const [internalAnchorEl, setInternalAnchorEl] =
-    useState<VirtualElement | null>(null);
-  const [internalIsOpen, internalSetOpen] = useState(false);
+  const PopoverComponent: FC<
+    Partial<PropsWithChildren<BasePopoverProps>>
+  > = props => {
+    const [internalAnchorEl, setInternalAnchorEl] =
+      useState<VirtualElement | null>(null);
 
-  const Popover: FC<Partial<PropsWithChildren<BasePopoverProps>>> =
-    React.useCallback(
-      props => {
-        isOpenCallback.current = internalSetOpen;
-        setAnchorElCallback.current = setInternalAnchorEl;
+    const [internalIsOpen, internalSetOpen] = useState(false);
 
-        return (
-          <BasePopover
-            {...props}
-            anchorEl={internalAnchorEl}
-            isOpen={internalIsOpen}
-          />
-        );
-      },
-      [internalAnchorEl, internalIsOpen]
+    isOpenCallback.current = internalSetOpen;
+    setAnchorElCallback.current = setInternalAnchorEl;
+
+    return (
+      <BasePopover
+        {...props}
+        anchorEl={internalAnchorEl}
+        isOpen={internalIsOpen}
+      />
     );
+  };
+
+  const Popover = React.useCallback(PopoverComponent, []);
 
   return {
     Popover,

--- a/client/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/client/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -13,7 +13,7 @@ type RowExpandLabels = {
 };
 
 export const getRowExpandColumn = <
-  T extends RecordWithId & { canExpand?: boolean; lines?: T[] }
+  T extends RecordWithId & { canExpand?: boolean; lines?: T[] },
 >(
   labels?: RowExpandLabels
 ): ColumnDefinition<T> => ({
@@ -50,10 +50,10 @@ export const getRowExpandColumn = <
     ) : null;
   },
   Cell: ({ rowData }) => {
-    if (!rowData.canExpand && !((rowData?.lines?.length ?? 0) > 1)) return null;
-
     const t = useTranslation('common');
     const { toggleExpanded, isExpanded } = useExpanded(rowData.id);
+
+    if (!rowData.canExpand && !((rowData?.lines?.length ?? 0) > 1)) return null;
 
     return (
       <IconButton

--- a/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell/CurrencyCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/Cells/CurrencyCell/CurrencyCell.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography } from '@mui/material';
-import { useCurrencyFormat } from '@common/intl';
+import { useFormatCurrency } from '@common/intl';
 import { RecordWithId } from '@common/types';
 import { CellProps } from '../../../columns/types';
 
@@ -9,7 +9,8 @@ export const CurrencyCell = <T extends RecordWithId>({
   rowData,
 }: CellProps<T>) => {
   const currencyValue = column.accessor({ rowData }) as string;
-  const formattedCurrency = useCurrencyFormat(currencyValue);
+  const formatCurrency = useFormatCurrency();
+  const formattedCurrency = formatCurrency(currencyValue);
 
   return (
     <Typography

--- a/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -58,20 +58,14 @@ export const TableProvider = <T extends RecordWithId>({
 };
 
 export function useTableStore<T = TableStore>(
-  selector?: (state: TableStore) => T,
+  selectorFn?: (state: TableStore) => T,
   equalityFn?: (a: T, b: T) => boolean
 ): T {
   const store = useContext(tableContext);
   const storeWithoutSelector = useStore(store) as unknown as T;
-  const storeWithSelector = useStore(
-    store,
-    selector ?? ((_: TableStore) => storeWithoutSelector),
-    equalityFn
-  );
+  const selector = selectorFn ?? ((_: TableStore) => storeWithoutSelector);
 
-  if (!selector) return storeWithoutSelector;
-
-  return storeWithSelector;
+  return useStore(store, selector, equalityFn) as unknown as T;
 }
 
 const getRowState = (

--- a/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -61,12 +61,17 @@ export function useTableStore<T = TableStore>(
   selector?: (state: TableStore) => T,
   equalityFn?: (a: T, b: T) => boolean
 ): T {
-  if (!selector) return useStore(useContext(tableContext)) as unknown as T;
-
   const store = useContext(tableContext);
-  if (!equalityFn) return useStore(store, selector);
+  const storeWithoutSelector = useStore(store) as unknown as T;
+  const storeWithSelector = useStore(
+    store,
+    selector ?? ((_: TableStore) => storeWithoutSelector),
+    equalityFn
+  );
 
-  return useStore(store, selector, equalityFn);
+  if (!selector) return storeWithoutSelector;
+
+  return storeWithSelector;
 }
 
 const getRowState = (

--- a/client/packages/config/package.json
+++ b/client/packages/config/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "devDependencies": {},
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {}
 }

--- a/client/packages/dashboard/package.json
+++ b/client/packages/dashboard/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "devDependencies": {},
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",

--- a/client/packages/electron/package.json
+++ b/client/packages/electron/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "make": "node updateElectronVersion.js && yarn prettier --write package.json && electron-forge make"
+    "make": "node updateElectronVersion.js && yarn prettier --write package.json && electron-forge make",
+    "eslint": "eslint ./src"
   },
   "author": {
     "name": "mSupply Foundation"

--- a/client/packages/host/package.json
+++ b/client/packages/host/package.json
@@ -22,7 +22,8 @@
     "build": "webpack --env production",
     "build-stats": "webpack --env stats --env production",
     "serve": "serve dist -p 3003",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.0.5",

--- a/client/packages/host/src/components/AppBar/SectionIcon.tsx
+++ b/client/packages/host/src/components/AppBar/SectionIcon.tsx
@@ -45,7 +45,7 @@ const getIcon = (section?: AppRoute) => {
   }
 };
 
-const getSection = (): Section | undefined => {
+const useSection = (): Section | undefined => {
   const routes = [
     AppRoute.Catalogue,
     AppRoute.Distribution,
@@ -77,7 +77,7 @@ const getSection = (): Section | undefined => {
 
 export const SectionIcon: React.FC = () => {
   const t = useTranslation('app');
-  const section = getSection();
+  const section = useSection();
 
   return section?.icon ? (
     <Tooltip title={t(section?.titleKey)}>

--- a/client/packages/inventory/package.json
+++ b/client/packages/inventory/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "devDependencies": {},
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",

--- a/client/packages/invoices/package.json
+++ b/client/packages/invoices/package.json
@@ -8,7 +8,8 @@
     "find-up": "^6.3.0"
   },
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",

--- a/client/packages/invoices/src/InboundShipment/api/hooks/utils/useIsStatusChangeDisabled.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/utils/useIsStatusChangeDisabled.ts
@@ -1,10 +1,8 @@
 import { useInbound } from '../document/useInbound';
-import {
-    useIsInboundStatusChangeDisabled,
-  } from '../../../../utils';
+import { isInboundStatusChangeDisabled } from '../../../../utils';
 
 export const useIsStatusChangeDisabled = (): boolean => {
   const { data } = useInbound();
   if (!data) return true;
-  return useIsInboundStatusChangeDisabled(data);
+  return isInboundStatusChangeDisabled(data);
 };

--- a/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/AddFromScannerButton.tsx
@@ -29,8 +29,6 @@ export const AddFromScannerButtonComponent = ({
   const { error, warning } = useNotification();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  if (!isEnabled) return null;
-
   const handleScanResult = async (result: ScanResult) => {
     if (!!result.content) {
       const { content, gtin, batch } = result;
@@ -88,6 +86,8 @@ export const AddFromScannerButtonComponent = ({
     ],
     [isScanning]
   );
+
+  if (!isEnabled) return null;
 
   return (
     <Tooltip title={isConnected ? '' : t('error.scanner-not-connected')}>

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -1,5 +1,4 @@
 import {
-  useCurrencyFormat,
   useColumns,
   PositiveNumberCell,
   ColumnAlign,
@@ -7,6 +6,7 @@ import {
   CheckCell,
   CurrencyCell,
   Column,
+  useCurrency,
 } from '@openmsupply-client/common';
 import { DraftStockOutLine } from '../../../types';
 import { PackQuantityCell, StockOutLineFragment } from '../../../StockOut';
@@ -18,6 +18,7 @@ export const useOutboundLineEditColumns = ({
   onChange: (key: string, value: number, packSize: number) => void;
   unit: string;
 }) => {
+  const { c } = useCurrency();
   const columns = useColumns<DraftStockOutLine>(
     [
       [
@@ -45,7 +46,7 @@ export const useOutboundLineEditColumns = ({
         'sellPricePerPack',
         {
           Cell: CurrencyCell,
-          formatter: sellPrice => useCurrencyFormat(Number(sellPrice)),
+          formatter: sellPrice => c(Number(sellPrice)).format(),
           width: 120,
         },
       ],

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
@@ -23,7 +23,7 @@ export const useServiceLineColumns = (
   setter: (patch: RecordPatch<DraftStockOutLine>) => void
 ) => {
   const t = useTranslation('distribution');
-  const c = useFormatCurrency();
+  const formatCurrency = useFormatCurrency();
   return useColumns<DraftStockOutLine>([
     {
       key: 'serviceItemName',
@@ -69,7 +69,7 @@ export const useServiceLineColumns = (
       label: 'label.total',
       align: ColumnAlign.Right,
       width: 75,
-      accessor: ({ rowData }) => c(rowData?.totalAfterTax),
+      accessor: ({ rowData }) => formatCurrency(rowData?.totalAfterTax),
     },
     {
       key: 'isDeleted',

--- a/client/packages/invoices/src/utils.ts
+++ b/client/packages/invoices/src/utils.ts
@@ -156,7 +156,7 @@ export const isInboundListItemDisabled = (
 export const isInboundPlaceholderRow = (row: InboundLineFragment): boolean =>
   row.type === InvoiceLineNodeType.StockIn && row.numberOfPacks === 0;
 
-export const useIsInboundStatusChangeDisabled = (
+export const isInboundStatusChangeDisabled = (
   inbound: InboundFragment
 ): boolean => {
   if (inbound.onHold) return true;

--- a/client/packages/programs/package.json
+++ b/client/packages/programs/package.json
@@ -4,7 +4,8 @@
   "main": "./src/index.ts",
   "private": true,
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",
@@ -19,6 +20,5 @@
     "react-diff-viewer": "3.1.1",
     "zod": "3.21.4"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/client/packages/requisitions/package.json
+++ b/client/packages/requisitions/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "devDependencies": {},
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -117,7 +117,7 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
       ? Math.round((100 * targetQuantity) / availableStockOnHand)
       : 100;
 
-  const control = useMemo(
+  const DistributionBars = useMemo(
     () => (
       <>
         <Typography variant="body1" fontWeight={700} fontSize={12}>

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -168,10 +168,14 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
     [availableStockOnHand, averageMonthlyConsumption, suggestedQuantity]
   );
 
-  if (averageMonthlyConsumption === 0) return <CalculationError isAmcZero />;
-  if (suggestedQuantity === 0 && availableStockOnHand === 0)
-    return <CalculationError isSohAndQtyZero />;
-  return control;
+  const isAmcZero = averageMonthlyConsumption === 0;
+  const isSohAndQtyZero = suggestedQuantity === 0 && availableStockOnHand === 0;
+
+  return isAmcZero || isSohAndQtyZero ? (
+    <CalculationError isAmcZero={isAmcZero} isSohAndQtyZero={isSohAndQtyZero} />
+  ) : (
+    DistributionBars
+  );
 };
 
 export const StockDistribution: React.FC<StockDistributionProps> = ({

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -108,21 +108,16 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
   averageMonthlyConsumption = 0,
   suggestedQuantity = 0,
 }) => {
-  if (averageMonthlyConsumption === 0) return <CalculationError isAmcZero />;
-
   const { maxMonthsOfStock } = useRequest.document.fields('maxMonthsOfStock');
   const targetQuantity = maxMonthsOfStock * averageMonthlyConsumption;
   const t = useTranslation('replenishment');
-
-  if (suggestedQuantity === 0 && availableStockOnHand === 0)
-    return <CalculationError isSohAndQtyZero />;
 
   const monthlyConsumptionWidth =
     availableStockOnHand > targetQuantity
       ? Math.round((100 * targetQuantity) / availableStockOnHand)
       : 100;
 
-  return useMemo(
+  const control = useMemo(
     () => (
       <>
         <Typography variant="body1" fontWeight={700} fontSize={12}>
@@ -172,6 +167,11 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
     ),
     [availableStockOnHand, averageMonthlyConsumption, suggestedQuantity]
   );
+
+  if (averageMonthlyConsumption === 0) return <CalculationError isAmcZero />;
+  if (suggestedQuantity === 0 && availableStockOnHand === 0)
+    return <CalculationError isSohAndQtyZero />;
+  return control;
 };
 
 export const StockDistribution: React.FC<StockDistributionProps> = ({

--- a/client/packages/system/package.json
+++ b/client/packages/system/package.json
@@ -8,7 +8,8 @@
     "@bcyesil/capacitor-plugin-printer": "^0.0.3"
   },
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "eslint": "eslint ./src"
   },
   "dependencies": {
     "@openmsupply-client/common": "^0.0.1",

--- a/client/packages/system/src/Encounter/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Encounter/DetailView/DetailView.tsx
@@ -22,7 +22,7 @@ import { Toolbar } from './Toolbar';
 import { Footer } from './Footer';
 import { SidePanel } from './SidePanel';
 import { AppBarButtons } from './AppBarButtons';
-import { useLogicalStatus } from '../utils';
+import { getLogicalStatus } from '../utils';
 
 export const DetailView: FC = () => {
   const t = useTranslation('dispensary');
@@ -95,15 +95,16 @@ export const DetailView: FC = () => {
               encounter.patient.lastName
             )}
           </Breadcrumb>
-          <span>{` / ${
-            encounter.document.documentRegistry?.name
-          } - ${dateFormat.localisedDate(encounter.startDatetime)}`}</span>
+          <span>{` / ${encounter.document.documentRegistry
+            ?.name} - ${dateFormat.localisedDate(
+            encounter.startDatetime
+          )}`}</span>
         </span>
       );
 
       if (encounter.status === EncounterNodeStatus.Pending) {
         const datetime = new Date(encounter.startDatetime);
-        const status = useLogicalStatus(datetime, t);
+        const status = getLogicalStatus(datetime, t);
         setLogicalStatus(status);
       }
     }

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -13,16 +13,16 @@ import {
   EncounterRowFragment,
   useDocumentRegistry,
 } from '@openmsupply-client/programs';
-import { useLogicalStatus } from '../utils';
+import { getLogicalStatus } from '../utils';
 import { ChipTableCell } from '../../Patient';
 
 interface useEncounterListColumnsProps {
-  onChangeSortBy: (column: Column<any>) => void;
+  onChangeSortBy: (column: Column<EncounterRowFragment>) => void;
   sortBy: SortBy<EncounterRowFragment>;
   includePatient?: boolean;
 }
 
-export const encounterAdditionalInfoAccessor: ColumnDataAccessor<
+export const useEncounterAdditionalInfoAccessor: ColumnDataAccessor<
   EncounterRowFragment,
   string[]
 > = ({ rowData }): string[] => {
@@ -35,7 +35,7 @@ export const encounterAdditionalInfoAccessor: ColumnDataAccessor<
 
   if (rowData?.status === EncounterNodeStatus.Pending) {
     const startDatetime = new Date(rowData?.startDatetime);
-    const status = useLogicalStatus(startDatetime, t);
+    const status = getLogicalStatus(startDatetime, t);
     if (status) {
       additionalInfo.push(status);
     }
@@ -107,7 +107,7 @@ export const useEncounterListColumns = ({
     label: 'label.additional-info',
     key: 'events',
     sortable: false,
-    accessor: encounterAdditionalInfoAccessor,
+    accessor: useEncounterAdditionalInfoAccessor,
     Cell: ChipTableCell,
     minWidth: 400,
   });

--- a/client/packages/system/src/Encounter/utils.ts
+++ b/client/packages/system/src/Encounter/utils.ts
@@ -45,7 +45,7 @@ export const useEncounterFragmentWithStatus = (
   );
 };
 
-export const useLogicalStatus = (
+export const getLogicalStatus = (
   startDatetime: Date,
   t: ReturnType<typeof useTranslation>
 ): string | undefined => {

--- a/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchInput/PatientSearchInput.tsx
@@ -6,7 +6,7 @@ import {
   filterByNameAndCode,
 } from '../../utils';
 import { getPatientOptionRenderer } from '../PatientOptionRenderer';
-import { searchPatient } from '../utils';
+import { useSearchPatient } from '../utils';
 
 export const PatientSearchInput: FC<NameSearchInputProps> = ({
   onChange,
@@ -15,7 +15,7 @@ export const PatientSearchInput: FC<NameSearchInputProps> = ({
   disabled = false,
 }) => {
   const PatientOptionRenderer = getPatientOptionRenderer();
-  const { isLoading, patients, search } = searchPatient();
+  const { isLoading, patients, search } = useSearchPatient();
 
   return (
     <Autocomplete

--- a/client/packages/system/src/Patient/Components/PatientSearchModal/PatientSearchModal.tsx
+++ b/client/packages/system/src/Patient/Components/PatientSearchModal/PatientSearchModal.tsx
@@ -17,7 +17,7 @@ import {
   PatientSearchModalProps,
   SearchInputPatient,
 } from '../../utils';
-import { searchPatient } from '../utils';
+import { useSearchPatient } from '../utils';
 
 const PatientSearchComponent: FC<PatientSearchModalProps> = ({
   open,
@@ -28,7 +28,7 @@ const PatientSearchComponent: FC<PatientSearchModalProps> = ({
   const PatientOptionRenderer = getPatientOptionRenderer();
   const { height } = useWindowDimensions();
   const { isLoading, patients, search, totalCount, isSuccess } =
-    searchPatient();
+    useSearchPatient();
 
   const modalHeight = height * 0.7;
   const handleClose = () => {

--- a/client/packages/system/src/Patient/Components/utils.ts
+++ b/client/packages/system/src/Patient/Components/utils.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { usePatient } from '../api';
 import { useDebounceCallback } from '@common/hooks';
 
-export const searchPatient = () => {
+export const useSearchPatient = () => {
   const [searchText, setSearchText] = useState('');
   const { mutate, isLoading, data, isSuccess } = usePatient.utils.search();
 

--- a/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
@@ -34,12 +34,10 @@ const useDraftStockLine = (
   const { mutate, isLoading } = useStock.line.update();
 
   const onUpdate = (patch: Partial<StockLineRowFragment>) => {
-    if (stockLine) setStockLine({ ...stockLine, ...patch });
+    setStockLine({ ...stockLine, ...patch });
   };
 
-  const onSave = async () => {
-    if (stockLine) mutate(stockLine);
-  };
+  const onSave = async () => mutate(stockLine);
 
   return {
     draft: stockLine,

--- a/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
@@ -17,26 +17,20 @@ interface StockLineEditModalProps {
   isOpen: boolean;
   onClose: () => void;
 
-  stockLine: StockLineRowFragment | null;
+  stockLine: StockLineRowFragment;
 }
 
 interface UseDraftStockLineControl {
-  draft: StockLineRowFragment | null;
+  draft: StockLineRowFragment;
   onUpdate: (patch: Partial<StockLineRowFragment>) => void;
   onSave: () => Promise<void>;
   isLoading: boolean;
 }
 
 const useDraftStockLine = (
-  seed: StockLineRowFragment | null
+  seed: StockLineRowFragment
 ): UseDraftStockLineControl => {
-  const [stockLine, setStockLine] = useState<StockLineRowFragment | null>(() =>
-    seed
-      ? {
-          ...seed,
-        }
-      : null
-  );
+  const [stockLine, setStockLine] = useState<StockLineRowFragment>(seed);
   const { mutate, isLoading } = useStock.line.update();
 
   const onUpdate = (patch: Partial<StockLineRowFragment>) => {
@@ -68,8 +62,6 @@ export const StockLineEditModal: FC<StockLineEditModalProps> = ({
   });
 
   const { draft, onUpdate, onSave } = useDraftStockLine(stockLine);
-
-  if (!stockLine || !draft) return null;
 
   const tabs = [
     {

--- a/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
@@ -30,7 +30,7 @@ interface UseDraftStockLineControl {
 const useDraftStockLine = (
   seed: StockLineRowFragment
 ): UseDraftStockLineControl => {
-  const [stockLine, setStockLine] = useState<StockLineRowFragment>(seed);
+  const [stockLine, setStockLine] = useState<StockLineRowFragment>({ ...seed });
   const { mutate, isLoading } = useStock.line.update();
 
   const onUpdate = (patch: Partial<StockLineRowFragment>) => {

--- a/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineEditModal.tsx
@@ -21,25 +21,31 @@ interface StockLineEditModalProps {
 }
 
 interface UseDraftStockLineControl {
-  draft: StockLineRowFragment;
+  draft: StockLineRowFragment | null;
   onUpdate: (patch: Partial<StockLineRowFragment>) => void;
   onSave: () => Promise<void>;
   isLoading: boolean;
 }
 
 const useDraftStockLine = (
-  seed: StockLineRowFragment
+  seed: StockLineRowFragment | null
 ): UseDraftStockLineControl => {
-  const [stockLine, setStockLine] = useState<StockLineRowFragment>(() => ({
-    ...seed,
-  }));
+  const [stockLine, setStockLine] = useState<StockLineRowFragment | null>(() =>
+    seed
+      ? {
+          ...seed,
+        }
+      : null
+  );
   const { mutate, isLoading } = useStock.line.update();
 
   const onUpdate = (patch: Partial<StockLineRowFragment>) => {
-    setStockLine({ ...stockLine, ...patch });
+    if (stockLine) setStockLine({ ...stockLine, ...patch });
   };
 
-  const onSave = async () => mutate(stockLine);
+  const onSave = async () => {
+    if (stockLine) mutate(stockLine);
+  };
 
   return {
     draft: stockLine,
@@ -61,9 +67,9 @@ export const StockLineEditModal: FC<StockLineEditModalProps> = ({
     message: t('messages.confirm-save-stock-line'),
   });
 
-  if (!stockLine) return null;
-
   const { draft, onUpdate, onSave } = useDraftStockLine(stockLine);
+
+  if (!stockLine || !draft) return null;
 
   const tabs = [
     {

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -132,7 +132,7 @@ const StockListComponent: FC = () => {
           stockLine={data?.nodes.find(({ id }) => id === repackId) ?? null}
         />
       )}
-      {isOpen && (
+      {isOpen && entity && (
         <StockLineEditModal
           isOpen={isOpen}
           onClose={onClose}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8559,6 +8559,11 @@ eslint-plugin-jest-dom@^5.0.1:
     "@babel/runtime" "^7.16.3"
     requireindex "^1.2.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.27.1:
   version "7.33.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.33.0.tgz#6c356fb0862fec2cd1b04426c669ea746e9b6eb3"


### PR DESCRIPTION
- Enables some react-hooks eslint rules
- Add eslinit script to check all packages
- Fix `react-hooks/rules-of-hooks`, i.e. a hook must always be called in same order, no conditional calls

Some issues have been fixed by making some hooks helper method and some methods hooks...