### PR TITLE
2158 fix stock item search autocomplete limit list with pagination

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.stories.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.stories.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 import { Autocomplete } from './Autocomplete';
 import { AutocompleteList } from './AutocompleteList';
 import { AutocompleteMultiList, AutocompleteOption } from '.';
+import { AutocompleteWithPagination } from './AutocompleteWithPagination';
 
 export default {
   title: 'Inputs/Autocomplete',
@@ -99,6 +100,42 @@ const longOptions = [
     label: 'PRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
     id: '19',
   },
+  {
+    label: 'P4RIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '20',
+  },
+  {
+    label: 'GSPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '21',
+  },
+  {
+    label: 'UYPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '22',
+  },
+  {
+    label: 'SRPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '23',
+  },
+  {
+    label: 'JHGSPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '24',
+  },
+  {
+    label: 'MNJPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '25',
+  },
+  {
+    label: 'GFMNJPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '26',
+  },
+  {
+    label: 'MLKJPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '27',
+  },
+  {
+    label: 'QEPRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+    id: '28',
+  },
 ];
 
 // TODO: Currently the styles are broken for this only within storybook
@@ -165,10 +202,57 @@ const MultiListTemplate: Story = () => {
   );
 };
 
+const AutocompleteWithPaginationTemplate: Story = () => {
+  const [pagination, setPagination] = React.useState({
+    page: 1,
+    first: 10,
+    offset: 0,
+  });
+  const [currOptions, setCurrOptions] = React.useState<typeof longOptions>(
+    longOptions.slice(0, pagination.first)
+  );
+
+  const onPageChange = (page: number) => {
+    setPagination({ ...pagination, offset: pagination.first * page, page });
+  };
+
+  React.useEffect(() => {
+    if (pagination.offset > 0) {
+      setCurrOptions(
+        longOptions.slice(
+          pagination.offset,
+          pagination.offset + pagination.first
+        )
+      );
+    }
+  }, [pagination]);
+
+  return (
+    <Grid container>
+      <Grid item>
+        <Paper>
+          <Typography fontWeight={700}>Autocomplete with Pagination</Typography>
+          <div style={{ paddingBottom: 30 }}>
+            <Typography>Search Text:</Typography>
+          </div>
+          <AutocompleteWithPagination
+            pagination={{ ...pagination, total: longOptions.length }}
+            onPageChange={onPageChange}
+            paginationDebounce={300}
+            options={currOptions}
+            width="500px"
+          />
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
+
 export const Basic = BasicTemplate.bind({});
 export const List = ListTemplate.bind({});
 export const LongOptions = BasicTemplate.bind({});
 export const MultiList = MultiListTemplate.bind({});
+export const WithPagination = AutocompleteWithPaginationTemplate.bind({});
 
 Basic.args = { options: options };
 LongOptions.args = { options: longOptions, popperMinWidth: 850 };

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -6,8 +6,6 @@ import {
   CreateFilterOptionsConfig,
   AutocompleteInputChangeReason,
   AutocompleteProps as MuiAutocompleteProps,
-  styled,
-  Popper,
   PopperProps,
   StandardTextFieldProps,
 } from '@mui/material';
@@ -17,6 +15,8 @@ import {
   AutocompleteOptionRenderer,
 } from './types';
 import { BasicTextInput } from '../TextInput';
+import { StyledPopper } from './components';
+
 export interface AutocompleteProps<T>
   extends Omit<
     MuiAutocompleteProps<T, undefined, boolean, undefined>,
@@ -48,10 +48,6 @@ export interface AutocompleteProps<T>
   popperMinWidth?: number;
   inputProps?: StandardTextFieldProps;
 }
-
-const StyledPopper = styled(Popper)(({ theme }) => ({
-  boxShadow: theme.shadows[2],
-}));
 
 export function Autocomplete<T>({
   defaultValue,

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -142,9 +142,6 @@ export function AutocompleteWithPagination<T>({
                 listboxNode.scrollTop + listboxNode.clientHeight ===
                 listboxNode.scrollHeight
               ) {
-                // testing
-                console.log('at the end', pagination);
-
                 // Scroll bar is at the end, load more data
                 const { page, first, total } = pagination;
                 if (first * (page + 1) > total) return; // We have no more data to fetch

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -1,10 +1,14 @@
-import React, { FC, PropsWithChildren, SyntheticEvent } from 'react';
+import React, {
+  FC,
+  PropsWithChildren,
+  SyntheticEvent,
+  useState,
+  useEffect,
+} from 'react';
 import {
   Autocomplete as MuiAutocomplete,
   AutocompleteRenderInputParams,
   createFilterOptions,
-  styled,
-  Popper,
   PopperProps,
   CircularProgress,
   Box,
@@ -12,6 +16,9 @@ import {
 import { BasicTextInput } from '../TextInput';
 import { useDebounceCallback } from '@common/hooks';
 import type { AutocompleteProps } from './Autocomplete';
+import { StyledPopper } from './components';
+
+const LOADER_HIDE_TIMEOUT = 500;
 
 export interface AutocompleteWithPaginationProps<T>
   extends AutocompleteProps<T> {
@@ -24,10 +31,6 @@ export interface AutocompleteWithPaginationProps<T>
   paginationDebounce?: number;
   onPageChange?: (page: number) => void;
 }
-
-const StyledPopper = styled(Popper)(({ theme }) => ({
-  boxShadow: theme.shadows[2],
-}));
 
 export function AutocompleteWithPagination<T>({
   defaultValue,
@@ -59,6 +62,7 @@ export function AutocompleteWithPagination<T>({
   ...restOfAutocompleteProps
 }: PropsWithChildren<AutocompleteWithPaginationProps<T>>) {
   const filter = filterOptions ?? createFilterOptions(filterOptionConfig);
+  const [isLoading, setIsLoading] = useState(true);
 
   const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
     <BasicTextInput
@@ -71,7 +75,9 @@ export function AutocompleteWithPagination<T>({
         // style: props.disabled ? { paddingLeft: 0 } : {},
         endAdornment: (
           <>
-            {loading ? <CircularProgress color="primary" size={18} /> : null}
+            {isLoading || loading ? (
+              <CircularProgress color="primary" size={18} />
+            ) : null}
             {props.InputProps.endAdornment}
           </>
         ),
@@ -80,7 +86,7 @@ export function AutocompleteWithPagination<T>({
     />
   );
 
-  const defaultRenderOption: FC = (
+  const DefaultRenderOption: FC = (
     props: React.HTMLAttributes<HTMLLIElement>,
     option: { id?: string; label?: string } & T
   ) => (
@@ -131,6 +137,10 @@ export function AutocompleteWithPagination<T>({
     />
   );
 
+  useEffect(() => {
+    setTimeout(() => setIsLoading(false), LOADER_HIDE_TIMEOUT);
+  }, [options]);
+
   return (
     <MuiAutocomplete
       {...restOfAutocompleteProps}
@@ -149,7 +159,7 @@ export function AutocompleteWithPagination<T>({
       options={options}
       size="small"
       renderInput={renderInput || defaultRenderInput}
-      renderOption={renderOption || defaultRenderOption}
+      renderOption={renderOption || DefaultRenderOption}
       onChange={onChange}
       getOptionLabel={getOptionLabel || defaultGetOptionLabel}
       PopperComponent={popperMinWidth ? CustomPopper : StyledPopper}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -1,0 +1,159 @@
+import React, { FC, PropsWithChildren, SyntheticEvent } from 'react';
+import {
+  Autocomplete as MuiAutocomplete,
+  AutocompleteRenderInputParams,
+  createFilterOptions,
+  styled,
+  Popper,
+  PopperProps,
+  CircularProgress,
+  Box,
+} from '@mui/material';
+import { BasicTextInput } from '../TextInput';
+import { useDebounceCallback } from '@common/hooks';
+import type { AutocompleteProps } from './Autocomplete';
+
+export interface AutocompleteWithPaginationProps<T>
+  extends AutocompleteProps<T> {
+  pagination?: {
+    page: number;
+    first: number;
+    offset: number;
+    total: number;
+  };
+  paginationDebounce?: number;
+  onPageChange?: (page: number) => void;
+}
+
+const StyledPopper = styled(Popper)(({ theme }) => ({
+  boxShadow: theme.shadows[2],
+}));
+
+export function AutocompleteWithPagination<T>({
+  defaultValue,
+  filterOptionConfig,
+  filterOptions,
+  getOptionDisabled,
+  optionKey,
+  loading,
+  loadingText,
+  noOptionsText,
+  onChange,
+  options,
+  renderInput,
+  renderOption,
+  width = 'auto',
+  value,
+  isOptionEqualToValue,
+  clearable = true,
+  disabled,
+  onInputChange,
+  inputValue,
+  autoFocus = false,
+  getOptionLabel,
+  popperMinWidth,
+  inputProps,
+  pagination,
+  paginationDebounce,
+  onPageChange,
+  ...restOfAutocompleteProps
+}: PropsWithChildren<AutocompleteWithPaginationProps<T>>) {
+  const filter = filterOptions ?? createFilterOptions(filterOptionConfig);
+
+  const defaultRenderInput = (props: AutocompleteRenderInputParams) => (
+    <BasicTextInput
+      {...props}
+      {...inputProps}
+      autoFocus={autoFocus}
+      InputProps={{
+        ...props.InputProps,
+        disableUnderline: false,
+        // style: props.disabled ? { paddingLeft: 0 } : {},
+        endAdornment: (
+          <>
+            {loading ? <CircularProgress color="primary" size={18} /> : null}
+            {props.InputProps.endAdornment}
+          </>
+        ),
+      }}
+      sx={{ width }}
+    />
+  );
+
+  const defaultRenderOption: FC = (
+    props: React.HTMLAttributes<HTMLLIElement>,
+    option: { id?: string; label?: string } & T
+  ) => (
+    <Box component="li" {...props} key={option.id}>
+      {option.label}
+    </Box>
+  );
+
+  const defaultGetOptionLabel = (option: T): string => {
+    if (!!optionKey) return String(option[optionKey]);
+
+    return (option as { label?: string }).label ?? '';
+  };
+
+  const debounceOnPageChange = useDebounceCallback(
+    (page: number) => {
+      onPageChange && onPageChange(page);
+    },
+    [onPageChange],
+    paginationDebounce || 500
+  );
+
+  const CustomPopper: React.FC<PopperProps> = props => (
+    <StyledPopper
+      {...props}
+      placement="bottom-start"
+      style={{ minWidth: popperMinWidth, width: 'auto' }}
+    />
+  );
+
+  return (
+    <MuiAutocomplete
+      {...restOfAutocompleteProps}
+      inputValue={inputValue}
+      onInputChange={onInputChange}
+      disabled={disabled}
+      isOptionEqualToValue={isOptionEqualToValue}
+      defaultValue={defaultValue}
+      disableClearable={!clearable}
+      value={value}
+      getOptionDisabled={getOptionDisabled}
+      filterOptions={filter}
+      loading={loading}
+      loadingText={loadingText}
+      noOptionsText={noOptionsText}
+      options={options}
+      size="small"
+      renderInput={renderInput || defaultRenderInput}
+      renderOption={renderOption || defaultRenderOption}
+      onChange={onChange}
+      getOptionLabel={getOptionLabel || defaultGetOptionLabel}
+      PopperComponent={popperMinWidth ? CustomPopper : StyledPopper}
+      ListboxProps={
+        (pagination &&
+          onPageChange && {
+            onScroll: (event: SyntheticEvent) => {
+              const listboxNode = event.currentTarget;
+              if (
+                listboxNode.scrollTop + listboxNode.clientHeight ===
+                listboxNode.scrollHeight
+              ) {
+                // testing
+                console.log('at the end', pagination);
+
+                // Scroll bar is at the end, load more data
+                const { page, first, total } = pagination;
+                if (first * (page + 1) > total) return; // We have no more data to fetch
+                debounceOnPageChange(page + 1);
+              }
+            },
+          }) ||
+        undefined
+      }
+    />
+  );
+}

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -103,6 +103,26 @@ export function AutocompleteWithPagination<T>({
     paginationDebounce
   );
 
+  const listboxProps =
+    !pagination || !onPageChange
+      ? undefined
+      : {
+          onScroll: (event: SyntheticEvent) => {
+            const listboxNode = event.currentTarget;
+            const scrollPosition =
+              listboxNode.scrollTop + listboxNode.clientHeight;
+
+            // the scrollPosition should equal scrollHeight at the end of the list
+            // but can be off by 0.5px, hence the +1 and greater than or equal to
+            if (scrollPosition + 1 >= listboxNode.scrollHeight) {
+              // Scroll bar is at the end, load more data
+              const { page, first, total } = pagination;
+              if (first * (page + 1) > total) return; // We have no more data to fetch
+              debounceOnPageChange(page + 1);
+            }
+          },
+        };
+
   const CustomPopper: React.FC<PopperProps> = props => (
     <StyledPopper
       {...props}
@@ -133,24 +153,7 @@ export function AutocompleteWithPagination<T>({
       onChange={onChange}
       getOptionLabel={getOptionLabel || defaultGetOptionLabel}
       PopperComponent={popperMinWidth ? CustomPopper : StyledPopper}
-      ListboxProps={
-        (pagination &&
-          onPageChange && {
-            onScroll: (event: SyntheticEvent) => {
-              const listboxNode = event.currentTarget;
-              if (
-                listboxNode.scrollTop + listboxNode.clientHeight ===
-                listboxNode.scrollHeight
-              ) {
-                // Scroll bar is at the end, load more data
-                const { page, first, total } = pagination;
-                if (first * (page + 1) > total) return; // We have no more data to fetch
-                debounceOnPageChange(page + 1);
-              }
-            },
-          }) ||
-        undefined
-      }
+      ListboxProps={listboxProps}
     />
   );
 }

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/AutocompleteWithPagination.tsx
@@ -72,7 +72,6 @@ export function AutocompleteWithPagination<T>({
       InputProps={{
         ...props.InputProps,
         disableUnderline: false,
-        // style: props.disabled ? { paddingLeft: 0 } : {},
         endAdornment: (
           <>
             {isLoading || loading ? (

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/components.tsx
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/components.tsx
@@ -1,0 +1,5 @@
+import { styled, Popper } from '@mui/material';
+
+export const StyledPopper = styled(Popper)(({ theme }) => ({
+  boxShadow: theme.shadows[2],
+}));

--- a/client/packages/common/src/ui/components/inputs/Autocomplete/index.ts
+++ b/client/packages/common/src/ui/components/inputs/Autocomplete/index.ts
@@ -4,6 +4,7 @@ import { FilterOptionsState } from '@mui/material';
 export * from './Autocomplete';
 export * from './AutocompleteList';
 export * from './AutocompleteMultiList';
+export * from './AutocompleteWithPagination';
 export * from './types';
 export * from './utils';
 export { AutocompleteRenderInputParams, FilterOptionsState };

--- a/client/packages/common/src/utils/arrays/ArrayUtils.ts
+++ b/client/packages/common/src/utils/arrays/ArrayUtils.ts
@@ -1,5 +1,5 @@
 import { RecordPatch, RecordWithId } from '@common/types';
-import { groupBy, uniqBy, orderBy } from 'lodash';
+import { groupBy, uniqBy } from 'lodash';
 
 export const ArrayUtils = {
   ifTheSameElseDefault: <T, K extends keyof T, J>(
@@ -46,5 +46,4 @@ export const ArrayUtils = {
     }),
   groupBy,
   uniqBy,
-  orderBy,
 };

--- a/client/packages/common/src/utils/arrays/ArrayUtils.ts
+++ b/client/packages/common/src/utils/arrays/ArrayUtils.ts
@@ -1,6 +1,5 @@
 import { RecordPatch, RecordWithId } from '@common/types';
-import groupBy from 'lodash/groupBy';
-import uniqBy from 'lodash/uniqBy';
+import { groupBy, uniqBy, orderBy } from 'lodash';
 
 export const ArrayUtils = {
   ifTheSameElseDefault: <T, K extends keyof T, J>(
@@ -47,4 +46,5 @@ export const ArrayUtils = {
     }),
   groupBy,
   uniqBy,
+  orderBy,
 };

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -11,7 +11,7 @@ import {
 import { ItemStockOnHandFragment, useItemStockOnHand } from '../../api';
 import { itemFilterOptions, StockItemSearchInputProps } from '../../utils';
 import { getItemOptionRenderer } from '../ItemOptionRenderer';
-import { useOrganisationFilter, usePagination } from './hooks';
+import { useItemFilter, usePagination } from './hooks';
 
 const DEBOUNCE_TIMEOUT = 300;
 
@@ -26,7 +26,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
 }) => {
   const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
   const { pagination, onPageChange } = usePagination();
-  const { filter, onFilter } = useOrganisationFilter();
+  const { filter, onFilter } = useItemFilter();
 
   const { data, isLoading } = useItemStockOnHand({
     pagination,

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -43,18 +43,14 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
       defaultOptionMapper(
         extraFilter ? items.filter(extraFilter) ?? [] : items ?? [],
         'name'
-      ),
+      ).sort((a, b) => a.label.localeCompare(b.label)),
     [items]
   );
 
-  const cachedSearchedItems = useMemo(() => {
-    const newItems = ArrayUtils.uniqBy(
-      [...items, ...(data?.nodes ?? [])],
-      'id'
-    );
-    const sorted = ArrayUtils.orderBy(newItems, ['name'], ['asc']);
-    return sorted;
-  }, [data]);
+  const cachedSearchedItems = useMemo(
+    () => ArrayUtils.uniqBy([...items, ...(data?.nodes ?? [])], 'id'),
+    [data]
+  );
 
   const debounceOnFilter = useDebounceCallback(
     (searchText: string) => {

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -54,14 +54,14 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
       onFilter(searchText);
     },
     [onFilter],
-    debounceTimeout
+    DEBOUNCE_TIMEOUT
   );
 
   useEffect(() => {
     // using the Autocomplete openOnFocus prop, the popper is incorrectly positioned
     // when used within a Dialog. This is a workaround to fix the popper position.
     if (openOnFocus) {
-      setTimeout(() => selectControl.toggleOn(), 300);
+      setTimeout(() => selectControl.toggleOn(), DEBOUNCE_TIMEOUT);
     }
   }, []);
 
@@ -90,7 +90,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
       open={selectControl.isOn}
       onInputChange={(_, value) => debounceOnFilter(value)}
       pagination={{ ...pagination, total: data?.totalCount ?? 0 }}
-      paginationDebounce={debounceTimeout}
+      paginationDebounce={DEBOUNCE_TIMEOUT}
       onPageChange={onPageChange}
     />
   );

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -13,6 +13,8 @@ import { itemFilterOptions, StockItemSearchInputProps } from '../../utils';
 import { getItemOptionRenderer } from '../ItemOptionRenderer';
 import { useOrganisationFilter, usePagination } from './hooks';
 
+const DEBOUNCE_TIMEOUT = 300;
+
 export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   onChange,
   currentItemId,
@@ -22,7 +24,6 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   autoFocus = false,
   openOnFocus,
 }) => {
-  const DEBOUNCE_TIMEOUT = 300;
   const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
   const { pagination, onPageChange } = usePagination();
   const { filter, onFilter } = useOrganisationFilter();

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -23,9 +23,9 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   openOnFocus,
 }) => {
   const debounceTimeout = 300;
+  const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
   const { pagination, onPageChange } = usePagination();
   const { filter, onFilter } = useOrganisationFilter();
-  const [items, setItems] = useState<ItemStockOnHandFragment[]>([]);
 
   const { data, isLoading } = useItemStockOnHand({
     pagination,

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -46,7 +46,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
     );
     const sorted = ArrayUtils.orderBy(newItems, ['name'], ['asc']);
     return sorted;
-  }, [items, data]);
+  }, [data]);
 
   const debounceOnFilter = useDebounceCallback(
     (searchText: string) => {

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -50,6 +50,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
 
   const debounceOnFilter = useDebounceCallback(
     (searchText: string) => {
+      onPageChange(0); // Reset pagination when searching for a new item
       onFilter(searchText);
     },
     [onFilter],

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/StockItemSearchInput.tsx
@@ -38,7 +38,14 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
   const value = items.find(({ id }) => id === currentItemId) ?? null;
   const selectControl = useToggle();
 
-  const options = extraFilter ? items.filter(extraFilter) ?? [] : items ?? [];
+  const options = useMemo(
+    () =>
+      defaultOptionMapper(
+        extraFilter ? items.filter(extraFilter) ?? [] : items ?? [],
+        'name'
+      ),
+    [items]
+  );
 
   const cachedSearchedItems = useMemo(() => {
     const newItems = ArrayUtils.uniqBy(
@@ -79,7 +86,7 @@ export const StockItemSearchInput: FC<StockItemSearchInputProps> = ({
       value={value ? { ...value, label: value.name ?? '' } : null}
       noOptionsText={t('error.no-items')}
       onChange={(_, item) => onChange(item)}
-      options={defaultOptionMapper(options, 'name')}
+      options={options}
       getOptionLabel={option => `${option.code}     ${option.name}`}
       renderOption={getItemOptionRenderer(
         t('label.units'),

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 
-export const useOrganisationFilter = (searchText = '') => {
+export const useItemFilter = (searchText = '') => {
   const filterBy = useCallback(
     (value: string) => ({ name: { like: value } }),
     [searchText]

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
@@ -12,10 +12,10 @@ export const useOrganisationFilter = (searchText = '') => {
   };
 };
 
-export const usePagination = () => {
+export const usePagination = (first: number = 500) => {
   const [pagination, setPagination] = useState({
     page: 0,
-    first: 1000,
+    first,
     offset: 0,
   });
 

--- a/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
+++ b/client/packages/system/src/Item/Components/StockItemSearchInput/hooks.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+
+export const useOrganisationFilter = (searchText = '') => {
+  const filterBy = useCallback(
+    (value: string) => ({ name: { like: value } }),
+    [searchText]
+  );
+  const [filter, setFilter] = useState(filterBy(searchText));
+  return {
+    filter,
+    onFilter: (searchText: string) => setFilter(filterBy(searchText)),
+  };
+};
+
+export const usePagination = () => {
+  const [pagination, setPagination] = useState({
+    page: 0,
+    first: 1000,
+    offset: 0,
+  });
+
+  const onPageChange = useCallback(
+    (page: number) =>
+      setPagination({
+        first: pagination.first,
+        offset: pagination.first * page,
+        page,
+      }),
+    []
+  );
+
+  return { pagination, onPageChange };
+};

--- a/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
+++ b/client/packages/system/src/Item/api/hooks/useItemStockOnHand/useItemStockOnHand.tsx
@@ -1,14 +1,27 @@
 import { useQuery } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
-export const useItemStockOnHand = () => {
+type UseItemStockOnHandParams = {
+  pagination: { first: number; offset: number };
+  filter: { name: { like: string } };
+  preload?: boolean;
+};
+
+export const useItemStockOnHand = ({
+  pagination,
+  filter,
+}: UseItemStockOnHandParams) => {
   const queryParams = {
+    ...pagination,
+    filterBy: filter,
     sortBy: { key: 'name', isDesc: false, direction: 'asc' as 'asc' | 'desc' },
-    offset: 0,
-    first: 5000, // TODO: remove arbitrary limit
   };
+
   const api = useItemApi();
-  return useQuery(api.keys.paramList(queryParams), () =>
-    api.get.itemStockOnHand(queryParams)
+
+  return useQuery(
+    api.keys.paramList(queryParams),
+    () => api.get.itemStockOnHand(queryParams),
+    { refetchOnWindowFocus: false, cacheTime: 0 }
   );
 };

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -52,7 +52,7 @@ export type ItemStockOnHandQueryVariables = Types.Exact<{
 }>;
 
 
-export type ItemStockOnHandQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', nodes: Array<{ __typename: 'ItemNode', code: string, id: string, name: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number }> } };
+export type ItemStockOnHandQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, name: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number }> } };
 
 export type ItemsWithStatsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -234,6 +234,7 @@ export const ItemStockOnHandDocument = gql`
         defaultPackSize
         availableStockOnHand(storeId: $storeId)
       }
+      totalCount
     }
   }
 }

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -167,6 +167,7 @@ query itemStockOnHand(
         defaultPackSize
         availableStockOnHand(storeId: $storeId)
       }
+      totalCount
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.3.00",
+  "version": "1.3.00-IS2158",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "1.3.00-IS2158",
+  "version": "1.3.00",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2158 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
- Loads stock items asynchronously with the help of pagination for a large dataset
- Handles search to the back when a user types in the autocomplete field

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Follow the reproducible steps in the #2158 to test

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
We faced the same issue in the [health supply hub](https://github.com/openmsupply/health-supply-hub/issues/1030) and thought to solve with same approach here as well by async loading of autocomplete list records with the help of the pagination.

![](http://g.recordit.co/vli8Dpp2hV.gif)

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2