### PR TITLE
Improve pack unit display

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -202,7 +202,6 @@
   "label.additional-info": "Additional Info",
   "label.program-enrolments": "Program Enrolments",
   "label.location": "Location",
-  "label.pack-unit": "Pack/Unit",
   "label.message": "Message",
   "label.reason": "Reason",
   "label.log": "Log",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4598,7 +4598,6 @@ export type UnitVariantNode = {
   __typename: 'UnitVariantNode';
   itemId: Scalars['String']['output'];
   mostUsedVariantId: Scalars['String']['output'];
-  unitName?: Maybe<Scalars['String']['output']>;
   variants: Array<VariantNode>;
 };
 

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitCell.tsx
@@ -15,7 +15,7 @@ export const getPackUnitCell =
   }: {
     getItemId: (row: T) => string;
     getPackSize: (row: T) => number;
-    getUnitName: (row: T) => string | undefined;
+    getUnitName: (row: T) => string | null;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
     const { asPackUnit } = useUnitVariant(

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitCell.tsx
@@ -11,12 +11,17 @@ export const getPackUnitCell =
   <T extends RecordWithId>({
     getItemId,
     getPackSize,
+    getUnitName,
   }: {
     getItemId: (row: T) => string;
     getPackSize: (row: T) => number;
+    getUnitName: (row: T) => string | undefined;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
-    const { asPackUnit } = useUnitVariant(getItemId(rowData));
+    const { asPackUnit } = useUnitVariant(
+      getItemId(rowData),
+      getUnitName(rowData)
+    );
 
     const packSize = getPackSize(rowData);
     const packUnit = asPackUnit(packSize);

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitQuantityCell.tsx
@@ -16,7 +16,10 @@ export const getPackUnitQuantityCell =
     getQuantity: (row: T) => number;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
-    const { numberOfPacksFromQuantity } = useUnitVariant(getItemId(rowData));
+    const { numberOfPacksFromQuantity } = useUnitVariant(
+      getItemId(rowData),
+      null
+    );
 
     const quantity = getQuantity(rowData);
     const packQuantity = numberOfPacksFromQuantity(quantity);

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -17,13 +17,14 @@ export const getPackUnitSelectCell =
     getUnitName: (row: T) => string | null;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
-    const { variantsControl } = useUnitVariant(
+    const { asPackUnit, variantsControl } = useUnitVariant(
       getItemId(rowData),
       getUnitName(rowData)
     );
 
-    if (typeof variantsControl == 'string') {
-      return <InnerBasicCell isError={isError} value={variantsControl} />;
+    if (!variantsControl) {
+      // If no variants exist, then use number of packs = 1
+      return <InnerBasicCell isError={isError} value={asPackUnit(1)} />;
     }
 
     const { variants, activeVariant, setUserSelectedVariant } = variantsControl;

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitSelectCell.tsx
@@ -14,13 +14,16 @@ export const getPackUnitSelectCell =
     getUnitName,
   }: {
     getItemId: (row: T) => string;
-    getUnitName: (row: T) => string;
+    getUnitName: (row: T) => string | null;
   }) =>
   ({ isError, rowData }: CellProps<T>): ReactElement => {
-    const { variantsControl } = useUnitVariant(getItemId(rowData));
+    const { variantsControl } = useUnitVariant(
+      getItemId(rowData),
+      getUnitName(rowData)
+    );
 
-    if (!variantsControl) {
-      return <InnerBasicCell isError={isError} value={getUnitName(rowData)} />;
+    if (typeof variantsControl == 'string') {
+      return <InnerBasicCell isError={isError} value={variantsControl} />;
     }
 
     const { variants, activeVariant, setUserSelectedVariant } = variantsControl;

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -43,7 +43,7 @@ const ItemListComponent: FC = () => {
       'name',
       {
         key: 'packUnit',
-        label: 'label.pack-unit',
+        label: 'label.pack',
         align: ColumnAlign.Right,
         Cell: getPackUnitSelectCell({
           getItemId: r => r.id,

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -47,7 +47,7 @@ const ItemListComponent: FC = () => {
         align: ColumnAlign.Right,
         Cell: getPackUnitSelectCell({
           getItemId: r => r.id,
-          getUnitName: r => r.unitName || '',
+          getUnitName: r => r.unitName || null,
         }),
       },
       [

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -78,14 +78,14 @@ export type ItemByIdQuery = { __typename: 'Queries', items: { __typename: 'ItemC
 
 export type VariantFragment = { __typename: 'VariantNode', id: string, longName: string, packSize: number, shortName: string };
 
-export type UnitVariantFragment = { __typename: 'UnitVariantNode', itemId: string, mostUsedVariantId: string, unitName?: string | null, variants: Array<{ __typename: 'VariantNode', id: string, longName: string, packSize: number, shortName: string }> };
+export type UnitVariantFragment = { __typename: 'UnitVariantNode', itemId: string, mostUsedVariantId: string, variants: Array<{ __typename: 'VariantNode', id: string, longName: string, packSize: number, shortName: string }> };
 
 export type ItemVariantsListQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
 }>;
 
 
-export type ItemVariantsListQuery = { __typename: 'Queries', itemVariantsList: Array<{ __typename: 'UnitVariantNode', itemId: string, mostUsedVariantId: string, unitName?: string | null, variants: Array<{ __typename: 'VariantNode', id: string, longName: string, packSize: number, shortName: string }> }> };
+export type ItemVariantsListQuery = { __typename: 'Queries', itemVariantsList: Array<{ __typename: 'UnitVariantNode', itemId: string, mostUsedVariantId: string, variants: Array<{ __typename: 'VariantNode', id: string, longName: string, packSize: number, shortName: string }> }> };
 
 export const ServiceItemRowFragmentDoc = gql`
     fragment ServiceItemRow on ItemNode {
@@ -221,7 +221,6 @@ export const UnitVariantFragmentDoc = gql`
     fragment UnitVariant on UnitVariantNode {
   itemId
   mostUsedVariantId
-  unitName
   variants {
     ...Variant
   }

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -246,7 +246,6 @@ fragment Variant on VariantNode {
 fragment UnitVariant on UnitVariantNode {
   itemId
   mostUsedVariantId
-  unitName
   variants {
     ...Variant
   }

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -76,14 +76,12 @@ export const useUnitVariant = (
 ): {
   asPackUnit: (packSize: number) => string;
   numberOfPacksFromQuantity: (totalQuantity: number) => number;
-  variantsControl:
-    | {
-        variants: VariantNode[];
-        // Selected by user or mostUsed (calculated by backend)
-        activeVariant: VariantNode;
-        setUserSelectedVariant: (variantId: string) => void;
-      }
-    | string;
+  variantsControl?: {
+    variants: VariantNode[];
+    // Selected by user or mostUsed (calculated by backend)
+    activeVariant: VariantNode;
+    setUserSelectedVariant: (variantId: string) => void;
+  };
 } => {
   const [item, userSelectedVariantId, setUserSelectedVariant] = useUnitStore(
     state => [
@@ -99,8 +97,6 @@ export const useUnitVariant = (
     return {
       asPackUnit: packSize => asPackUnit({ packSize, unitName, t }),
       numberOfPacksFromQuantity: totalQuantity => totalQuantity,
-      // If no variants exists return default pack unit display
-      variantsControl: asPackUnit({ packSize: 1, unitName, t }),
     };
   }
 
@@ -132,14 +128,11 @@ export const useUnitVariant = (
     numberOfPacksFromQuantity: totalQuantity =>
       NumUtils.round(totalQuantity / activeVariant.packSize, 2),
     // TODO what if variants were soft deleted ?
-    variantsControl:
-      (variants.length > 0 && {
-        variants: variants,
-        activeVariant,
-        setUserSelectedVariant: variantId =>
-          setUserSelectedVariant({ itemId, variantId }),
-      }) ||
-      // If no variants exists return default pack unit display
-      asPackUnit({ packSize: 1, unitName, t }),
+    variantsControl: {
+      variants: variants,
+      activeVariant,
+      setUserSelectedVariant: variantId =>
+        setUserSelectedVariant({ itemId, variantId }),
+    },
   };
 };

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -66,7 +66,7 @@ const asPackUnit: AsPackUnit = ({ packSize, packUnitName, unitName, t }) => {
   if (packUnitName) return packUnitName;
   if (unitName) return `${packSize} ${unitName}`;
 
-  let defaultUnit = t('label.unit');
+  const defaultUnit = t('label.unit');
   return `${packSize} ${defaultUnit};`;
 };
 

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -67,7 +67,7 @@ const asPackUnit: AsPackUnit = ({ packSize, packUnitName, unitName, t }) => {
   if (unitName) return `${packSize} ${unitName}`;
 
   const defaultUnit = t('label.unit');
-  return `${packSize} ${defaultUnit};`;
+  return `${packSize} ${defaultUnit}`;
 };
 
 export const useUnitVariant = (

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -56,13 +56,18 @@ export const useInitUnitStore = () => {
   // TODO add user selected from app data
 };
 
-type AsPackUnit = (_: {
+type CommonAsPackUnit = (_: {
   packSize: number;
   packUnitName?: string;
   unitName: string | null;
   t: TypedTFunction<LocaleKey>;
 }) => string;
-const asPackUnit: AsPackUnit = ({ packSize, packUnitName, unitName, t }) => {
+const commonAsPackUnit: CommonAsPackUnit = ({
+  packSize,
+  packUnitName,
+  unitName,
+  t,
+}) => {
   if (packUnitName) return packUnitName;
   if (unitName) return `${packSize} ${unitName}`;
 
@@ -95,7 +100,7 @@ export const useUnitVariant = (
 
   if (!item || item.variants.length == 0) {
     return {
-      asPackUnit: packSize => asPackUnit({ packSize, unitName, t }),
+      asPackUnit: packSize => commonAsPackUnit({ packSize, unitName, t }),
       numberOfPacksFromQuantity: totalQuantity => totalQuantity,
     };
   }
@@ -118,7 +123,7 @@ export const useUnitVariant = (
         variant => variant.packSize === packSize
       );
 
-      return asPackUnit({
+      return commonAsPackUnit({
         packSize,
         unitName,
         packUnitName: foundVariant?.shortName,

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -89,7 +89,7 @@ const StockListComponent: FC = () => {
         Cell: getPackUnitCell({
           getItemId: r => r.itemId,
           getPackSize: r => r.packSize,
-          getUnitName: r => r.item.unitName || undefined,
+          getUnitName: r => r.item.unitName || null,
         }),
       },
       [

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -85,10 +85,11 @@ const StockListComponent: FC = () => {
       ['locationName', { sortable: false }],
       {
         key: 'packUnit',
-        label: 'label.pack-unit',
+        label: 'label.pack',
         Cell: getPackUnitCell({
           getItemId: r => r.itemId,
           getPackSize: r => r.packSize,
+          getUnitName: r => r.item.unitName || undefined,
         }),
       },
       [

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -86,6 +86,7 @@ const StockListComponent: FC = () => {
       {
         key: 'packUnit',
         label: 'label.pack',
+        sortable: false,
         Cell: getPackUnitCell({
           getItemId: r => r.itemId,
           getPackSize: r => r.packSize,

--- a/server/graphql/general/src/queries/item_variant.rs
+++ b/server/graphql/general/src/queries/item_variant.rs
@@ -11,7 +11,6 @@ pub struct VariantNode {
 #[derive(SimpleObject)]
 pub struct UnitVariantNode {
     pub item_id: String, // item id
-    pub unit_name: Option<String>,
     pub most_used_variant_id: String,
     pub variants: Vec<VariantNode>,
 }
@@ -21,7 +20,6 @@ pub fn item_variants_list(_store_id: &str) -> Vec<UnitVariantNode> {
         UnitVariantNode {
             // Reference data: Amoxicillin 250mg tabs
             item_id: "E43D125F51DE4355AE1233DA449ED08A".to_string(),
-            unit_name: Some("tablet".to_string()),
             most_used_variant_id: "amo-50".to_string(),
             variants: vec![
                 VariantNode {
@@ -47,7 +45,6 @@ pub fn item_variants_list(_store_id: &str) -> Vec<UnitVariantNode> {
         UnitVariantNode {
             // Reference data: Acetylsalicylic Acid 100mg tabs
             item_id: "179D364578D343C8BC45930C16A1D61C".to_string(),
-            unit_name: Some("tablet".to_string()),
             most_used_variant_id: "ace-twenty".to_string(),
             variants: vec![
                 VariantNode {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2176

# 👩🏻‍💻 What does this PR do? 

Simplifies and aligns pack unit display, as per this comment https://github.com/openmsupply/open-msupply/pull/2157#pullrequestreview-1603540024

# 🧪 How has/should this change been tested? 

Initialise from reference data:
```
cargo run --bin remote_server_cli -- initialise-from-export -n reference1
```

Then look at items in stock view and in item list view, you should see the following:

* If there is a unit variant matching item and packs size, it should show variant short name (mock variants are here: https://github.com/openmsupply/open-msupply/blob/daae2622b06ea64ccaadf5ba8888069f3b58e541/server/graphql/general/src/queries/item_variant.rs#L18)
* if there is a unit name, show as 1 tab instead of just tab (or 100 tabs etc)
* if there isn't a unit name, show 1 unit (or 100 units etc)
