### PR TITLE
#2141 Fix Notes maxAge edit restriction

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
@@ -144,7 +144,11 @@ const NotesComponent = (props: ArrayControlCustomProps) => {
       return false;
 
     // Must not be older than `maxAge` days
-    if (DateUtils.ageInDays(created) >= 1) return false;
+    if (
+      DateUtils.ageInDays(created) >= options['editRestrictions']['maxAge'] ??
+      Infinity
+    )
+      return false;
 
     return true;
   };

--- a/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
@@ -62,7 +62,7 @@ const NotesComponent = (props: ArrayControlCustomProps) => {
   const { enabled, data, config } = props;
   const { localisedDateTime } = useFormatDateTime();
 
-  const options = props.uischema.options;
+  const options = NotesOptions.parse(props.uischema.options);
 
   const inputData = (data as NoteSchema[]) ?? [];
 
@@ -145,8 +145,8 @@ const NotesComponent = (props: ArrayControlCustomProps) => {
 
     // Must not be older than `maxAge` days
     if (
-      DateUtils.ageInDays(created) >= options['editRestrictions']['maxAge'] ??
-      Infinity
+      DateUtils.ageInDays(created) >=
+      (options?.editRestrictions?.maxAge ?? Infinity)
     )
       return false;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2141

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Updated the check to actually *use* the maxAge value (instead of the hard-coded 1 day), and use `Infinity` as a fallback if `maxAge` is not specified (i.e. can always be edited)

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Tested with "Notes" on Patient JSON Form (PNG schema).
- Checked correct behaviour with new notes (can be edited) and after setting the created date to more than one day
- Manually changed UI JsonSchema to remove `maxAge` property --notes are always editable