### PR TITLE
2208 add pack entry

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -236,7 +236,7 @@
   "label.pack-quantity-issued": "Pack Qty Issued",
   "label.pack-size": "Pack Size",
   "label.unit-variant-and-pack-size": "Unit Variant / Pack Size",
-  "label.enter-pack-size": "Enter Pack Size:",
+  "label.enter-pack-size": "Enter pack size:",
   "label.patient": "Patient",
   "label.period": "Period",
   "label.phone": "Phone",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -235,6 +235,8 @@
   "label.pack-quantity": "Pack Qty",
   "label.pack-quantity-issued": "Pack Qty Issued",
   "label.pack-size": "Pack Size",
+  "label.unit-variant-and-pack-size": "Unit Variant / Pack Size",
+  "label.enter-pack-size": "Enter Pack Size:",
   "label.patient": "Patient",
   "label.period": "Period",
   "label.phone": "Phone",

--- a/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef } from 'react';
 import {
   Box,
   StandardTextFieldProps,
@@ -8,6 +8,7 @@ import {
 
 export type BasicTextInputProps = StandardTextFieldProps & {
   textAlign?: 'left' | 'center' | 'right';
+  focusOnRender?: boolean;
 };
 
 /**
@@ -16,55 +17,78 @@ export type BasicTextInputProps = StandardTextFieldProps & {
  */
 
 export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
-  ({ sx, style, InputProps, error, required, textAlign, ...props }, ref) => (
-    <Box
-      display="flex"
-      justifyContent="flex-end"
-      alignItems="center"
-      flexBasis={style?.flexBasis}
-      flex={style?.flex}
-      width={props.fullWidth ? '100%' : undefined}
-    >
-      <TextField
-        ref={ref}
-        color="secondary"
-        sx={{
-          '& .MuiInput-underline:before': { borderBottomWidth: 0 },
-          '& .MuiInput-input': { color: 'gray.dark', textAlign },
-          ...sx,
-        }}
-        variant="standard"
-        size="small"
-        InputProps={{
-          disableUnderline: error ? true : false,
-          ...InputProps,
-          sx: {
-            border: theme =>
-              error ? `2px solid ${theme.palette.error.main}` : 'none',
-            backgroundColor: theme =>
-              props.disabled
-                ? theme.palette.background.toolbar
-                : theme.palette.background.menu,
-            borderRadius: '8px',
-            padding: '4px 8px',
-            ...InputProps?.sx,
-          },
-        }}
-        {...props}
-      />
-      <Box width={2}>
-        {required && (
-          <Typography
-            sx={{
-              color: 'primary.light',
-              fontSize: '17px',
-              marginRight: 0.5,
-            }}
-          >
-            *
-          </Typography>
-        )}
+  (
+    {
+      sx,
+      style,
+      InputProps,
+      error,
+      required,
+      textAlign,
+      focusOnRender,
+      ...props
+    },
+    ref
+  ) => {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    useEffect(() => {
+      if (focusOnRender) {
+        inputRef?.current;
+        inputRef?.current?.focus();
+      }
+    }, []);
+
+    return (
+      <Box
+        display="flex"
+        justifyContent="flex-end"
+        alignItems="center"
+        flexBasis={style?.flexBasis}
+        flex={style?.flex}
+        width={props.fullWidth ? '100%' : undefined}
+      >
+        <TextField
+          ref={ref}
+          inputRef={inputRef}
+          color="secondary"
+          sx={{
+            '& .MuiInput-underline:before': { borderBottomWidth: 0 },
+            '& .MuiInput-input': { color: 'gray.dark', textAlign },
+            ...sx,
+          }}
+          variant="standard"
+          size="small"
+          InputProps={{
+            disableUnderline: error ? true : false,
+            ...InputProps,
+            sx: {
+              border: theme =>
+                error ? `2px solid ${theme.palette.error.main}` : 'none',
+              backgroundColor: theme =>
+                props.disabled
+                  ? theme.palette.background.toolbar
+                  : theme.palette.background.menu,
+              borderRadius: '8px',
+              padding: '4px 8px',
+              ...InputProps?.sx,
+            },
+          }}
+          {...props}
+        />
+        <Box width={2}>
+          {required && (
+            <Typography
+              sx={{
+                color: 'primary.light',
+                fontSize: '17px',
+                marginRight: 0.5,
+              }}
+            >
+              *
+            </Typography>
+          )}
+        </Box>
       </Box>
-    </Box>
-  )
+    );
+  }
 );

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
@@ -4,6 +4,7 @@ import { BasicTextInput } from '../BasicTextInput';
 export interface NumericTextInputProps
   extends Omit<StandardTextFieldProps, 'onChange'> {
   onChange?: (value: number | undefined) => void;
+  focusOnRender?: boolean;
   width?: number;
 }
 

--- a/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/numeric/NumericTextInput.tsx
@@ -8,8 +8,19 @@ export interface NumericTextInputProps
   width?: number;
 }
 
