### PR TITLE
Add drop down unit variant selector

### DIFF
--- a/client/packages/common/src/utils/arrays/ArrayUtils.ts
+++ b/client/packages/common/src/utils/arrays/ArrayUtils.ts
@@ -1,6 +1,7 @@
 import { RecordPatch, RecordWithId } from '@common/types';
 import groupBy from 'lodash/groupBy';
 import uniqBy from 'lodash/uniqBy';
+import keyBy from 'lodash/keyBy';
 
 export const ArrayUtils = {
   ifTheSameElseDefault: <T, K extends keyof T, J>(
@@ -47,4 +48,5 @@ export const ArrayUtils = {
     }),
   groupBy,
   uniqBy,
+  keyBy,
 };

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
@@ -6,7 +6,7 @@ import {
 } from '@openmsupply-client/common';
 import { useUnitVariant } from '../../context';
 
-// Adjust pack size
+// Adjust quantity to reflect selected unit variant
 export const getPackUnitQuantityCell =
   <T extends RecordWithId>({
     getItemId,

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import {
+  RecordWithId,
+  CellProps,
+  InnerBasicCell,
+} from '@openmsupply-client/common';
+import { useUnitVariant } from '../../context';
+
+// Adjust pack size
+export const getPackUnitQuantityCell =
+  <T extends RecordWithId>({
+    getItemId,
+    getQuantity,
+  }: {
+    getItemId: (row: T) => string;
+    getQuantity: (row: T) => number;
+  }) =>
+  ({ isError, rowData }: CellProps<T>): ReactElement => {
+    const { numberOfPacksFromQuantity } = useUnitVariant(getItemId(rowData));
+
+    const quantity = getQuantity(rowData);
+    const packQuantity = numberOfPacksFromQuantity(quantity);
+
+    return <InnerBasicCell isError={isError} value={String(packQuantity)} />;
+  };

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -7,7 +7,7 @@ import {
 } from '@openmsupply-client/common';
 import { useUnitVariant } from '../../context';
 
-// Adjust pack size
+// Drop down selector for unit variant
 export const getPackUnitSelectCell =
   <T extends RecordWithId>({
     getItemId,
@@ -20,7 +20,6 @@ export const getPackUnitSelectCell =
     const { variantsControll } = useUnitVariant(getItemId(rowData));
 
     if (!variantsControll) {
-      // TODO should do default if not units ? (check what happens)
       return <InnerBasicCell isError={isError} value={getUnitName(rowData)} />;
     }
 

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -29,12 +29,10 @@ export const getPackUnitSelectCell =
       <Select
         options={variants.map(v => ({ label: v.shortName, value: v.id }))}
         value={activeVariant.id}
-        onClick={e => {
-          e.stopPropagation();
-        }}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          setUserSelectedVariant(e.target.value);
-        }}
+        onClick={e => e.stopPropagation()}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setUserSelectedVariant(e.target.value)
+        }
       />
     );
   };

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement } from 'react';
+import {
+  RecordWithId,
+  CellProps,
+  InnerBasicCell,
+  Select,
+} from '@openmsupply-client/common';
+import { useUnitVariant } from '../../context';
+
+// Adjust pack size
+export const getPackUnitSelectCell =
+  <T extends RecordWithId>({
+    getItemId,
+    getUnitName,
+  }: {
+    getItemId: (row: T) => string;
+    getUnitName: (row: T) => string;
+  }) =>
+  ({ isError, rowData }: CellProps<T>): ReactElement => {
+    const { variantsControll } = useUnitVariant(getItemId(rowData));
+
+    if (!variantsControll) {
+      // TODO should do default if not units ? (check what happens)
+      return <InnerBasicCell isError={isError} value={getUnitName(rowData)} />;
+    }
+
+    const { variants, activeVariant, setUserSelectedVariant } =
+      variantsControll;
+
+    console.log(activeVariant);
+    return (
+      <Select
+        options={variants.map(v => ({ label: v.shortName, value: v.id }))}
+        value={activeVariant.id}
+        onClick={e => {
+          e.stopPropagation();
+        }}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setUserSelectedVariant(e.target.value);
+        }}
+      />
+    );
+  };

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -26,7 +26,6 @@ export const getPackUnitSelectCell =
     const { variants, activeVariant, setUserSelectedVariant } =
       variantsControll;
 
