### PR TITLE
Add a EnrolmentId control

### DIFF
--- a/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
+++ b/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
@@ -60,7 +60,7 @@ const UIComponent = (props: ControlProps) => {
         sx: { ...inputProps.sx, ...DefaultFormRowSpacing },
       }}
       labelWidthPercentage={FORM_LABEL_WIDTH}
-      inputAlignment={'start'}
+      inputAlignment="start"
     />
   );
 };

--- a/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
+++ b/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
@@ -25,7 +25,7 @@ const UIComponent = (props: ControlProps) => {
     uischema.options
   );
 
-  // fetch current encounter
+  // fetch matching program enrolment
   const { data } = useProgramEnrolments.document.list({
     filterBy: {
       type: { equalTo: options?.programEnrolmentType },

--- a/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
+++ b/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
@@ -1,0 +1,73 @@
+import { ControlProps, rankWith, uiTypeIs } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import { DetailInputWithLabelRow } from '@openmsupply-client/common';
+import React from 'react';
+import { z } from 'zod';
+import { useProgramEnrolments } from '../../api';
+import {
+  DefaultFormRowSpacing,
+  FORM_LABEL_WIDTH,
+  useZodOptionsValidation,
+} from '../common';
+
+const Options = z
+  .object({
+    programEnrolmentType: z.string(),
+  })
+  .strict();
+type Options = z.infer<typeof Options>;
+
+const UIComponent = (props: ControlProps) => {
+  const { label, uischema, config } = props;
+
+  const { errors, options } = useZodOptionsValidation(
+    Options,
+    uischema.options
+  );
+
+  // fetch current encounter
+  const { data } = useProgramEnrolments.document.list({
+    filterBy: {
+      type: { equalTo: options?.programEnrolmentType },
+      patientId: { equalTo: config?.patientId },
+    },
+  });
+  const enrolment = data?.nodes[0];
+
+  if (!props.visible) {
+    return null;
+  }
+
+  const inputProps = {
+    value: enrolment?.programEnrolmentId ? enrolment.programEnrolmentId : '',
+    disabled: true,
+    sx: {},
+    required: props.required,
+    errors,
+  };
+
+  return (
+    <DetailInputWithLabelRow
+      label={label}
+      inputProps={{
+        value: enrolment?.programEnrolmentId
+          ? enrolment.programEnrolmentId
+          : '',
+        disabled: true,
+        required: props.required,
+        error: !!errors,
+        helperText: errors,
+        sx: { ...inputProps.sx, ...DefaultFormRowSpacing },
+      }}
+      labelWidthPercentage={FORM_LABEL_WIDTH}
+      inputAlignment={'start'}
+    />
+  );
+};
+
+/**
+ * Shows a the enrolment id for a given enrolment type
+ */
+export const EnrolmentId = withJsonFormsControlProps(UIComponent);
+
+export const enrolmentIdTester = rankWith(10, uiTypeIs('EnrolmentId'));

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -35,6 +35,7 @@ import {
   historicEncounterDataTester,
   HistoricEncounterData,
 } from './components';
+import { EnrolmentId, enrolmentIdTester } from './components/EnrolmentId';
 
 // https://stackoverflow.com/questions/57874879/how-to-treat-missing-undefined-properties-as-equivalent-in-lodashs-isequalwit
 // TODO: handle undefined and empty string as equal? e.g. initial data is undefined and current data is ""
@@ -93,6 +94,7 @@ const additionalRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: searchTester, renderer: Search },
   { tester: programEventTester, renderer: ProgramEvent },
   { tester: historicEncounterDataTester, renderer: HistoricEncounterData },
+  { tester: enrolmentIdTester, renderer: EnrolmentId },
 ];
 
 /**

--- a/client/packages/programs/src/api/api.ts
+++ b/client/packages/programs/src/api/api.ts
@@ -14,6 +14,7 @@ import {
   ProgramEventNode,
   UpdateEncounterInput,
   UpdateProgramEnrolmentInput,
+  ProgramEnrolmentFilterInput,
 } from '@common/types';
 import { EncounterListParams } from './hooks/utils/useEncounterApi';
 import {
@@ -258,7 +259,7 @@ export const getAllocateProgramNumber = (sdk: Sdk, storeId: string) => ({
 
 export type ProgramEnrolmentListParams = {
   sortBy?: SortRule<ProgramEnrolmentSortFieldInput>;
-  filterBy?: FilterBy;
+  filterBy?: ProgramEnrolmentFilterInput;
 };
 
 export const getProgramEnrolmentQueries = (sdk: Sdk, storeId: string) => ({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2170

Add missing control for the HIV testing encounter. The control shows the enrolment ID of a certain enrolment type.

This control will also be needed for contact tracing entries. However, it will some tweaking to get the contact's patient id then...

# Testing
Create a HIV testing encounter adn got to: "Hiv Testing" and select Result "Positive". The ART Number should show up (but blank).

Enrol into a the HIV care encounter and assign a enrolment id during enrolment. Going back to the testing encounter, the ART Number should now show a value.

![image](https://github.com/openmsupply/open-msupply/assets/88299195/9b735e22-01e9-43e2-9bbc-339d36e0f2dc)