+export const DEFAULT_NUMERIC_TEXT_INPUT_WIDTH = 75;
+
 export const NumericTextInput: FC<NumericTextInputProps> = React.forwardRef(
-  ({ sx, InputProps, width = 75, onChange, ...props }, ref) => (
+  (
+    {
+      sx,
+      InputProps,
+      width = DEFAULT_NUMERIC_TEXT_INPUT_WIDTH,
+      onChange,
+      ...props
+    },
+    ref
+  ) => (
     <BasicTextInput
       ref={ref}
       sx={{

--- a/client/packages/common/src/ui/layout/tables/components/index.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/index.tsx
@@ -28,9 +28,11 @@ export const BasicCell = <T extends RecordWithId>({
 export const InnerBasicCell = ({
   isError,
   value,
+  width
 }: {
   isError?: boolean;
   value: string;
+  width?: number;
 }): ReactElement => (
   <Box
     sx={{
@@ -42,6 +44,7 @@ export const InnerBasicCell = ({
   >
     <div
       style={{
+        width,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
       }}

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -47,7 +47,15 @@ export type ColumnKey =
   | 'stockOnHand'
   | 'theirReference';
 
-export const getColumnLookup = <T extends RecordWithId>(): Record<
+export const getColumnLookupWithOverrides = <T extends RecordWithId>(
+  columnKey: ColumnKey,
+  overrides: Partial<ColumnDefinition<T>>
+): ColumnDefinition<T> => ({
+  ...getColumnLookup<T>()[columnKey],
+  ...overrides,
+});
+
+const getColumnLookup = <T extends RecordWithId>(): Record<
   ColumnKey,
   ColumnDefinition<T>
 > => ({

--- a/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/client/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -47,7 +47,7 @@ export type ColumnKey =
   | 'stockOnHand'
   | 'theirReference';
 
-const getColumnLookup = <T extends RecordWithId>(): Record<
+export const getColumnLookup = <T extends RecordWithId>(): Record<
   ColumnKey,
   ColumnDefinition<T>
 > => ({

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -191,6 +191,7 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
             />
             <Divider margin={5} />
             <TabLayout
+              item={currentItem}
               draftLines={draftLines}
               addDraftLine={addDraftLine}
               updateDraftLine={updateDraftLine}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -19,7 +19,7 @@ import { InboundLineFragment, useInbound } from '../../../api';
 import { DraftInboundLine } from '../../../../types';
 import { CreateDraft } from '../utils';
 import { TabLayout } from './TabLayout';
-import { useUnitVariant } from 'packages/system/src';
+import { useUnitVariant } from '@openmsupply-client/system';
 
 type InboundLineItem = InboundLineFragment['item'];
 interface InboundLineEditProps {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabLayout.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabLayout.tsx
@@ -16,12 +16,14 @@ import {
 import { DraftInboundLine } from '../../../../types';
 import { InboundLineEditPanel } from './InboundLineEditPanel';
 import { QuantityTable, PricingTable, LocationTable } from './TabTables';
+import { InboundLineFragment } from '../../../api';
 
 interface TabLayoutProps {
   addDraftLine: () => void;
   draftLines: DraftInboundLine[];
   isDisabled: boolean;
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
+  item: InboundLineFragment['item'] | null;
 }
 
 enum Tabs {
@@ -31,6 +33,7 @@ enum Tabs {
 }
 
 export const TabLayout: FC<TabLayoutProps> = ({
+  item,
   addDraftLine,
   draftLines,
   isDisabled,
@@ -100,6 +103,7 @@ export const TabLayout: FC<TabLayoutProps> = ({
       >
         <InboundLineEditPanel value={Tabs.Batch}>
           <QuantityTable
+            item={item}
             isDisabled={isDisabled}
             lines={draftLines}
             updateDraftLine={updateDraftLine}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -13,7 +13,7 @@ import {
   createQueryParamsStore,
   NonNegativeIntegerCell,
   CellProps,
-  ColumnAlign,
+  getColumnLookupWithOverrides,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
@@ -102,16 +102,13 @@ export const QuantityTableComponent: FC<
           setter: updateDraftLine,
         },
       ],
-      {
+      getColumnLookupWithOverrides('packSize', {
         label: unitVariantsExist
           ? 'label.unit-variant-and-pack-size'
           : 'label.pack-size',
-        key: 'packSize',
-        width: 125,
-        align: ColumnAlign.Right,
         Cell: PackUnitEntryCell,
         setter: updateDraftLine,
-      },
+      }),
       [
         'unitQuantity',
         {

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -21,7 +21,7 @@ import {
   LocationRowFragment,
   useInitUnitStore,
 } from '@openmsupply-client/system';
-import { getPackUnitEntryCell } from 'packages/system/src/Item/Components/ItemVariant';
+import { getPackUnitEntryCell } from '@openmsupply-client/system';
 
 interface TableProps {
   lines: DraftInboundLine[];

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -13,15 +13,17 @@ import {
   createQueryParamsStore,
   NonNegativeIntegerCell,
   CellProps,
-  getColumnLookup,
+  ColumnAlign,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import {
   getLocationInputColumn,
   LocationRowFragment,
   useInitUnitStore,
+  useUnitVariant,
 } from '@openmsupply-client/system';
 import { getPackUnitEntryCell } from '@openmsupply-client/system';
+import { InboundLineFragment } from '../../../api';
 
 interface TableProps {
   lines: DraftInboundLine[];
@@ -79,14 +81,14 @@ const PackUnitEntryCell = getPackUnitEntryCell<DraftInboundLine>({
   getUnitName: r => r.item.unitName || null,
 });
 
-export const QuantityTableComponent: FC<TableProps> = ({
-  lines,
-  updateDraftLine,
-  isDisabled = false,
-}) => {
+export const QuantityTableComponent: FC<
+  TableProps & { item: InboundLineFragment['item'] | null }
+> = ({ item, lines, updateDraftLine, isDisabled = false }) => {
   // TODO this is not the right place for it, see comment in method
   useInitUnitStore();
+  const { unitVariantsExist } = useUnitVariant(item?.id || '', null);
   const theme = useTheme();
+
   const columns = useColumns<DraftInboundLine>(
     [
       getBatchColumn(updateDraftLine, theme),
@@ -101,7 +103,12 @@ export const QuantityTableComponent: FC<TableProps> = ({
         },
       ],
       {
-        ...getColumnLookup<DraftInboundLine>()['packSize'],
+        label: unitVariantsExist
+          ? 'label.unit-variant-and-pack-size'
+          : 'label.pack-size',
+        key: 'packSize',
+        width: 125,
+        align: ColumnAlign.Right,
         Cell: PackUnitEntryCell,
         setter: updateDraftLine,
       },

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
@@ -9,12 +9,14 @@ export interface CreateDraftInboundLineParams {
   invoiceId: string;
   seed?: InboundLineFragment;
   type?: InvoiceLineNodeType;
+  defaultPackSize: number;
 }
 
 const createDraftInboundLine = ({
   item,
   invoiceId,
   seed,
+  defaultPackSize,
   type = InvoiceLineNodeType.StockIn,
 }: CreateDraftInboundLineParams): DraftInboundLine => {
   const draftLine: DraftInboundLine = {
@@ -26,7 +28,7 @@ const createDraftInboundLine = ({
     sellPricePerPack: 0,
     costPricePerPack: 0,
     numberOfPacks: 0,
-    packSize: item.defaultPackSize,
+    packSize: defaultPackSize,
     isCreated: seed ? false : true,
     expiryDate: undefined,
     location: undefined,
@@ -40,6 +42,12 @@ const createDraftInboundLine = ({
 
 export const CreateDraft = {
   stockInLine: createDraftInboundLine,
-  serviceLine: (params: Omit<CreateDraftInboundLineParams, 'type'>) =>
-    createDraftInboundLine({ ...params, type: InvoiceLineNodeType.Service }),
+  serviceLine: (
+    params: Omit<CreateDraftInboundLineParams, 'type' | 'defaultPackSize'>
+  ) =>
+    createDraftInboundLine({
+      ...params,
+      type: InvoiceLineNodeType.Service,
+      defaultPackSize: 1,
+    }),
 };

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -19,9 +19,8 @@ import {
   ItemRowFragment,
 } from '@openmsupply-client/system';
 import { usePrescription } from '../../api';
-import { DraftItem } from '../../..';
+import { DraftItem, DraftStockOutLine } from '../../..';
 import { PackSizeController } from '../../../StockOut';
-import { DraftStockOutLine } from 'packages/invoices/src/types';
 
 interface PrescriptionLineEditFormProps {
   allocatedQuantity: number;

--- a/client/packages/invoices/src/index.ts
+++ b/client/packages/invoices/src/index.ts
@@ -1,4 +1,4 @@
-import { ItemRowFragment } from 'packages/system/src';
+import { ItemRowFragment } from '@openmsupply-client/system';
 
 export { default as InvoiceService } from './InvoiceService';
 export { useOutbound } from './OutboundShipment/api';
@@ -10,3 +10,5 @@ export type Draft = {
   item?: DraftItem;
   barcode?: { id?: string; gtin: string; batch?: string };
 };
+
+export { DraftStockOutLine } from './types';

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
@@ -19,7 +19,7 @@ export const getPackUnitEntryCell =
     getUnitName: (row: T) => string | null;
   }) =>
   ({ rowData, column }: CellProps<T>): ReactElement => {
-    const { asPackUnit, variantsControl } = useUnitVariant(
+    const { variantsControl } = useUnitVariant(
       getItemId(rowData),
       getUnitName(rowData)
     );
@@ -34,7 +34,7 @@ export const getPackUnitEntryCell =
     const numberInput = (
       <PositiveNumberInput
         value={packSize}
-        // Should PoaistiveNumberInput ever return undefined ?
+        // Should PositiveNumberInput ever return undefined ?
         onChange={newValue => {
           setPackSize(newValue || 1);
           updater({ ...rowData, [column.key]: newValue });
@@ -48,22 +48,19 @@ export const getPackUnitEntryCell =
     }
 
     const { variants } = variantsControl;
-
-    // Options should include manually entered option
-    const extraOptions = variants.find(v => v.packSize === packSize)
-      ? []
-      : [{ label: asPackUnit(packSize), value: packSize }];
+    const isManuallyEntered =
+      variants.find(v => v.packSize === packSize) === undefined;
 
     return (
       <Box display="flex" flexDirection="row">
-        {numberInput}
+        {(packSize === 1 || isManuallyEntered) && numberInput}
         <Select
-          sx={{ flexGrow: 1 }}
-          options={[
-            ...extraOptions,
-            ...variants.map(v => ({ label: v.shortName, value: v.packSize })),
-          ]}
-          value={packSize}
+          sx={{ flexGrow: 1, marginLeft: '-2px' }}
+          options={variants.map(v => ({
+            label: v.shortName,
+            value: v.packSize,
+          }))}
+          value={isManuallyEntered ? 1 : packSize}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const newValue = Number(e.target.value);
 

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
@@ -6,8 +6,12 @@ import {
   PositiveNumberInput,
   useDebounceCallback,
   Box,
+  useTranslation,
+  InnerBasicCell,
 } from '@openmsupply-client/common';
 import { useUnitVariant } from '../../context';
+
+const ENTER_PACK_SIZE = -1;
 
 // This cell displays a packSize number input and unit pack drop down if unit pack variants exist
 export const getPackUnitEntryCell =
@@ -23,7 +27,8 @@ export const getPackUnitEntryCell =
       getItemId(rowData),
       getUnitName(rowData)
     );
-
+    const t = useTranslation();
+    const [isEnterPackSize, setIsEnterPackSize] = useState(false);
     const [packSize, setPackSize] = useState(
       Number(column.accessor({ rowData }))
     );
@@ -31,43 +36,67 @@ export const getPackUnitEntryCell =
     const updater = useDebounceCallback(column.setter, [column.setter], 250);
 
     // This is shared between input with drop down and without drop down
-    const numberInput = (
-      <PositiveNumberInput
-        value={packSize}
-        // Should PositiveNumberInput ever return undefined ?
-        onChange={newValue => {
-          setPackSize(newValue || 1);
-          updater({ ...rowData, [column.key]: newValue });
-        }}
-      />
-    );
-
-    if (!variantsControl) {
-      // If no variants exist, then default to just pack size entry
-      return numberInput;
-    }
-
-    const { variants } = variantsControl;
-    const isManuallyEntered =
-      variants.find(v => v.packSize === packSize) === undefined;
-
-    return (
-      <Box display="flex" flexDirection="row">
-        {(packSize === 1 || isManuallyEntered) && numberInput}
-        <Select
-          sx={{ flexGrow: 1, marginLeft: '-2px' }}
-          options={variants.map(v => ({
-            label: v.shortName,
-            value: v.packSize,
-          }))}
-          value={isManuallyEntered ? 1 : packSize}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            const newValue = Number(e.target.value);
-
-            setPackSize(newValue);
+    const numberInput = () => {
+      return (
+        <PositiveNumberInput
+          focusOnRender={isEnterPackSize}
+          value={packSize}
+          onChange={newValue => {
+            setPackSize(newValue || 1);
             updater({ ...rowData, [column.key]: newValue });
           }}
         />
+      );
+    };
+
+    if (!variantsControl) {
+      // If no variants exist, then default to just pack size entry
+      return numberInput();
+    }
+
+    const { variants } = variantsControl;
+
+    const options = [
+      ...variants.map(v => ({
+        label: v.shortName,
+        value: v.packSize,
+      })),
+      {
+        label: t('label.enter-pack-size'),
+        value: ENTER_PACK_SIZE,
+      },
+    ];
+
+    return (
+      <Box display="flex" flexDirection="row" alignItems="center">
+        <Select
+          sx={{ flexGrow: 1, marginLeft: '-2px' }}
+          options={options}
+          value={isEnterPackSize ? ENTER_PACK_SIZE : packSize}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const newValue = Number(e.target.value);
+
+            // When manually entered pack size is selected, turn on manual entry
+            // and set pack size to 1
+            const isEnterPackSizeSelected = newValue === ENTER_PACK_SIZE;
+            const newPackSize = isEnterPackSizeSelected ? 1 : newValue;
+
+            setPackSize(newPackSize);
+            setIsEnterPackSize(isEnterPackSizeSelected);
+            updater({ ...rowData, [column.key]: newPackSize });
+          }}
+        />
+
+        <InnerBasicCell value={'/'} />
+
+        {
+          /* Allo input only when manually entering pack size */
+          isEnterPackSize ? (
+            numberInput()
+          ) : (
+            <InnerBasicCell value={String(packSize)} />
+          )
+        }
       </Box>
     );
   };

--- a/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
+++ b/client/packages/system/src/Item/Components/ItemVariant/PackUnitEntryCell.tsx
@@ -1,0 +1,76 @@
+import React, { ReactElement, useState } from 'react';
+import {
+  RecordWithId,
+  CellProps,
+  Select,
+  PositiveNumberInput,
+  useDebounceCallback,
+  Box,
+} from '@openmsupply-client/common';
+import { useUnitVariant } from '../../context';
+
+// This cell displays a packSize number input and unit pack drop down if unit pack variants exist
+export const getPackUnitEntryCell =
+  <T extends RecordWithId>({
+    getItemId,
+    getUnitName,
+  }: {
+    getItemId: (row: T) => string;
+    getUnitName: (row: T) => string | null;
+  }) =>
+  ({ rowData, column }: CellProps<T>): ReactElement => {
+    const { asPackUnit, variantsControl } = useUnitVariant(
+      getItemId(rowData),
+      getUnitName(rowData)
+    );
+
+    const [packSize, setPackSize] = useState(
+      Number(column.accessor({ rowData }))
+    );
+
+    const updater = useDebounceCallback(column.setter, [column.setter], 250);
+
+    // This is shared between input with drop down and without drop down
+    const numberInput = (
+      <PositiveNumberInput
+        value={packSize}
+        // Should PoaistiveNumberInput ever return undefined ?
+        onChange={newValue => {
+          setPackSize(newValue || 1);
+          updater({ ...rowData, [column.key]: newValue });
+        }}
+      />
+    );
+
+    if (!variantsControl) {
+      // If no variants exist, then default to just pack size entry
+      return numberInput;
+    }
+
+    const { variants } = variantsControl;
+
+    // Options should include manually entered option
+    const extraOptions = variants.find(v => v.packSize === packSize)
+      ? []
+      : [{ label: asPackUnit(packSize), value: packSize }];
+
+    return (
+      <Box display="flex" flexDirection="row">
+        {numberInput}
+        <Select
+          sx={{ flexGrow: 1 }}
+          options={[
+            ...extraOptions,
+            ...variants.map(v => ({ label: v.shortName, value: v.packSize })),
+          ]}
+          value={packSize}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const newValue = Number(e.target.value);
+
+            setPackSize(newValue);
+            updater({ ...rowData, [column.key]: newValue });
+          }}
+        />
+      </Box>
+    );
+  };

--- a/client/packages/system/src/Item/Components/ItemVariant/index.ts
+++ b/client/packages/system/src/Item/Components/ItemVariant/index.ts
@@ -1,3 +1,4 @@
 export * from './PackUnitCell';
 export * from './PackUnitSelectCell';
 export * from './PackUnitQuantityCell';
+export * from './PackUnitEntryCell';

--- a/client/packages/system/src/Item/Components/index.ts
+++ b/client/packages/system/src/Item/Components/index.ts
@@ -1,3 +1,4 @@
+export * from './ItemVariant';
 export * from './ServiceItemSearchInput';
 export * from './StockItemSearchInputWithStats';
 export * from './StockItemSelectModal';

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -87,6 +87,7 @@ export const useUnitVariant = (
     activeVariant: VariantNode;
     setUserSelectedVariant: (variantId: string) => void;
   };
+  unitVariantsExist: boolean;
 } => {
   const [item, userSelectedVariantId, setUserSelectedVariant] = useUnitStore(
     state => [
@@ -102,6 +103,7 @@ export const useUnitVariant = (
     return {
       asPackUnit: packSize => commonAsPackUnit({ packSize, unitName, t }),
       numberOfPacksFromQuantity: totalQuantity => totalQuantity,
+      unitVariantsExist: false,
     };
   }
 
@@ -139,5 +141,6 @@ export const useUnitVariant = (
       setUserSelectedVariant: variantId =>
         setUserSelectedVariant({ itemId, variantId }),
     },
+    unitVariantsExist: true,
   };
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2208

https://github.com/openmsupply/open-msupply/assets/26194949/1f9a7342-af49-4179-87bb-b347e4faec08

# 👩🏻‍💻 What does this PR do? 

Creates input for pack size, using unit packs configurations.

If unit pack variants are configured for item, then a select drop down is added. (for now inbound shipment only, but should also be in stocktake).

Also uses unit variant 'active' packSize, if exists, in favour to defaultPackSize on item.

# 🧪 How has/should this change been tested? 

init database with: `cargo run --bin remote_server_cli -- initialise-from-export -n reference1`

Create new inbound shipment and add lines, for [these items](https://github.com/openmsupply/open-msupply/blob/182464d70543241a42b96b5e825912d58b335fa0/server/graphql/general/src/queries/item_variant.rs#L18) a drop down should be added. Drop down current variant should match the pack size that is manually entered, and if no variant found, one should be added with default display (same as default display for columns in stock view).

Items with no configured unit pack variants, should look and behave the same (i.e. default pack size should come from item).

## 💌 Any notes for the reviewer?

The original KDD mock up had one field to do both things (enter pack and select pack), I started implementing it, but it seemed not very user friendly

## 📃 Documentation
