### PR TITLE
Exclude expired when counting expiring stock

### DIFF
--- a/server/graphql/general/src/queries/stock_counts.rs
+++ b/server/graphql/general/src/queries/stock_counts.rs
@@ -31,8 +31,9 @@ impl StockCounts {
         let date = Utc::now().with_timezone(&self.timezone_offset).date_naive()
             + Duration::days(days_till_expired as i64);
         let expired = self.expired(ctx).await?;
-
-        Ok(service.count_expired_stock(&service_ctx, &self.store_id, date)? - expired)
+        let expiring = service.count_expired_stock(&service_ctx, &self.store_id, date)? - expired;
+        // I don't see how it is possible that expired is greater than expiring.. if it happened it would look daft though
+        Ok(std::cmp::max(0, expiring))
     }
 }
 

--- a/server/graphql/general/src/queries/stock_counts.rs
+++ b/server/graphql/general/src/queries/stock_counts.rs
@@ -30,7 +30,9 @@ impl StockCounts {
         let days_till_expired = self.days_till_expired.unwrap_or(7);
         let date = Utc::now().with_timezone(&self.timezone_offset).date_naive()
             + Duration::days(days_till_expired as i64);
-        Ok(service.count_expired_stock(&service_ctx, &self.store_id, date)?)
+        let expired = self.expired(ctx).await?;
+
+        Ok(service.count_expired_stock(&service_ctx, &self.store_id, date)? - expired)
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2123 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The `expiring_soon` count is including stock which is already expired, though the wording change on the dashboard says that the stock is expiring in the next month.


Have reduced the expiring count by the count of expired stock, giving this:

<img width="248" alt="image" src="https://github.com/openmsupply/open-msupply/assets/9192912/b37453f6-fb28-4edf-9032-5d5df045834c">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2