### PR TITLE
Fix program enrolment for a patient that doesn't has a document

### DIFF
--- a/server/service/src/programs/program_enrolment/upsert.rs
+++ b/server/service/src/programs/program_enrolment/upsert.rs
@@ -1,13 +1,13 @@
 use chrono::Utc;
 use repository::{
-    Document, DocumentFilter, DocumentRegistry, DocumentRegistryCategory, DocumentRegistryFilter,
-    DocumentRegistryRepository, DocumentRepository, DocumentStatus, EqualFilter, Pagination,
-    ProgramFilter, ProgramRepository, ProgramRow, RepositoryError, StringFilter, TransactionError,
+    Document, DocumentRegistry, DocumentRegistryCategory, DocumentRegistryFilter,
+    DocumentRegistryRepository, DocumentStatus, EqualFilter, PatientFilter, PatientRepository,
+    ProgramFilter, ProgramRepository, ProgramRow, RepositoryError, TransactionError,
 };
 
 use crate::{
     document::{document_service::DocumentInsertError, is_latest_doc, raw_document::RawDocument},
-    programs::patient::{main_patient_doc_name, patient_doc_name},
+    programs::patient::patient_doc_name,
     service_provider::{ServiceContext, ServiceProvider},
 };
 
@@ -133,15 +133,13 @@ fn validate_patient_exists(
     ctx: &ServiceContext,
     patient_id: &str,
 ) -> Result<bool, RepositoryError> {
-    let doc_name = main_patient_doc_name(patient_id);
-    let document = DocumentRepository::new(&ctx.connection)
-        .query(
-            Pagination::one(),
-            Some(DocumentFilter::new().name(StringFilter::equal_to(&doc_name))),
+    let patient = PatientRepository::new(&ctx.connection)
+        .query_by_filter(
+            PatientFilter::new().id(EqualFilter::equal_to(patient_id)),
             None,
         )?
         .pop();
-    Ok(document.is_some())
+    Ok(patient.is_some())
 }
 
 fn validate_program_not_exists(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Related to #2023

While doing #2023 I noticed that you get an error when enrolling a mSupply patient without a document. This PR checks if the patient exists and not if the patient document exists. For example, enrolling a patient from the Harry P dataset will now work without first editing the patient details.