### PR TITLE
2173 Add missing AddPatient Permission

### DIFF
--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -329,7 +329,7 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<Permission> {
                 output.insert(Permission::StocktakeQuery);
             }
             Permissions::AddStocktakeLines => {
-                output.insert(Permission::StocktakeQuery);
+                output.insert(Permission::StocktakeMutate);
             }
             Permissions::EditStocktakeLines => {
                 output.insert(Permission::StocktakeMutate);
@@ -379,6 +379,9 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<Permission> {
                 output.insert(Permission::LogQuery);
             }
             // patient
+            Permissions::AddPatients => {
+                output.insert(Permission::PatientMutate);
+            }
             Permissions::EditPatientDetails => {
                 output.insert(Permission::PatientQuery);
                 output.insert(Permission::PatientMutate);

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -380,6 +380,7 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<Permission> {
             }
             // patient
             Permissions::AddPatients => {
+                output.insert(Permission::PatientQuery);
                 output.insert(Permission::PatientMutate);
             }
             Permissions::EditPatientDetails => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2173 

# 👩🏻‍💻 What does this PR do? 
Found while checking out #2106 
Map `AddPatient` permission since users might be allowed to add patients but not edit them 🤷🏻  + fix mis-mapped `AddStocktakeLines` permission

# 🧪 How has/should this change been tested? 
Should be able to add a patient without edit patient permission
