### PR TITLE
1693 For locations, limit of records per page doesn't seem to be respected

### DIFF
--- a/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/client/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -69,7 +69,7 @@ export const StocktakeListView: FC = () => {
 
       <DataTable
         id="stocktake-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes ?? []}

--- a/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -78,7 +78,7 @@ export const InboundListView: FC = () => {
 
       <DataTable
         id="inbound-line-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes ?? []}

--- a/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/client/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -85,7 +85,7 @@ const OutboundShipmentListViewComponent: FC = () => {
       <DataTable
         id="outbound-list"
         enableColumnSelection
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes ?? []}

--- a/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
+++ b/client/packages/invoices/src/Prescriptions/ListView/ListView.tsx
@@ -75,7 +75,7 @@ const PrescriptionListViewComponent: FC = () => {
       <DataTable
         id="prescription-list"
         enableColumnSelection
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes ?? []}

--- a/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -125,7 +125,7 @@ export const RequestRequisitionListView: FC = () => {
 
       <DataTable
         id="internal-order-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -95,7 +95,7 @@ const ItemListComponent: FC = () => {
       <Toolbar filter={filter} />
       <DataTable
         id="item-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -50,7 +50,7 @@ const LocationListComponent: FC = () => {
       <AppBarButtons onCreate={() => onOpen()} />
       <DataTable
         id="location-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={locations}

--- a/client/packages/system/src/Location/api/api.ts
+++ b/client/packages/system/src/Location/api/api.ts
@@ -8,7 +8,11 @@ import {
 } from '@openmsupply-client/common';
 import { Sdk, LocationRowFragment } from './operations.generated';
 
-export type ListParams = { sortBy: SortBy<LocationRowFragment> };
+export type ListParams = {
+  sortBy: SortBy<LocationRowFragment>;
+  first?: number;
+  offset?: number;
+};
 
 const locationParsers = {
   toSortInput: (sortBy: SortBy<LocationRowFragment>): LocationSortInput => ({
@@ -34,8 +38,10 @@ const locationParsers = {
 
 export const getLocationQueries = (sdk: Sdk, storeId: string) => ({
   get: {
-    list: async ({ sortBy }: ListParams) => {
+    list: async ({ sortBy, first, offset }: ListParams) => {
       const response = await sdk.locations({
+        first,
+        offset,
         sort: [locationParsers.toSortInput(sortBy)],
         storeId,
       });

--- a/client/packages/system/src/Location/api/operations.generated.ts
+++ b/client/packages/system/src/Location/api/operations.generated.ts
@@ -9,6 +9,8 @@ export type LocationRowFragment = { __typename: 'LocationNode', id: string, name
 export type LocationsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   sort?: Types.InputMaybe<Array<Types.LocationSortInput> | Types.LocationSortInput>;
+  first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
 
@@ -48,8 +50,12 @@ export const LocationRowFragmentDoc = gql`
 }
     `;
 export const LocationsDocument = gql`
-    query locations($storeId: String!, $sort: [LocationSortInput!]) {
-  locations(storeId: $storeId, sort: $sort) {
+    query locations($storeId: String!, $sort: [LocationSortInput!], $first: Int, $offset: Int) {
+  locations(
+    storeId: $storeId
+    sort: $sort
+    page: {first: $first, offset: $offset}
+  ) {
     __typename
     ... on LocationConnector {
       __typename
@@ -216,7 +222,7 @@ export type Sdk = ReturnType<typeof getSdk>;
  * @see https://mswjs.io/docs/basics/response-resolver
  * @example
  * mockLocationsQuery((req, res, ctx) => {
- *   const { storeId, sort } = req.variables;
+ *   const { storeId, sort, first, offset } = req.variables;
  *   return res(
  *     ctx.data({ locations })
  *   )

--- a/client/packages/system/src/Location/api/operations.graphql
+++ b/client/packages/system/src/Location/api/operations.graphql
@@ -6,8 +6,17 @@ fragment LocationRow on LocationNode {
   code
 }
 
-query locations($storeId: String!, $sort: [LocationSortInput!]) {
-  locations(storeId: $storeId, sort: $sort) {
+query locations(
+  $storeId: String!
+  $sort: [LocationSortInput!]
+  $first: Int
+  $offset: Int
+) {
+  locations(
+    storeId: $storeId
+    sort: $sort
+    page: { first: $first, offset: $offset }
+  ) {
     __typename
     ... on LocationConnector {
       __typename

--- a/client/packages/system/src/MasterList/ListView/ListView.tsx
+++ b/client/packages/system/src/MasterList/ListView/ListView.tsx
@@ -40,7 +40,7 @@ const MasterListComponent: FC = () => {
       <AppBarButtons />
       <DataTable
         id="master-list-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -48,7 +48,7 @@ const NameListComponent: FC<{ type: 'customer' | 'supplier' }> = ({ type }) => {
     <>
       <DataTable
         id="name-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}

--- a/client/packages/system/src/Patient/ListView/ListView.tsx
+++ b/client/packages/system/src/Patient/ListView/ListView.tsx
@@ -105,7 +105,7 @@ const PatientListComponent: FC = () => {
       <AppBarButtons sortBy={sortBy} />
       <DataTable
         id="patients"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -100,7 +100,7 @@ const ProgramListComponent: FC = () => {
   return (
     <DataTable
       id="program-enrolment-list"
-      pagination={{ ...pagination, total: data?.totalCount }}
+      pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
       onChangePage={updatePaginationQuery}
       columns={columns}
       data={data?.nodes}

--- a/client/packages/system/src/Report/ListView/ListView.tsx
+++ b/client/packages/system/src/Report/ListView/ListView.tsx
@@ -144,7 +144,7 @@ const ReportListComponent = ({ context }: { context: ReportContext }) => {
       <Toolbar filter={filter} />
       <DataTable
         id="item-list"
-        pagination={{ ...pagination, total: data?.totalCount }}
+        pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
         onChangePage={updatePaginationQuery}
         columns={columns}
         data={data?.nodes}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1693 

# 👩🏻‍💻 What does this PR do? 
Add offset and first to locations hook to get the ListView to paginate properly.

# 🧪 How has/should this change been tested? 
- [ ] Have more than 20 locations
- [ ] Go to Location page
- [ ] Should only have the first 20 locations on first page 
- [ ] Swap to 2nd page and the rest of the locations should load