### PR TITLE
2151 When lines are sorted, the Ok&Next button should respect the sorted sequence in Inbound shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useNextItem.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useNextItem.ts
@@ -1,5 +1,5 @@
+import { useInbound } from '..';
 import { InboundLineFragment } from '../../operations.generated';
-import { useInboundItems } from '../line/useInboundItems';
 
 type InboundLineItem = InboundLineFragment['item'];
 
@@ -8,14 +8,16 @@ export const useNextItem = (
 ): { next: InboundLineItem | null; disabled: boolean } => {
   const next: InboundLineItem | null = null;
   const disabled = true;
-  const { data } = useInboundItems();
+  const { items } = useInbound.lines.rows();
 
-  if (!data) return { next, disabled };
+  if (!items) return { next, disabled };
 
-  const numberOfItems = data.length;
-  const currentIndex = data.findIndex(({ itemId }) => itemId === currentItemId);
+  const numberOfItems = items.length;
+  const currentIndex = items.findIndex(
+    ({ itemId }) => itemId === currentItemId
+  );
   const nextIndex = currentIndex + 1;
-  const nextItem = data?.[nextIndex];
+  const nextItem = items?.[nextIndex];
   if (!nextItem) return { next, disabled };
 
   return {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2151 

# 👩🏻‍💻 What does this PR do? 
Make `Ok & Next` button go to the next item on the list even if the list has been resorted for inbound invoices.

# 🧪 How has/should this change been tested? 
- [ ] Create an inbound shipment from a master list 
- [ ] Change how the inbound shipment lines are sorted
- [ ] Click of one of the lines to go to the edit modal
- [ ] Enter some packs and click `Ok & Next`
- [ ] Should go to next item on the list instead of going to the next item in the alphabet
