### PR TITLE
Display numerical value within value bar component

### DIFF
--- a/client/packages/common/src/styles/theme.ts
+++ b/client/packages/common/src/styles/theme.ts
@@ -161,7 +161,7 @@ export const themeOptions = {
       pale: '#ccddff',
     },
     border: '#e4e4eb',
-    primary: { main: '#e95c30', light: '#ed7d59', dark: '#c43c11' },
+    primary: { main: '#e95c30', light: '#ed7d59', dark: '#c43c11', contrastText: '#fff' },
     secondary: { main: '#3e7bfa', light: '#5b8def', dark: '#3568d4' },
     background: {
       drawer: '#f2f2f5',

--- a/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
+++ b/client/packages/common/src/ui/components/charts/ValueBar/ValueBar.tsx
@@ -36,7 +36,23 @@ export const ValueBar: FC<ValueBarProps> = ({
       {startDivider ? <Divider /> : null}
       <Tooltip title={`${label}: ${formatNumber.round(value)}`} placement="top">
         <Box flexBasis={`${flexBasis}%`} flexGrow={1}>
-          <Box sx={{ backgroundColor: colour, height: '20px' }} />
+          <Box sx={{ backgroundColor: colour, height: '20px' }}>
+            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
+              <Typography
+                fontSize={12}
+                sx={{
+                  color: 'primary.contrastText',
+                  flex: 1,
+                  justifyContent: 'center',
+                  display: 'flex',
+                  fontWeight: 'bold',
+                }}
+                component="div"
+              >
+                {formatNumber.round(value)}
+              </Typography>
+            ) : null}
+          </Box>
           <Box
             style={{
               textAlign: 'end',
@@ -51,9 +67,6 @@ export const ValueBar: FC<ValueBarProps> = ({
               >
                 {label}
               </Typography>
-            ) : null}
-            {flexBasis > MIN_FLEX_BASIS_TO_SHOW_VALUE ? (
-              <Typography fontSize={12}>{formatNumber.round(value)}</Typography>
             ) : null}
           </Box>
         </Box>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1572 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
I've moved the numerical value to be within the bar to prevent the overlap. 

Given this starting point:

<img width="1073" alt="Screenshot 2023-08-28 at 9 20 55 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/e16ae954-54fe-4ebd-a242-b9fea2c8566e">

The bar now looks like this:

<img width="1059" alt="Screenshot 2023-08-28 at 9 29 57 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/4720b197-8cd5-46e3-bc1b-30b1f55a51f5">

<img width="241" alt="Screenshot 2023-08-28 at 9 34 52 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/a251098b-e2b2-414f-b7ce-7e4e69dfc348">

<img width="153" alt="Screenshot 2023-08-28 at 9 35 13 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/c7c30413-3337-4534-b77a-016bcf82ff8d">

(note that the grey bar has the numerical value showing, the screenshot is clipped tho)

<img width="999" alt="Screenshot 2023-08-28 at 9 39 23 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/4c7be634-379d-4c3c-9252-acd737a0659e">

With the tooltip still available for further detail:

<img width="251" alt="Screenshot 2023-08-28 at 9 34 32 AM" src="https://github.com/openmsupply/open-msupply/assets/9192912/fb93d031-f0ae-43c5-9b3d-295fee3f064b">

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2