### PR TITLE
2210 The "no stock available" message needs to be set for prescriptions

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -62,6 +62,7 @@
   "messages.recorded-on": "Recorded on {{datetime}}",
   "messages.results-found": "{{totalCount}} results found",
   "messages.results-over-limit": "Showing the first 100 results only - please refine your search",  
+  "messages.no-stock-available": "There is no stock available",
   "placeholder.search-by-first-name": "Search by first name",
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id",

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -19,14 +19,17 @@ import {
 } from '@openmsupply-client/common';
 import { OutboundLineEditTable } from './OutboundLineEditTable';
 import { OutboundLineEditForm } from './OutboundLineEditForm';
-import {
-  useDraftOutboundLines,
-  useNextItem,
-} from './hooks';
+import { useDraftOutboundLines, useNextItem } from './hooks';
 import { useOutbound } from '../../api';
 import { getPackQuantityCellId } from '../../../utils';
 import { Draft, DraftItem } from '../../..';
-import { PackSizeController, allocateQuantities, getAllocatedQuantity, sumAvailableQuantity, usePackSizeController } from '../../../StockOut';
+import {
+  PackSizeController,
+  allocateQuantities,
+  getAllocatedQuantity,
+  sumAvailableQuantity,
+  usePackSizeController,
+} from '../../../StockOut';
 import { DraftStockOutLine } from '../../../types';
 
 interface ItemDetailsModalProps {
@@ -104,9 +107,8 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
     // it is possible for the user to select multiple batch lines
     // if the scanned barcode does not contain a batch number
     // however the scanned barcode can only relate to a specific pack size and therefore batch
-    const packSize = draftStockOutLines.find(
-      line => line.numberOfPacks > 0
-    )?.packSize;
+    const packSize = draftStockOutLines.find(line => line.numberOfPacks > 0)
+      ?.packSize;
 
     const input = {
       input: {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -32,11 +32,12 @@ export const useDraftOutboundLines = (
   const [draftStockOutLines, setDraftStockOutLines] = useState<
     DraftStockOutLine[]
   >([]);
+  const noStockLines = !data?.nodes.length;
 
   useConfirmOnLeaving(isDirty);
 
   useEffect(() => {
-    if (!item) {
+    if (!item || noStockLines) {
       return setDraftStockOutLines([]);
     }
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -37,6 +37,8 @@ export const useDraftOutboundLines = (
   useConfirmOnLeaving(isDirty);
 
   useEffect(() => {
+    // Check placed in since last else in the map is needed to show placeholder row,
+    // but also causes a placeholder row to be created when there is no stock lines.
     if (!item || noStockLines) {
       return setDraftStockOutLines([]);
     }

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -147,6 +147,10 @@ export const PrescriptionLineEditForm: React.FC<
               />
             </Grid>
           </ModalRow>
+        </>
+      )}
+      {item && canAutoAllocate ? (
+        <>
           <ModalRow>
             <ModalLabel label={t('label.note')} />
             <BasicTextInput
@@ -163,10 +167,6 @@ export const PrescriptionLineEditForm: React.FC<
               style={{ flex: 1 }}
             />
           </ModalRow>
-        </>
-      )}
-      {item && canAutoAllocate ? (
-        <>
           <Divider margin={10} />
           <Grid container>
             <ModalLabel label={t('label.issue')} />


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2210 

# 👩🏻‍💻 What does this PR do? 
Display no stock available message for prescription and outbound shipments (see screenshots below). Have also hid the prescriptions note component if there is no stock line for that item.
#### Prescription
![Screenshot 2023-09-12 at 8 14 35 AM](https://github.com/openmsupply/open-msupply/assets/61820074/53aedb23-a124-4b8f-b72b-2559554e466a)
#### Outbound
![Screenshot 2023-09-12 at 8 17 15 AM](https://github.com/openmsupply/open-msupply/assets/61820074/57debc7f-3782-40c6-829b-7e22b66e3bfb)

# 🧪 How has/should this change been tested? 
- [ ] Go to outbound/prescription
- [ ] Try add item with no stock line
- [ ] See message