### PR TITLE
Update internal order consumption chart

### DIFF
--- a/client/packages/common/src/intl/locales/en/replenishment.json
+++ b/client/packages/common/src/intl/locales/en/replenishment.json
@@ -29,6 +29,7 @@
   "info.manual-shipment": "This shipment was created manually. The delivery status will not be automatically updated.",
   "label.add-batch": "Add batch",
   "label.consumption": "Consumption",
+  "label.current": "Current",
   "label.draft": "Draft",
   "label.finalised": "Finalised",
   "label.hide-stock-over-minimum": "Hide stock over minimum",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4026,7 +4026,7 @@ export type RequisitionLineNode = {
   requestedQuantity: Scalars['Int']['output'];
   /**
    * Calculated quantity
-   * When months_of_stock < requisition.min_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
+   * When months_of_stock < requisition.min_months_of_stock, calculated = average_monthly_consumption * requisition.max_months_of_stock - months_of_stock
    */
   suggestedQuantity: Scalars['Int']['output'];
   /** Quantity to be supplied in the next shipment, only used in response requisition */

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
@@ -14,18 +14,18 @@ import {
 } from '@common/components';
 import {
   Box,
-  ConsumptionHistoryNode,
   LocaleKey,
   useFormatDateTime,
   useTheme,
   useTranslation,
 } from '@openmsupply-client/common';
 import { useRequest } from '../../../api/hooks';
+import { ConsumptionHistoryFragment } from '../../../api';
 
 const getLabelLocaleKey = ({
   payload,
 }: {
-  payload?: ConsumptionHistoryNode;
+  payload?: ConsumptionHistoryFragment;
 }): LocaleKey => {
   switch (true) {
     case payload?.isHistoric:
@@ -53,7 +53,7 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
     value: number,
     name: string,
     props: {
-      payload?: ConsumptionHistoryNode; // { date: string; isHistoric: boolean; isCurrent: boolean };
+      payload?: ConsumptionHistoryFragment; // { date: string; isHistoric: boolean; isCurrent: boolean };
     }
   ): [number, string] => {
     switch (name) {
@@ -69,7 +69,7 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
 
   const tooltipLabelFormatter = (date: string) => dateFormatter(date);
 
-  const getFillColour = (entry: ConsumptionHistoryNode): string => {
+  const getFillColour = (entry: ConsumptionHistoryFragment): string => {
     switch (true) {
       case entry.isHistoric:
         return theme.palette.gray.light;

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/ConsumptionHistory.tsx
@@ -14,11 +14,28 @@ import {
 } from '@common/components';
 import {
   Box,
+  ConsumptionHistoryNode,
+  LocaleKey,
   useFormatDateTime,
   useTheme,
   useTranslation,
 } from '@openmsupply-client/common';
 import { useRequest } from '../../../api/hooks';
+
+const getLabelLocaleKey = ({
+  payload,
+}: {
+  payload?: ConsumptionHistoryNode;
+}): LocaleKey => {
+  switch (true) {
+    case payload?.isHistoric:
+      return 'label.consumption';
+    case payload?.isCurrent:
+      return 'label.current';
+    default:
+      return 'label.projected';
+  }
+};
 
 export interface ConsumptionHistoryProps {
   id: string;
@@ -35,14 +52,13 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
   const tooltipFormatter = (
     value: number,
     name: string,
-    props: { payload?: { date: string; isHistoric: boolean } }
+    props: {
+      payload?: ConsumptionHistoryNode; // { date: string; isHistoric: boolean; isCurrent: boolean };
+    }
   ): [number, string] => {
     switch (name) {
       case 'consumption':
-        const label = props.payload?.isHistoric
-          ? t('label.consumption')
-          : t('label.projected');
-        return [value, label];
+        return [value, t(getLabelLocaleKey(props))];
       case 'averageMonthlyConsumption':
         return [value, t('label.moving-average')];
       default:
@@ -52,6 +68,17 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
   if (!data || !data.consumptionHistory) return null;
 
   const tooltipLabelFormatter = (date: string) => dateFormatter(date);
+
+  const getFillColour = (entry: ConsumptionHistoryNode): string => {
+    switch (true) {
+      case entry.isHistoric:
+        return theme.palette.gray.light;
+      case entry.isCurrent:
+        return theme.palette.gray.main;
+      default:
+        return theme.palette.primary.light;
+    }
+  };
 
   return isLoading ? (
     <CircularProgress />
@@ -94,32 +121,31 @@ export const ConsumptionHistory: React.FC<ConsumptionHistoryProps> = ({
                   value: t('label.consumption'),
                   type: 'rect',
                   id: '1',
+                  color: theme.palette.gray.light,
+                },
+                {
+                  value: t('label.current'),
+                  type: 'rect',
+                  id: '2',
                   color: theme.palette.gray.main,
                 },
                 {
                   value: t('label.projected'),
                   type: 'rect',
-                  id: '2',
+                  id: '3',
                   color: theme.palette.primary.light,
                 },
                 {
                   value: t('label.moving-average'),
                   type: 'rect',
-                  id: '3',
+                  id: '4',
                   color: theme.palette.secondary.light,
                 },
               ]}
             />
             <Bar dataKey="consumption">
               {data.consumptionHistory.nodes?.map(entry => (
-                <Cell
-                  key={entry.date}
-                  fill={
-                    entry.isHistoric
-                      ? theme.palette.gray.main
-                      : theme.palette.primary.light
-                  }
-                />
+                <Cell key={entry.date} fill={getFillColour(entry)} />
               ))}
             </Bar>
             <Line

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -117,10 +117,16 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
   if (suggestedQuantity === 0 && availableStockOnHand === 0)
     return <CalculationError isSohAndQtyZero />;
 
-  const monthlyConsumptionWidth =
+  const targetQuantityWidth =
     availableStockOnHand > targetQuantity
       ? Math.round((100 * targetQuantity) / availableStockOnHand)
       : 100;
+  const barWidth =
+    availableStockOnHand + suggestedQuantity < targetQuantity
+      ? `${Math.round(
+          (100 * (availableStockOnHand + suggestedQuantity)) / targetQuantity
+        )}%`
+      : '100%';
 
   return useMemo(
     () => (
@@ -131,14 +137,12 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
         <Box
           display="flex"
           alignItems="flex-start"
-          width={`${monthlyConsumptionWidth}%`}
+          width={`${targetQuantityWidth}%`}
           style={{ paddingBottom: 7 }}
         >
           <MonthlyBar
             flexBasis="1px"
-            label={
-              monthlyConsumptionWidth > MIN_MC_WIDTH_TO_SHOW_TEXT ? '0' : ''
-            }
+            label={targetQuantityWidth > MIN_MC_WIDTH_TO_SHOW_TEXT ? '0' : ''}
             left={true}
           />
 
@@ -148,12 +152,12 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
               month={i + 1}
               flexBasis={`${100 / maxMonthsOfStock}%`}
               averageMonthlyConsumption={averageMonthlyConsumption}
-              showText={monthlyConsumptionWidth > MIN_MC_WIDTH_TO_SHOW_TEXT}
+              showText={targetQuantityWidth > MIN_MC_WIDTH_TO_SHOW_TEXT}
             />
           ))}
         </Box>
 
-        <Box display="flex" alignItems="flex-start" width="100%">
+        <Box display="flex" alignItems="flex-start" width={barWidth}>
           <ValueBar
             value={availableStockOnHand}
             total={targetQuantity}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/ItemCharts/StockDistribution.tsx
@@ -17,18 +17,24 @@ export interface StockDistributionProps {
 
 const MIN_MC_WIDTH_TO_SHOW_TEXT = 5;
 
+interface MonthlyConsumptionProps {
+  month: number;
+  flexBasis: string;
+  averageMonthlyConsumption: number;
+  showText: boolean;
+  isTarget: boolean;
+  isThreshold: boolean;
+}
+
 const MonthlyConsumption = ({
   month,
   flexBasis,
   averageMonthlyConsumption,
   showText,
-}: {
-  month: number;
-  flexBasis: string;
-  averageMonthlyConsumption: number;
-  showText: boolean;
-}) => {
-  const t = useTranslation('common');
+  isTarget,
+  isThreshold,
+}: MonthlyConsumptionProps) => {
+  const t = useTranslation('replenishment');
   const formatNumber = useFormatNumber();
   const text = ` (${month} ${t('label.months', {
     count: month,
@@ -37,21 +43,45 @@ const MonthlyConsumption = ({
     showText ? text : ''
   }`;
 
-  return <MonthlyBar flexBasis={flexBasis} label={label} />;
+  const additionalLabel =
+    isTarget && showText
+      ? t('label.max-months-of-stock')
+      : isThreshold && showText
+      ? t('label.min-months-of-stock')
+      : undefined;
+
+  return (
+    <MonthlyBar
+      flexBasis={flexBasis}
+      label={label}
+      additionalLabel={additionalLabel}
+      showText={showText}
+    />
+  );
 };
 
 const MonthlyBar = ({
   label,
   left,
   flexBasis,
+  additionalLabel,
+  showText,
 }: {
   label: string;
   left?: boolean;
   flexBasis?: string;
+  additionalLabel?: string;
+  showText?: boolean;
 }) => {
   const directionStyle = left
-    ? { borderLeftWidth: 1, paddingLeft: 8 }
+    ? { borderLeftWidth: 1, paddingLeft: 0 }
     : { paddingLeft: 3, paddingRight: 8, borderRightWidth: 1 };
+  const additionalLabelStyle = additionalLabel
+    ? { height: 40 }
+    : showText
+    ? { height: 20, marginTop: 20 }
+    : {};
+
   return (
     <Box
       sx={{
@@ -62,9 +92,23 @@ const MonthlyBar = ({
         height: '20px',
         overflow: 'hidden',
       }}
-      style={{ ...directionStyle, textAlign: left ? undefined : 'right' }}
+      style={{
+        ...directionStyle,
+        ...additionalLabelStyle,
+        textAlign: left ? undefined : 'right',
+      }}
       flexBasis={flexBasis}
     >
+      {additionalLabel && (
+        <Typography
+          variant="body1"
+          fontSize={12}
+          color="primary"
+          style={{ color: 'primary' }}
+        >
+          {additionalLabel}
+        </Typography>
+      )}
       <Tooltip title={label} placement="top">
         <Typography
           variant="body1"
@@ -110,7 +154,10 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
 }) => {
   if (averageMonthlyConsumption === 0) return <CalculationError isAmcZero />;
 
-  const { maxMonthsOfStock } = useRequest.document.fields('maxMonthsOfStock');
+  const { maxMonthsOfStock, minMonthsOfStock } = useRequest.document.fields([
+    'maxMonthsOfStock',
+    'minMonthsOfStock',
+  ]);
   const targetQuantity = maxMonthsOfStock * averageMonthlyConsumption;
   const t = useTranslation('replenishment');
 
@@ -127,6 +174,7 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
           (100 * (availableStockOnHand + suggestedQuantity)) / targetQuantity
         )}%`
       : '100%';
+  const showText = targetQuantityWidth > MIN_MC_WIDTH_TO_SHOW_TEXT;
 
   return useMemo(
     () => (
@@ -142,7 +190,8 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
         >
           <MonthlyBar
             flexBasis="1px"
-            label={targetQuantityWidth > MIN_MC_WIDTH_TO_SHOW_TEXT ? '0' : ''}
+            label={showText ? '0' : ''}
+            showText={showText}
             left={true}
           />
 
@@ -152,7 +201,9 @@ const StockDistributionContent: React.FC<StockDistributionProps> = ({
               month={i + 1}
               flexBasis={`${100 / maxMonthsOfStock}%`}
               averageMonthlyConsumption={averageMonthlyConsumption}
-              showText={targetQuantityWidth > MIN_MC_WIDTH_TO_SHOW_TEXT}
+              showText={showText}
+              isThreshold={i + 1 === minMonthsOfStock}
+              isTarget={i + 1 === maxMonthsOfStock}
             />
           ))}
         </Box>

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -13,6 +13,8 @@ export type RequestLineFragment = { __typename: 'RequisitionLineNode', id: strin
 
 export type RequestFragment = { __typename: 'RequisitionNode', id: string, type: Types.RequisitionNodeType, status: Types.RequisitionNodeStatus, createdDatetime: string, sentDatetime?: string | null, finalisedDatetime?: string | null, requisitionNumber: number, colour?: string | null, theirReference?: string | null, comment?: string | null, otherPartyName: string, otherPartyId: string, maxMonthsOfStock: number, minMonthsOfStock: number, approvalStatus: Types.RequisitionNodeApprovalStatus, programName?: string | null, orderType?: string | null, user?: { __typename: 'UserNode', username: string, email?: string | null } | null, lines: { __typename: 'RequisitionLineConnector', totalCount: number, nodes: Array<{ __typename: 'RequisitionLineNode', id: string, itemId: string, requestedQuantity: number, suggestedQuantity: number, comment?: string | null, itemStats: { __typename: 'ItemStatsNode', availableStockOnHand: number, availableMonthsOfStockOnHand?: number | null, averageMonthlyConsumption: number }, linkedRequisitionLine?: { __typename: 'RequisitionLineNode', approvedQuantity: number, approvalComment?: string | null } | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null, defaultPackSize: number, availableStockOnHand: number, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand?: number | null } } }> }, shipments: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', id: string, invoiceNumber: number, createdDatetime: string, user?: { __typename: 'UserNode', username: string } | null }> }, otherParty: { __typename: 'NameNode', id: string, code: string, isCustomer: boolean, isSupplier: boolean, isOnHold: boolean, name: string, store?: { __typename: 'StoreNode', id: string, code: string } | null }, linkedRequisition?: { __typename: 'RequisitionNode', approvalStatus: Types.RequisitionNodeApprovalStatus } | null, period?: { __typename: 'PeriodNode', name: string, startDate: string, endDate: string } | null };
 
+export type ConsumptionHistoryFragment = { __typename: 'ConsumptionHistoryNode', averageMonthlyConsumption: number, consumption: number, date: string, isCurrent: boolean, isHistoric: boolean };
+
 export type RequestByNumberQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   requisitionNumber: Types.Scalars['Int']['input'];
@@ -253,6 +255,15 @@ export const RequestFragmentDoc = gql`
   orderType
 }
     ${RequestLineFragmentDoc}`;
+export const ConsumptionHistoryFragmentDoc = gql`
+    fragment ConsumptionHistory on ConsumptionHistoryNode {
+  averageMonthlyConsumption
+  consumption
+  date
+  isCurrent
+  isHistoric
+}
+    `;
 export const ProgramSettingsFragmentDoc = gql`
     fragment ProgramSettings on ProgramRequisitionSettingNode {
   programName
@@ -310,11 +321,7 @@ export const RequisitionLineChartDocument = gql`
       consumptionHistory {
         totalCount
         nodes {
-          averageMonthlyConsumption
-          consumption
-          date
-          isCurrent
-          isHistoric
+          ...ConsumptionHistory
         }
       }
       stockEvolution {
@@ -348,7 +355,7 @@ export const RequisitionLineChartDocument = gql`
     }
   }
 }
-    `;
+    ${ConsumptionHistoryFragmentDoc}`;
 export const RequestsDocument = gql`
     query requests($storeId: String!, $filter: RequisitionFilterInput, $page: PaginationInput, $sort: [RequisitionSortInput!]) {
   requisitions(storeId: $storeId, filter: $filter, page: $page, sort: $sort) {

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.graphql
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.graphql
@@ -133,6 +133,14 @@ fragment Request on RequisitionNode {
   orderType
 }
 
+fragment ConsumptionHistory on ConsumptionHistoryNode {
+  averageMonthlyConsumption
+  consumption
+  date
+  isCurrent
+  isHistoric
+}
+
 query requestByNumber($storeId: String!, $requisitionNumber: Int!) {
   requisitionByNumber(
     requisitionNumber: $requisitionNumber
@@ -171,11 +179,7 @@ query requisitionLineChart($storeId: String!, $requisitionLineId: String!) {
       consumptionHistory {
         totalCount
         nodes {
-          averageMonthlyConsumption
-          consumption
-          date
-          isCurrent
-          isHistoric
+          ...ConsumptionHistory
         }
       }
       stockEvolution {

--- a/server/graphql/types/src/types/item_chart.rs
+++ b/server/graphql/types/src/types/item_chart.rs
@@ -3,6 +3,7 @@ use chrono::NaiveDate;
 use service::requisition_line::chart::{
     ConsumptionHistory, ItemChart, StockEvolution, SuggestedQuantityCalculation,
 };
+use util::last_day_of_the_month;
 
 pub struct ConsumptionHistoryNode {
     pub consumption_history: ConsumptionHistory,
@@ -56,8 +57,10 @@ impl ConsumptionHistoryNode {
         self.reference_date > self.consumption_history.date
     }
 
+    // the reference date is the current date; the consumption_history date
+    // is always the last day of the month
     pub async fn is_current(&self) -> bool {
-        self.reference_date == self.consumption_history.date
+        last_day_of_the_month(&self.reference_date) == self.consumption_history.date
     }
 }
 
@@ -179,14 +182,14 @@ mod test {
     use super::*;
 
     #[actix_rt::test]
-    async fn graphq_test_item_chart_node() {
+    async fn graphql_test_item_chart_node() {
         #[derive(Clone)]
         struct TestQuery;
 
         let (_, _, _, settings) = setup_graphl_test(
             TestQuery,
             EmptyMutation,
-            "graphq_test_item_chart_node",
+            "graphql_test_item_chart_node",
             MockDataInserts::none(),
         )
         .await;
@@ -199,12 +202,12 @@ mod test {
                         ConsumptionHistory {
                             consumption: 10,
                             average_monthly_consumption: 11.0,
-                            date: NaiveDate::from_ymd_opt(2020, 12, 01).unwrap(),
+                            date: NaiveDate::from_ymd_opt(2020, 12, 31).unwrap(),
                         },
                         ConsumptionHistory {
                             consumption: 10,
                             average_monthly_consumption: 11.0,
-                            date: NaiveDate::from_ymd_opt(2021, 01, 01).unwrap(),
+                            date: NaiveDate::from_ymd_opt(2021, 01, 31).unwrap(),
                         },
                     ]),
                     stock_evolution: Some(vec![
@@ -273,14 +276,14 @@ mod test {
                   {
                     "averageMonthlyConsumption": 11,
                     "consumption": 10,
-                    "date": "2020-12-01",
+                    "date": "2020-12-31",
                     "isCurrent": false,
                     "isHistoric": true
                   },
                   {
                     "averageMonthlyConsumption": 11,
                     "consumption": 10,
-                    "date": "2021-01-01",
+                    "date": "2021-01-31",
                     "isCurrent": true,
                     "isHistoric": false
                   }

--- a/server/graphql/types/src/types/requisition_line.rs
+++ b/server/graphql/types/src/types/requisition_line.rs
@@ -67,13 +67,13 @@ impl RequisitionLineNode {
     }
 
     /// Calculated quantity
-    /// When months_of_stock < requisition.min_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
+    /// When months_of_stock < requisition.min_months_of_stock, calculated = average_monthly_consumption * requisition.max_months_of_stock - months_of_stock
     pub async fn suggested_quantity(&self) -> &i32 {
         &self.row().suggested_quantity
     }
 
     pub async fn approved_quantity(&self) -> &i32 {
-        &self.row().approved_quantity 
+        &self.row().approved_quantity
     }
 
     pub async fn approval_comment(&self) -> &Option<String> {

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -452,10 +452,22 @@ mod test {
                     date: NaiveDate::from_ymd_opt(2020, 12, 31).unwrap()
                 },
                 ConsumptionHistory {
+                    // 2021-01-01 to 2021-01-31
+                    consumption: 20,
+                    // 2020-09-01 to 2021-01-31
+                    // average_monthly_consumption: 25.657894736842106,
+                    average_monthly_consumption: (20 + 10 + 30 + 40 + 5 + 5 + 20) as f64
+                        / (NaiveDate::from_ymd_opt(2021, 01, 31).unwrap()
+                            - NaiveDate::from_ymd_opt(2020, 09, 01).unwrap())
+                        .num_days() as f64
+                        * NUMBER_OF_DAYS_IN_A_MONTH,
+                    date: NaiveDate::from_ymd_opt(2021, 01, 31).unwrap()
+                },
+                ConsumptionHistory {
                     // This is populated by requisition line amc
                     consumption: 333,
                     average_monthly_consumption: 333.0,
-                    date: NaiveDate::from_ymd_opt(2021, 01, 31).unwrap()
+                    date: NaiveDate::from_ymd_opt(2021, 02, 28).unwrap()
                 },
             ]
         );

--- a/server/service/src/requisition_line/chart/mod.rs
+++ b/server/service/src/requisition_line/chart/mod.rs
@@ -3,6 +3,7 @@ use repository::{
     requisition_row::RequisitionRowType, RepositoryError, RequisitionLine, RequisitionLineRow,
     StorageConnection,
 };
+use util::{date_with_months_offset, last_day_of_the_month};
 mod historic_consumption;
 pub use historic_consumption::*;
 
@@ -86,10 +87,13 @@ pub fn get_requisition_line_chart(
         consumption_history_options,
     )?;
 
-    // Replace last consumption_history element with requisition line AMC (current AMC)
-    if let Some(last) = consumption_history.last_mut() {
-        last.consumption = average_monthly_consumption as u32;
-        last.average_monthly_consumption = average_monthly_consumption as f64;
+    // Add in the projected month which shows the requisition line AMC (current AMC)
+    if let Some(last) = consumption_history.last() {
+        consumption_history.push(ConsumptionHistory {
+            consumption: average_monthly_consumption as u32,
+            average_monthly_consumption: average_monthly_consumption as f64,
+            date: last_day_of_the_month(&date_with_months_offset(&last.date, 1)),
+        });
     }
 
     let StockEvolutionResult {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2194 #2195 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Added the next month to the chart; so the chart now shows 13 months - the current month, 11 months of historical data and a projection for next month.

Found that the `is_current` property was not set correctly, so have fixed that and added support for it in the front end.

<img width="1055" alt="image" src="https://github.com/openmsupply/open-msupply/assets/9192912/d00f7adf-87e0-45c0-a0e6-60df13f793af">

Unable to replicate the issue with the bar chart though. and the internal order mentioned in the issue has had the item removed.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

I took a backup of the demo server and tested against that. You should be able to replicate by adding a large quantity of an item to an outbound shipment and setting the status to picked.



## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