-    console.log(activeVariant);
     return (
       <Select
         options={variants.map(v => ({ label: v.shortName, value: v.id }))}

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -17,14 +17,13 @@ export const getPackUnitSelectCell =
     getUnitName: (row: T) => string;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
-    const { variantsControll } = useUnitVariant(getItemId(rowData));
+    const { variantsControl } = useUnitVariant(getItemId(rowData));
 
-    if (!variantsControll) {
+    if (!variantsControl) {
       return <InnerBasicCell isError={isError} value={getUnitName(rowData)} />;
     }
 
-    const { variants, activeVariant, setUserSelectedVariant } =
-      variantsControll;
+    const { variants, activeVariant, setUserSelectedVariant } = variantsControl;
 
     return (
       <Select

--- a/client/packages/system/src/Item/Components/ItemVariant/index.ts
+++ b/client/packages/system/src/Item/Components/ItemVariant/index.ts
@@ -1,1 +1,3 @@
 export * from './PackUnitCell';
+export * from './PackUnitSelectCell';
+export * from './PackUnitQuantityCell';

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -55,7 +55,7 @@ const ItemListComponent: FC = () => {
         {
           Cell: getPackUnitQuantityCell({
             getItemId: r => r.id,
-            getQuantity: r => r.stats.availableStockOnHand,
+            getQuantity: r => NumUtils.round(r.stats.availableStockOnHand),
           }),
           label: 'label.soh',
           description: 'description.soh',

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -9,10 +9,15 @@ import {
   useTranslation,
   useUrlQueryParams,
   ColumnAlign,
-  useFormatNumber,
+  NumUtils,
 } from '@openmsupply-client/common';
-import { useItems, ItemRowFragment } from '../api';
+import { useItems, ItemsWithStatsFragment } from '../api';
 import { Toolbar } from './Toolbar';
+import {
+  getPackUnitQuantityCell,
+  getPackUnitSelectCell,
+} from '../Components/ItemVariant';
+import { useInitUnitStore } from '../context';
 // import { getItemVariantInputColumn } from '../Components/ItemVariant';
 
 const ItemListComponent: FC = () => {
@@ -25,30 +30,33 @@ const ItemListComponent: FC = () => {
     initialSort: { key: 'name', dir: 'asc' },
     filterKey: 'codeOrName',
   });
+  // TODO this is not the right place for it, see comment in method
+  useInitUnitStore();
   const { data, isError, isLoading } = useItems();
   const pagination = { page, first, offset };
   const navigate = useNavigate();
   const t = useTranslation('catalogue');
-  const formatNumber = useFormatNumber();
 
-  type ItemWithStats = ItemRowFragment & {
-    stats: {
-      averageMonthlyConsumption?: number | null;
-      availableStockOnHand?: number | null;
-      availableMonthsOfStockOnHand?: number | null;
-    };
-  };
-
-  const columns = useColumns<ItemWithStats>(
+  const columns = useColumns<ItemsWithStatsFragment>(
     [
       'code',
       'name',
-      // getItemVariantInputColumn(),
+      {
+        key: 'packUnit',
+        label: 'label.pack-unit',
+        align: ColumnAlign.Right,
+        Cell: getPackUnitSelectCell({
+          getItemId: r => r.id,
+          getUnitName: r => r.unitName || '',
+        }),
+      },
       [
         'stockOnHand',
         {
-          accessor: ({ rowData }) =>
-            formatNumber.round(rowData.stats.availableStockOnHand ?? 0),
+          Cell: getPackUnitQuantityCell({
+            getItemId: r => r.id,
+            getQuantity: r => r.stats.availableStockOnHand,
+          }),
           label: 'label.soh',
           description: 'description.soh',
           sortable: false,
@@ -57,18 +65,21 @@ const ItemListComponent: FC = () => {
       [
         'monthlyConsumption',
         {
-          accessor: ({ rowData }) =>
-            formatNumber.round(rowData.stats.averageMonthlyConsumption ?? 0, 2),
+          Cell: getPackUnitQuantityCell({
+            getItemId: r => r.id,
+            getQuantity: r =>
+              NumUtils.round(r.stats.averageMonthlyConsumption, 2),
+          }),
           align: ColumnAlign.Right,
           sortable: false,
         },
       ],
       {
-        accessor: ({ rowData }) =>
-          formatNumber.round(
-            rowData.stats.availableMonthsOfStockOnHand ?? 0,
-            2
-          ),
+        Cell: getPackUnitQuantityCell({
+          getItemId: r => r.id,
+          getQuantity: r =>
+            NumUtils.round(r.stats.availableMonthsOfStockOnHand ?? 0, 2),
+        }),
         align: ColumnAlign.Right,
         description: 'description.months-of-stock',
         key: 'availableMonthsOfStockOnHand',

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -54,6 +54,8 @@ export type ItemStockOnHandQueryVariables = Types.Exact<{
 
 export type ItemStockOnHandQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', nodes: Array<{ __typename: 'ItemNode', code: string, id: string, name: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number }> } };
 
+export type ItemsWithStatsFragment = { __typename: 'ItemNode', code: string, id: string, name: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand?: number | null } };
+
 export type ItemsWithStatsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   key?: Types.InputMaybe<Types.ItemSortFieldInput>;
@@ -190,6 +192,23 @@ export const ItemFragmentDoc = gql`
   }
 }
     ${StockLineFragmentDoc}`;
+export const ItemsWithStatsFragmentDoc = gql`
+    fragment ItemsWithStats on ItemNode {
+  __typename
+  code
+  id
+  name
+  unitName
+  defaultPackSize
+  availableStockOnHand(storeId: $storeId)
+  stats(storeId: $storeId) {
+    __typename
+    averageMonthlyConsumption
+    availableStockOnHand
+    availableMonthsOfStockOnHand
+  }
+}
+    `;
 export const VariantFragmentDoc = gql`
     fragment Variant on VariantNode {
   id
@@ -278,25 +297,13 @@ export const ItemsWithStatsDocument = gql`
     ... on ItemConnector {
       __typename
       nodes {
-        __typename
-        code
-        id
-        name
-        unitName
-        defaultPackSize
-        availableStockOnHand(storeId: $storeId)
-        stats(storeId: $storeId) {
-          __typename
-          averageMonthlyConsumption
-          availableStockOnHand
-          availableMonthsOfStockOnHand
-        }
+        ...ItemsWithStats
       }
       totalCount
     }
   }
 }
-    `;
+    ${ItemsWithStatsFragmentDoc}`;
 export const ItemByIdDocument = gql`
     query itemById($storeId: String!, $itemId: String!) {
   items(storeId: $storeId, filter: {id: {equalTo: $itemId}}) {

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -171,6 +171,22 @@ query itemStockOnHand(
   }
 }
 
+fragment ItemsWithStats on ItemNode {
+  __typename
+  code
+  id
+  name
+  unitName
+  defaultPackSize
+  availableStockOnHand(storeId: $storeId)
+  stats(storeId: $storeId) {
+    __typename
+    averageMonthlyConsumption
+    availableStockOnHand
+    availableMonthsOfStockOnHand
+  }
+}
+
 query itemsWithStats(
   $storeId: String!
   $key: ItemSortFieldInput
@@ -188,19 +204,7 @@ query itemsWithStats(
     ... on ItemConnector {
       __typename
       nodes {
-        __typename
-        code
-        id
-        name
-        unitName
-        defaultPackSize
-        availableStockOnHand(storeId: $storeId)
-        stats(storeId: $storeId) {
-          __typename
-          averageMonthlyConsumption
-          availableStockOnHand
-          availableMonthsOfStockOnHand
-        }
+        ...ItemsWithStats
       }
       totalCount
     }

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -1,7 +1,7 @@
 import { useUnitVariantList } from '../api';
 import { create } from 'zustand';
 import { UnitVariantNode, VariantNode } from '@common/types';
-import { NumUtils, isEqual } from '@common/utils';
+import { ArrayUtils, NumUtils, isEqual } from '@common/utils';
 import { useEffect } from 'react';
 
 type UserSelectedVariants = {
@@ -30,11 +30,11 @@ const useUnitStore = create<UnitState>(set => {
       })),
     setItems: newItems =>
       set(({ userSelectedVariants }) => {
-        const items = newItems.reduce(
-          (acc, item) => ({ [item.itemId]: item, ...acc }),
-          {}
-        );
-        return { items, userSelectedVariants };
+        return {
+          // Using function for iterator instead of just itemId for type safety
+          items: ArrayUtils.keyBy(newItems, item => item.itemId),
+          userSelectedVariants,
+        };
       }),
   };
 });

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -60,7 +60,7 @@ export const useUnitVariant = (
 ): {
   asPackUnit: (packSize: number) => string;
   numberOfPacksFromQuantity: (totalQuantity: number) => number;
-  variantsControll?: {
+  variantsControl?: {
     variants: VariantNode[];
     // Selected by user or mostUsed (calculated by backend)
     activeVariant: VariantNode;
@@ -108,7 +108,7 @@ export const useUnitVariant = (
     numberOfPacksFromQuantity: totalQuantity =>
       NumUtils.round(totalQuantity / activeVariant.packSize, 2),
     // TODO what if variants were soft deleted ?
-    variantsControll: {
+    variantsControl: {
       variants: variants,
       activeVariant,
       setUserSelectedVariant: variantId =>

--- a/server/cli/src/refresh_dates.rs
+++ b/server/cli/src/refresh_dates.rs
@@ -40,18 +40,6 @@ fn get_timestamp_fields() -> Vec<TableAndFieldName> {
         ("requisition_line", "snapshot_datetime"),
         ("stocktake", "created_datetime"),
         ("stocktake", "finalised_datetime"),
-        ("sync_log", "started_datetime"),
-        ("sync_log", "finished_datetime"),
-        ("sync_log", "prepare_initial_started_datetime"),
-        ("sync_log", "prepare_initial_finished_datetime"),
-        ("sync_log", "push_started_datetime"),
-        ("sync_log", "push_finished_datetime"),
-        ("sync_log", "pull_central_started_datetime"),
-        ("sync_log", "pull_central_finished_datetime"),
-        ("sync_log", "pull_remote_started_datetime"),
-        ("sync_log", "pull_remote_finished_datetime"),
-        ("sync_log", "integration_started_datetime"),
-        ("sync_log", "integration_finished_datetime"),
         ("activity_log", "datetime"),
     ]
     .iter()
@@ -68,6 +56,18 @@ fn get_exclude_timestamp_fields() -> Vec<TableAndFieldName> {
     vec![
         ("sync_buffer", "received_datetime"),
         ("sync_buffer", "integration_datetime"),
+        ("sync_log", "started_datetime"),
+        ("sync_log", "finished_datetime"),
+        ("sync_log", "prepare_initial_started_datetime"),
+        ("sync_log", "prepare_initial_finished_datetime"),
+        ("sync_log", "push_started_datetime"),
+        ("sync_log", "push_finished_datetime"),
+        ("sync_log", "pull_central_started_datetime"),
+        ("sync_log", "pull_central_finished_datetime"),
+        ("sync_log", "pull_remote_started_datetime"),
+        ("sync_log", "pull_remote_finished_datetime"),
+        ("sync_log", "integration_started_datetime"),
+        ("sync_log", "integration_finished_datetime"),
     ]
     .iter()
     .map(|(table_name, field_name)| TableAndFieldName {

--- a/server/graphql/general/src/queries/item_variant.rs
+++ b/server/graphql/general/src/queries/item_variant.rs
@@ -22,7 +22,7 @@ pub fn item_variants_list(_store_id: &str) -> Vec<UnitVariantNode> {
             // Reference data: Amoxicillin 250mg tabs
             item_id: "E43D125F51DE4355AE1233DA449ED08A".to_string(),
             unit_name: Some("tablet".to_string()),
-            most_used_variant_id: "ghi".to_string(),
+            most_used_variant_id: "amo-50".to_string(),
             variants: vec![
                 VariantNode {
                     id: "amo-one".to_string(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2156

# 👩🏻‍💻 What does this PR do? 

Add drop down unit variant selector to item list and adjusts quantities based on the selected variant. Also moved sync log datetime to be excluded in refresh date cli, see test description.

# 🧪 How has/should this change been tested? 

Initialise from reference data:
```
cargo run --bin remote_server_cli -- initialise-from-export -n reference1
```
then refresh dates
```
cargo run --bin remote_server_cli -- refresh-dates
```

Check out item view as per screenshot above, try changing unit variants, see stats column reflect selected variant. Also selected variant will be saved, but not in app data (not on refresh, but if navigating to another page through menu), saving userSelected through app data will be added in next task, I added this to epic (btw without user selected, should default to calculated by server, as per mock data for now).

![Screenshot 2023-08-30 at 7 39 09 PM](https://github.com/openmsupply/open-msupply/assets/26194949/a34735c2-af19-4ad2-943f-1d2a77fd5442)

## 💌 Any notes for the reviewer?

The task in epic suggests the memoisation should be done, this was already one through zutand selector (i.e. when new variant is selected through drop down, only the cells for that item should re-render
