### PR TITLE
Only show events that have type starting with "status"

### DIFF
--- a/client/packages/programs/src/index.ts
+++ b/client/packages/programs/src/index.ts
@@ -3,3 +3,4 @@ export * from './Components';
 export * from './hooks';
 export * from './JsonForms';
 export * from './schema_types';
+export * from './utils';

--- a/client/packages/programs/src/utils.ts
+++ b/client/packages/programs/src/utils.ts
@@ -1,0 +1,10 @@
+import { ProgramEventFragment } from './api';
+
+/**
+ * Finds all events that are status events and return their data
+ */
+export const getStatusEventData = (events: ProgramEventFragment[]): string[] =>
+  events
+    .filter(e => e.type?.startsWith('status'))
+    .map(e => e.data)
+    .filter((data): data is string => !!data);

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -11,6 +11,7 @@ import {
 import { useFormatDateTime, useTranslation } from '@common/intl';
 import {
   EncounterRowFragment,
+  getStatusEventData,
   useDocumentRegistry,
 } from '@openmsupply-client/programs';
 import { getLogicalStatus } from '../utils';
@@ -28,9 +29,7 @@ const useEncounterAdditionalInfoAccessor: () => {
   const t = useTranslation();
   return {
     additionalInfoAccessor: ({ rowData }): string[] => {
-      const additionalInfo = rowData.activeProgramEvents
-        .map(e => (e.type?.startsWith('status') ? e.data : undefined))
-        .filter((data): data is string => !!data);
+      const additionalInfo = getStatusEventData(rowData.activeProgramEvents);
 
       if (rowData?.status === EncounterNodeStatus.Pending) {
         const startDatetime = new Date(rowData?.startDatetime);

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -22,26 +22,27 @@ interface useEncounterListColumnsProps {
   includePatient?: boolean;
 }
 
-export const useEncounterAdditionalInfoAccessor: ColumnDataAccessor<
-  EncounterRowFragment,
-  string[]
-> = ({ rowData }): string[] => {
+const useEncounterAdditionalInfoAccessor: () => {
+  additionalInfoAccessor: ColumnDataAccessor<EncounterRowFragment, string[]>;
+} = () => {
   const t = useTranslation();
-  const additionalInfo = [];
+  return {
+    additionalInfoAccessor: ({ rowData }): string[] => {
+      const additionalInfo = rowData.activeProgramEvents
+        .map(e => (e.type?.startsWith('status') ? e.data : undefined))
+        .filter((data): data is string => !!data);
 
-  if (rowData?.activeProgramEvents[0]?.data) {
-    additionalInfo.push(rowData.activeProgramEvents[0].data);
-  }
+      if (rowData?.status === EncounterNodeStatus.Pending) {
+        const startDatetime = new Date(rowData?.startDatetime);
+        const status = getLogicalStatus(startDatetime, t);
+        if (status) {
+          additionalInfo.push(status);
+        }
+      }
 
-  if (rowData?.status === EncounterNodeStatus.Pending) {
-    const startDatetime = new Date(rowData?.startDatetime);
-    const status = getLogicalStatus(startDatetime, t);
-    if (status) {
-      additionalInfo.push(status);
-    }
-  }
-
-  return additionalInfo;
+      return additionalInfo;
+    },
+  };
 };
 
 export const useEncounterListColumns = ({
@@ -59,6 +60,8 @@ export const useEncounterListColumns = ({
       },
     });
   includePatient;
+
+  const { additionalInfoAccessor } = useEncounterAdditionalInfoAccessor();
 
   const columnList: ColumnDescription<EncounterRowFragment>[] = [
     {
@@ -107,7 +110,7 @@ export const useEncounterListColumns = ({
     label: 'label.additional-info',
     key: 'events',
     sortable: false,
-    accessor: useEncounterAdditionalInfoAccessor,
+    accessor: additionalInfoAccessor,
     Cell: ChipTableCell,
     minWidth: 400,
   });

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -27,11 +27,9 @@ const programAdditionalInfoAccessor: ColumnDataAccessor<
   ProgramEnrolmentRowFragmentWithId,
   string[]
 > = ({ rowData }): string[] => {
-  const additionalInfo = [];
-
-  if (rowData?.activeProgramEvents[0]?.data) {
-    additionalInfo.push(rowData.activeProgramEvents[0].data);
-  }
+  const additionalInfo = rowData.activeProgramEvents
+    .map(e => (e.type?.startsWith('status') ? e.data : undefined))
+    .filter((data): data is string => !!data);
 
   return additionalInfo;
 };

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -15,6 +15,7 @@ import {
 import {
   PatientModal,
   ProgramEnrolmentRowFragmentWithId,
+  getStatusEventData,
   usePatientModalStore,
   useProgramEnrolments,
 } from '@openmsupply-client/programs';
@@ -27,10 +28,7 @@ const programAdditionalInfoAccessor: ColumnDataAccessor<
   ProgramEnrolmentRowFragmentWithId,
   string[]
 > = ({ rowData }): string[] => {
-  const additionalInfo = rowData.activeProgramEvents
-    .map(e => (e.type?.startsWith('status') ? e.data : undefined))
-    .filter((data): data is string => !!data);
-
+  const additionalInfo = getStatusEventData(rowData.activeProgramEvents);
   return additionalInfo;
 };
 


### PR DESCRIPTION
Fixes #1270 

Only display events with a type starting with "status".

Also fixes the use of a hook which was passed as a function...

For testing, create a remote server with program config, e.g. `./dev_server_schema_update.sh`
- Enrol into HIV Care and create an encounter way in the base, e.g. a year back
- In ARV medication section dispense some pills
- In Viral Load section enter some VL results
- Enrolment list should show "LTFU"
- Encounter list should show "VL Result"

![image](https://github.com/openmsupply/open-msupply/assets/88299195/5fee2e88-7dae-48b6-a477-ec9402346444)
![image](https://github.com/openmsupply/open-msupply/assets/88299195/60f0926a-47c8-414e-80b5-5cac4bbfe5a4)
