### PR TITLE
Fix requested quantity display in Firefox

### DIFF
--- a/client/packages/common/src/ui/components/navigation/Tabs/ModalTab.tsx
+++ b/client/packages/common/src/ui/components/navigation/Tabs/ModalTab.tsx
@@ -8,7 +8,6 @@ interface DetailTabProps {
 }
 
 const StyledTabPanel = styled(TabPanel)({
-  height: '100%',
   flex: 1,
   padding: 0,
 });
@@ -17,7 +16,6 @@ const StyledTabContainer = styled(Box)(({ theme }) => ({
   borderColor: theme.palette.divider,
   flexDirection: 'column',
   display: 'flex',
-  height: '100%',
 }));
 
 export const ModalTab: FC<PropsWithChildren<DetailTabProps>> = ({

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ReponseStats/ResponseStoreStats.tsx
@@ -44,33 +44,31 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
           paddingBottom: 2,
         }}
       >
-        <>
-          <Box
-            display="flex"
-            alignItems="flex-start"
-            width={predictedStockPercent}
-          >
-            <ValueBar
-              value={stockOnHand}
-              total={predictedStockLevels}
-              label={t('label.stock-on-hand')}
-              colour="gray.dark"
-              startDivider
-            />
-            <ValueBar
-              value={incomingStock}
-              total={predictedStockLevels}
-              label={t('label.incoming-stock')}
-              colour="gray.main"
-            />
-            <ValueBar
-              value={stockOnOrder}
-              total={predictedStockLevels}
-              label={t('label.stock-on-order')}
-              colour="gray.light"
-            />
-          </Box>
-        </>
+        <Box
+          display="flex"
+          alignItems="flex-start"
+          width={predictedStockPercent}
+        >
+          <ValueBar
+            value={stockOnHand}
+            total={predictedStockLevels}
+            label={t('label.stock-on-hand')}
+            colour="gray.dark"
+            startDivider
+          />
+          <ValueBar
+            value={incomingStock}
+            total={predictedStockLevels}
+            label={t('label.incoming-stock')}
+            colour="gray.main"
+          />
+          <ValueBar
+            value={stockOnOrder}
+            total={predictedStockLevels}
+            label={t('label.stock-on-order')}
+            colour="gray.light"
+          />
+        </Box>
       </Box>
       <Box
         sx={{
@@ -80,23 +78,21 @@ export const ResponseStoreStats: React.FC<ResponseStoreStatsProps> = ({
           paddingBottom: 2,
         }}
       >
-        <>
-          <Box display="flex" alignItems="flex-start" width={requestedPercent}>
-            <ValueBar
-              value={requestedQuantity}
-              total={totalRequested}
-              label={t('label.requested-quantity')}
-              colour="primary.main"
-              startDivider
-            />
-            <ValueBar
-              value={otherRequestedQuantity}
-              total={totalRequested}
-              label={t('label.all-requested-quantity')}
-              colour="primary.light"
-            />
-          </Box>
-        </>
+        <Box display="flex" alignItems="flex-start" width={requestedPercent}>
+          <ValueBar
+            value={requestedQuantity}
+            total={totalRequested}
+            label={t('label.requested-quantity')}
+            colour="primary.main"
+            startDivider
+          />
+          <ValueBar
+            value={otherRequestedQuantity}
+            total={totalRequested}
+            label={t('label.all-requested-quantity')}
+            colour="primary.light"
+          />
+        </Box>
       </Box>
     </>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2145

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Quick fix -- seems to work fine after removing the `height: "100%"` props from ModalTabs. Not sure if this might cause problems somewhere else -- can you think of why it might have been necessary @mark-prins 

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Tested on Firefox and Chrome, in Requisitions -> requisition -> item line modal.

## 💌 Any notes for the reviewer?

Please see if you can think of any potential regressions.