### PR TITLE
Use pagination from useUrlQueryParams

### DIFF
--- a/client/packages/system/src/Encounter/ListView/ListView.tsx
+++ b/client/packages/system/src/Encounter/ListView/ListView.tsx
@@ -21,17 +21,16 @@ const EncounterListComponent: FC = () => {
     updateSortQuery,
     updatePaginationQuery,
     queryParams: { sortBy, page, first, offset },
-  } = useUrlQueryParams();
-  const { queryParams } = useUrlQueryParams({
+  } = useUrlQueryParams({
     initialSort: {
       key: EncounterSortFieldInput.StartDatetime,
       dir: 'desc',
     },
   });
   const { data, isError, isLoading } = useEncounter.document.list({
-    ...queryParams,
+    pagination: { first, offset },
+    sortBy,
   });
-  const pagination = { page, first, offset };
   const navigate = useNavigate();
   const columns = useEncounterListColumns({
     onChangeSortBy: updateSortQuery,
@@ -44,7 +43,7 @@ const EncounterListComponent: FC = () => {
   return (
     <DataTable
       id="name-list"
-      pagination={{ ...pagination, total: data?.totalCount }}
+      pagination={{ page, first, offset, total: data?.totalCount }}
       onChangePage={updatePaginationQuery}
       columns={columns}
       data={dataWithStatus}

--- a/client/packages/system/src/Patient/Encounter/ListView.tsx
+++ b/client/packages/system/src/Patient/Encounter/ListView.tsx
@@ -23,16 +23,18 @@ import { usePatient } from '../api';
 const EncounterListComponent: FC = () => {
   const {
     sort: { sortBy, onChangeSortBy },
-    pagination: { page, first, offset, onChangePage },
   } = useQueryParamsStore();
 
-  const { queryParams } = useUrlQueryParams();
+  const {
+    queryParams: { page, first, offset, filterBy },
+    updatePaginationQuery,
+  } = useUrlQueryParams();
 
   const patientId = usePatient.utils.id();
   const { data, isError, isLoading } = useEncounter.document.list({
-    ...queryParams,
+    pagination: { first, offset },
     // enforce filtering by patient id
-    filterBy: { ...queryParams.filterBy, patientId: { equalTo: patientId } },
+    filterBy: { ...filterBy, patientId: { equalTo: patientId } },
     sortBy: {
       key: sortBy.key as EncounterSortFieldInput,
       isDesc: sortBy.isDesc,
@@ -41,7 +43,6 @@ const EncounterListComponent: FC = () => {
   });
   const dataWithStatus: EncounterFragmentWithStatus[] | undefined =
     useEncounterFragmentWithStatus(data?.nodes);
-  const pagination = { page, first, offset };
   const navigate = useNavigate();
 
   const columns = useEncounterListColumns({ onChangeSortBy, sortBy });
@@ -49,8 +50,8 @@ const EncounterListComponent: FC = () => {
   return (
     <DataTable
       id="encounter-list"
-      pagination={{ ...pagination, total: data?.totalCount }}
-      onChangePage={onChangePage}
+      pagination={{ page, first, offset, total: data?.totalCount }}
+      onChangePage={updatePaginationQuery}
       columns={columns}
       data={dataWithStatus}
       isLoading={isLoading}

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -38,17 +38,20 @@ const programAdditionalInfoAccessor: ColumnDataAccessor<
 
 const ProgramListComponent: FC = () => {
   const {
-    pagination: { page, first, offset, onChangePage },
+    sort: { sortBy, onChangeSortBy },
   } = useQueryParamsStore();
 
-  const { queryParams, updateSortQuery } = useUrlQueryParams();
+  const {
+    queryParams: { page, first, offset },
+    updatePaginationQuery,
+  } = useUrlQueryParams();
 
   const patientId = usePatient.utils.id();
 
   const { data, isError, isLoading } = useProgramEnrolments.document.list({
     sortBy: {
-      key: queryParams.sortBy.key as ProgramEnrolmentSortFieldInput,
-      isDesc: queryParams.sortBy.isDesc,
+      key: sortBy.key as ProgramEnrolmentSortFieldInput,
+      isDesc: sortBy.isDesc,
     },
     filterBy: { patientId: { equalTo: patientId } },
   });
@@ -92,17 +95,17 @@ const ProgramListComponent: FC = () => {
       },
     ],
     {
-      sortBy: queryParams.sortBy,
-      onChangeSortBy: updateSortQuery,
+      sortBy,
+      onChangeSortBy,
     },
-    [queryParams.sortBy, updateSortQuery]
+    [sortBy, onChangeSortBy]
   );
 
   return (
     <DataTable
       id="program-enrolment-list"
       pagination={{ ...pagination, total: data?.totalCount }}
-      onChangePage={onChangePage}
+      onChangePage={updatePaginationQuery}
       columns={columns}
       data={data?.nodes}
       isLoading={isLoading}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2144

Uses the pagination from useUrlQueryParams for encounter and program enrolment lists.

Testing:
- pagination, filter, and sort works for both encounter lists and the program enrolment list