### PR TITLE
Adjust internal order consumption history chart

### DIFF
--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -29,6 +29,7 @@
   "info.manual-shipment": "This shipment was created manually. The delivery status will not be automatically updated.",
   "label.add-batch": "Add batch",
   "label.consumption": "Consumption",
+  "label.current": "Current",
   "label.draft": "Draft",
   "label.finalised": "Finalised",
   "label.hide-stock-over-minimum": "Hide stock over minimum",

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
@@ -35,12 +35,16 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
   const tooltipFormatter = (
     value: number,
     name: string,
-    props: { payload?: { date: string; isHistoric: boolean } }
+    props: {
+      payload?: { date: string; isHistoric: boolean; isCurrent: boolean };
+    }
   ): [number, string] => {
     switch (name) {
       case 'consumption':
         const label = props.payload?.isHistoric
           ? t('label.consumption')
+          : props.payload?.isCurrent
+          ? t('label.current')
           : t('label.projected');
         return [value, label];
       case 'averageMonthlyConsumption':
@@ -94,6 +98,12 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
                   value: t('label.consumption'),
                   type: 'rect',
                   id: '1',
+                  color: theme.palette.gray.light,
+                },
+                {
+                  value: t('label.current'),
+                  type: 'rect',
+                  id: '2',
                   color: theme.palette.gray.main,
                 },
                 {
@@ -116,6 +126,8 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
                   key={entry.date}
                   fill={
                     entry.isHistoric
+                      ? theme.palette.gray.light
+                      : entry.isCurrent
                       ? theme.palette.gray.main
                       : theme.palette.primary.light
                   }

--- a/server/graphql/types/src/types/item_chart.rs
+++ b/server/graphql/types/src/types/item_chart.rs
@@ -180,14 +180,14 @@ mod test {
     use super::*;
 
     #[actix_rt::test]
-    async fn graphq_test_item_chart_node() {
+    async fn graphql_test_item_chart_node() {
         #[derive(Clone)]
         struct TestQuery;
 
         let (_, _, _, settings) = setup_graphl_test(
             TestQuery,
             EmptyMutation,
-            "graphq_test_item_chart_node",
+            "graphql_test_item_chart_node",
             MockDataInserts::none(),
         )
         .await;
@@ -200,12 +200,12 @@ mod test {
                         ConsumptionHistory {
                             consumption: 10,
                             average_monthly_consumption: 11.0,
-                            date: NaiveDate::from_ymd_opt(2020, 12, 01).unwrap(),
+                            date: NaiveDate::from_ymd_opt(2020, 12, 31).unwrap(),
                         },
                         ConsumptionHistory {
                             consumption: 10,
                             average_monthly_consumption: 11.0,
-                            date: NaiveDate::from_ymd_opt(2021, 01, 01).unwrap(),
+                            date: NaiveDate::from_ymd_opt(2021, 01, 31).unwrap(),
                         },
                     ]),
                     stock_evolution: Some(vec![
@@ -274,14 +274,14 @@ mod test {
                   {
                     "averageMonthlyConsumption": 11,
                     "consumption": 10,
-                    "date": "2020-12-01",
+                    "date": "2020-12-31",
                     "isCurrent": false,
                     "isHistoric": true
                   },
                   {
                     "averageMonthlyConsumption": 11,
                     "consumption": 10,
-                    "date": "2021-01-01",
+                    "date": "2021-01-31",
                     "isCurrent": true,
                     "isHistoric": false
                   }

--- a/server/graphql/types/src/types/item_chart.rs
+++ b/server/graphql/types/src/types/item_chart.rs
@@ -3,6 +3,7 @@ use chrono::NaiveDate;
 use service::requisition_line::chart::{
     ConsumptionHistory, ItemChart, StockEvolution, SuggestedQuantityCalculation,
 };
+use util::last_day_of_the_month;
 
 pub struct ConsumptionHistoryNode {
     pub consumption_history: ConsumptionHistory,
@@ -57,7 +58,7 @@ impl ConsumptionHistoryNode {
     }
 
     pub async fn is_current(&self) -> bool {
-        self.reference_date == self.consumption_history.date
+        last_day_of_the_month(&self.reference_date) == self.consumption_history.date
     }
 }
 

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -8,6 +8,7 @@ pub use historic_consumption::*;
 
 mod stock_evolution;
 pub use stock_evolution::*;
+use util::{date_with_months_offset, last_day_of_the_month};
 
 use crate::service_provider::ServiceContext;
 
@@ -86,10 +87,13 @@ pub fn get_requisition_line_chart(
         consumption_history_options,
     )?;
 
-    // Replace last consumption_history element with requisition line AMC (current AMC)
-    if let Some(last) = consumption_history.last_mut() {
-        last.consumption = average_monthly_consumption as u32;
-        last.average_monthly_consumption = average_monthly_consumption as f64;
+    // Add in the projected month which shows the requisition line AMC (current AMC)
+    if let Some(last) = consumption_history.last() {
+        consumption_history.push(ConsumptionHistory {
+            consumption: average_monthly_consumption as u32,
+            average_monthly_consumption: average_monthly_consumption as f64,
+            date: last_day_of_the_month(&date_with_months_offset(&last.date, 1)),
+        });
     }
 
     let StockEvolutionResult {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2194 #2195 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Added the next month to the chart; so the chart now shows 13 months - the current month, 11 months of historical data and a projection for next month.

Found that the `is_current` property was not set correctly, so have fixed that and added support for it in the front end.

<img width="1067" alt="image" src="https://github.com/openmsupply/open-msupply/assets/9192912/1c2daca3-2c73-4663-afcc-9a4ace1b4c8c">

Unable to replicate the issue with the bar chart though. and the internal order mentioned in the issue has had the item removed.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
I took a backup of the demo server and tested against that. You should be able to replicate by adding a large quantity of an item to an outbound shipment and setting the status to picked. 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
