### PR TITLE
Add programEvents node to the EncounterNode + misc related updates

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -32,6 +32,17 @@ export type Scalars = {
   NaiveDate: { input: string; output: string; }
 };
 
+export type ActiveEncounterEventFilterInput = {
+  data?: InputMaybe<StringFilterInput>;
+  /**
+   * 	Only include events that are for the current encounter, i.e. have matching encounter type
+   * and matching encounter name of the current encounter. If not set all events with matching
+   * encounter type are returned.
+   */
+  isCurrentEncounter?: InputMaybe<Scalars['Boolean']['input']>;
+  type?: InputMaybe<EqualFilterStringInput>;
+};
+
 export type ActivityLogConnector = {
   __typename: 'ActivityLogConnector';
   nodes: Array<ActivityLogNode>;
@@ -979,6 +990,10 @@ export type EncounterConnector = {
 };
 
 export type EncounterEventFilterInput = {
+  activeEndDatetime?: InputMaybe<DatetimeFilterInput>;
+  activeStartDatetime?: InputMaybe<DatetimeFilterInput>;
+  data?: InputMaybe<StringFilterInput>;
+  datetime?: InputMaybe<DatetimeFilterInput>;
   /**
    * 	Only include events that are for the current encounter, i.e. have matching encounter type
    * and matching encounter name of the current encounter. If not set all events with matching
@@ -1023,7 +1038,7 @@ export type EncounterFilterInput = {
 
 export type EncounterNode = {
   __typename: 'EncounterNode';
-  activeProgramEvents: Array<ProgramEventNode>;
+  activeProgramEvents: ProgramEventResponse;
   clinician?: Maybe<ClinicianNode>;
   contextId: Scalars['String']['output'];
   createdDatetime: Scalars['DateTime']['output'];
@@ -1036,6 +1051,7 @@ export type EncounterNode = {
   patientId: Scalars['String']['output'];
   /** Returns the matching program enrolment for the patient of this encounter */
   programEnrolment?: Maybe<ProgramEnrolmentNode>;
+  programEvents: ProgramEventResponse;
   programId: Scalars['String']['output'];
   startDatetime: Scalars['DateTime']['output'];
   status?: Maybe<EncounterNodeStatus>;
@@ -1045,7 +1061,14 @@ export type EncounterNode = {
 
 export type EncounterNodeActiveProgramEventsArgs = {
   at?: InputMaybe<Scalars['DateTime']['input']>;
+  filter?: InputMaybe<ActiveEncounterEventFilterInput>;
+};
+
+
+export type EncounterNodeProgramEventsArgs = {
   filter?: InputMaybe<EncounterEventFilterInput>;
+  page?: InputMaybe<PaginationInput>;
+  sort?: InputMaybe<ProgramEventSortInput>;
 };
 
 export enum EncounterNodeStatus {
@@ -3252,7 +3275,7 @@ export type ProgramEnrolmentFilterInput = {
 
 export type ProgramEnrolmentNode = {
   __typename: 'ProgramEnrolmentNode';
-  activeProgramEvents: Array<ProgramEventNode>;
+  activeProgramEvents: ProgramEventResponse;
   contextId: Scalars['String']['output'];
   /** The encounter document */
   document: DocumentNode;
@@ -3317,6 +3340,7 @@ export type ProgramEventConnector = {
 export type ProgramEventFilterInput = {
   activeEndDatetime?: InputMaybe<DatetimeFilterInput>;
   activeStartDatetime?: InputMaybe<DatetimeFilterInput>;
+  data?: InputMaybe<StringFilterInput>;
   documentName?: InputMaybe<EqualFilterStringInput>;
   documentType?: InputMaybe<EqualFilterStringInput>;
   patientId?: InputMaybe<EqualFilterStringInput>;
@@ -3326,7 +3350,8 @@ export type ProgramEventFilterInput = {
 
 export type ProgramEventNode = {
   __typename: 'ProgramEventNode';
-  activeDatetime: Scalars['DateTime']['output'];
+  activeEndDatetime: Scalars['DateTime']['output'];
+  activeStartDatetime: Scalars['DateTime']['output'];
   data?: Maybe<Scalars['String']['output']>;
   datetime: Scalars['DateTime']['output'];
   /** The document associated with the document_name */

--- a/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
+++ b/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
@@ -105,7 +105,7 @@ const usePreviousCountFromEvent = (
 
   return {
     count,
-    time: new Date(event.activeDatetime),
+    time: new Date(event.activeStartDatetime),
   };
 };
 

--- a/client/packages/programs/src/api/api.ts
+++ b/client/packages/programs/src/api/api.ts
@@ -11,7 +11,6 @@ import {
   PaginationInput,
   ProgramEnrolmentSortFieldInput,
   ProgramEventFilterInput,
-  ProgramEventNode,
   UpdateEncounterInput,
   UpdateProgramEnrolmentInput,
   ProgramEnrolmentFilterInput,
@@ -27,6 +26,7 @@ import {
   FormSchemaFragment,
   ProgramEnrolmentFragment,
   ProgramEnrolmentRowFragment,
+  ProgramEventFragment,
   Sdk,
 } from './operations.generated';
 
@@ -386,7 +386,7 @@ export const getProgramEventQueries = (sdk: Sdk, storeId: string) => ({
     filter,
     page,
   }: ProgramEventParams): Promise<{
-    nodes: ProgramEventNode[];
+    nodes: ProgramEventFragment[];
     totalCount: number;
   }> => {
     const result = await sdk.activeProgramEvents({

--- a/client/packages/programs/src/api/hooks/document/useProgramEnrolments.ts
+++ b/client/packages/programs/src/api/hooks/document/useProgramEnrolments.ts
@@ -28,7 +28,7 @@ export const useProgramEnrolmentsPromise = () => {
     return {
       nodes: programs.nodes.map(node => {
         // only take the latest status event
-        const events = node.activeProgramEvents
+        const events = node.activeProgramEvents.nodes
           .filter(e => e.type === 'programStatus' && e.data)
           .slice(0, 1);
         return {
@@ -57,7 +57,7 @@ export const useProgramEnrolments = (input: ProgramEnrolmentListParams) => {
     api.programEnrolments(params).then(programs => ({
       nodes: programs.nodes.map(node => {
         // only take the latest status event
-        const events = node.activeProgramEvents
+        const events = node.activeProgramEvents.nodes
           .filter(e => e.type === 'programStatus' && e.data)
           .slice(0, 1);
         return {

--- a/client/packages/programs/src/api/operations.generated.ts
+++ b/client/packages/programs/src/api/operations.generated.ts
@@ -53,7 +53,7 @@ export type AllocateProgramNumberMutation = { __typename: 'Mutations', allocateP
 
 export type EncounterFieldsFragment = { __typename: 'EncounterFieldsNode', fields: Array<any>, encounter: { __typename: 'EncounterNode', name: string, startDatetime: string, endDatetime?: string | null } };
 
-export type ProgramEventFragment = { __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null };
+export type ProgramEventFragment = { __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null };
 
 export type EncounterFieldsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -95,7 +95,7 @@ export type EncounterByDocNameQueryVariables = Types.Exact<{
 
 export type EncounterByDocNameQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } }> } };
 
-export type EncounterRowFragment = { __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> };
+export type EncounterRowFragment = { __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: { __typename: 'ProgramEventConnector', nodes: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> } };
 
 export type EncountersQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -107,7 +107,7 @@ export type EncountersQueryVariables = Types.Exact<{
 }>;
 
 
-export type EncountersQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> }> } };
+export type EncountersQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: { __typename: 'ProgramEventConnector', nodes: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> } }> } };
 
 export type InsertEncounterMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -125,7 +125,7 @@ export type UpdateEncounterMutationVariables = Types.Exact<{
 
 export type UpdateEncounterMutation = { __typename: 'Mutations', updateEncounter: { __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } } };
 
-export type ProgramEnrolmentRowFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> };
+export type ProgramEnrolmentRowFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: { __typename: 'ProgramEventConnector', nodes: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> } };
 
 export type ProgramEnrolmentsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -136,7 +136,7 @@ export type ProgramEnrolmentsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ProgramEnrolmentsQuery = { __typename: 'Queries', programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> }> } };
+export type ProgramEnrolmentsQuery = { __typename: 'Queries', programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: { __typename: 'ProgramEventConnector', nodes: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> } }> } };
 
 export type ProgramEnrolmentFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } };
 
@@ -193,7 +193,7 @@ export type ActiveProgramEventsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ActiveProgramEventsQuery = { __typename: 'Queries', activeProgramEvents: { __typename: 'ProgramEventConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEventNode', type: string, patientId?: string | null, documentType: string, documentName?: string | null, datetime: string, data?: string | null, activeDatetime: string }> } };
+export type ActiveProgramEventsQuery = { __typename: 'Queries', activeProgramEvents: { __typename: 'ProgramEventConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> } };
 
 export const EncounterFieldsFragmentDoc = gql`
     fragment EncounterFields on EncounterFieldsNode {
@@ -281,9 +281,10 @@ export const EncounterFragmentDoc = gql`
     ${DocumentFragmentDoc}`;
 export const ProgramEventFragmentDoc = gql`
     fragment ProgramEvent on ProgramEventNode {
-  activeDatetime
+  activeStartDatetime
   type
   data
+  documentName
 }
     `;
 export const EncounterRowFragmentDoc = gql`
@@ -307,7 +308,12 @@ export const EncounterRowFragmentDoc = gql`
     name
   }
   activeProgramEvents(at: $eventTime, filter: {isCurrentEncounter: true}) {
-    ...ProgramEvent
+    ... on ProgramEventConnector {
+      nodes {
+        __typename
+        ...ProgramEvent
+      }
+    }
   }
 }
     ${ProgramEventFragmentDoc}`;
@@ -327,7 +333,12 @@ export const ProgramEnrolmentRowFragmentDoc = gql`
     }
   }
   activeProgramEvents(at: $eventTime) {
-    ...ProgramEvent
+    ... on ProgramEventConnector {
+      nodes {
+        __typename
+        ...ProgramEvent
+      }
+    }
   }
 }
     ${ProgramEventFragmentDoc}`;
@@ -626,18 +637,12 @@ export const ActiveProgramEventsDocument = gql`
       totalCount
       nodes {
         __typename
-        type
-        patientId
-        documentType
-        documentName
-        datetime
-        data
-        activeDatetime
+        ...ProgramEvent
       }
     }
   }
 }
-    `;
+    ${ProgramEventFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 

--- a/client/packages/programs/src/api/operations.graphql
+++ b/client/packages/programs/src/api/operations.graphql
@@ -111,9 +111,10 @@ fragment EncounterFields on EncounterFieldsNode {
 }
 
 fragment ProgramEvent on ProgramEventNode {
-  activeDatetime
+  activeStartDatetime
   type
   data
+  documentName
 }
 
 query encounterFields(
@@ -248,7 +249,12 @@ fragment EncounterRow on EncounterNode {
     name
   }
   activeProgramEvents(at: $eventTime, filter: { isCurrentEncounter: true }) {
-    ...ProgramEvent
+    ... on ProgramEventConnector {
+      nodes {
+        __typename
+        ...ProgramEvent
+      }
+    }
   }
 }
 
@@ -311,7 +317,12 @@ fragment ProgramEnrolmentRow on ProgramEnrolmentNode {
     }
   }
   activeProgramEvents(at: $eventTime) {
-    ...ProgramEvent
+    ... on ProgramEventConnector {
+      nodes {
+        __typename
+        ...ProgramEvent
+      }
+    }
   }
 }
 
@@ -461,13 +472,7 @@ query activeProgramEvents(
       totalCount
       nodes {
         __typename
-        type
-        patientId
-        documentType
-        documentName
-        datetime
-        data
-        activeDatetime
+        ...ProgramEvent
       }
     }
   }

--- a/client/packages/system/src/Encounter/ListView/columns.ts
+++ b/client/packages/system/src/Encounter/ListView/columns.ts
@@ -29,7 +29,9 @@ const useEncounterAdditionalInfoAccessor: () => {
   const t = useTranslation();
   return {
     additionalInfoAccessor: ({ rowData }): string[] => {
-      const additionalInfo = getStatusEventData(rowData.activeProgramEvents);
+      const additionalInfo = getStatusEventData(
+        rowData.activeProgramEvents.nodes
+      );
 
       if (rowData?.status === EncounterNodeStatus.Pending) {
         const startDatetime = new Date(rowData?.startDatetime);

--- a/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
+++ b/client/packages/system/src/Patient/ProgramEnrolment/Components/ListView.tsx
@@ -28,7 +28,7 @@ const programAdditionalInfoAccessor: ColumnDataAccessor<
   ProgramEnrolmentRowFragmentWithId,
   string[]
 > = ({ rowData }): string[] => {
-  const additionalInfo = getStatusEventData(rowData.activeProgramEvents);
+  const additionalInfo = getStatusEventData(rowData.activeProgramEvents.nodes);
   return additionalInfo;
 };
 

--- a/server/graphql/programs/src/lib.rs
+++ b/server/graphql/programs/src/lib.rs
@@ -12,6 +12,7 @@ use graphql_types::types::patient::PatientNode;
 use graphql_types::types::program_enrolment::ProgramEnrolmentFilterInput;
 use graphql_types::types::program_enrolment::ProgramEnrolmentSortInput;
 use graphql_types::types::program_enrolment::ProgramEventFilterInput;
+use graphql_types::types::program_event::ProgramEventResponse;
 use graphql_types::types::program_event::ProgramEventSortInput;
 use mutations::allocate_number::allocate_program_number;
 use mutations::allocate_number::AllocateProgramNumberInput;

--- a/server/graphql/programs/src/queries/program_event.rs
+++ b/server/graphql/programs/src/queries/program_event.rs
@@ -7,21 +7,12 @@ use graphql_core::{
 };
 use graphql_types::types::{
     program_enrolment::ProgramEventFilterInput,
-    program_event::{ProgramEventNode, ProgramEventSortInput},
+    program_event::{
+        ProgramEventConnector, ProgramEventNode, ProgramEventResponse, ProgramEventSortInput,
+    },
 };
 use repository::{PaginationOption, ProgramEventFilter};
 use service::auth::{Resource, ResourceAccessRequest};
-
-#[derive(SimpleObject)]
-pub struct ProgramEventConnector {
-    pub total_count: u32,
-    pub nodes: Vec<ProgramEventNode>,
-}
-
-#[derive(Union)]
-pub enum ProgramEventResponse {
-    Response(ProgramEventConnector),
-}
 
 pub fn program_events(
     ctx: &Context<'_>,
@@ -74,7 +65,6 @@ pub fn program_events(
 
     Ok(ProgramEventResponse::Response(ProgramEventConnector {
         total_count: list_result.count,
-
         nodes,
     }))
 }

--- a/server/graphql/types/src/types/program/encounter.rs
+++ b/server/graphql/types/src/types/program/encounter.rs
@@ -350,6 +350,8 @@ impl EncounterNode {
         ctx: &Context<'_>,
         at: Option<DateTime<Utc>>,
         filter: Option<ActiveEncounterEventFilterInput>,
+        page: Option<PaginationInput>,
+        sort: Option<ProgramEventSortInput>,
     ) -> Result<ProgramEventResponse> {
         // TODO use loader?
         let context = ctx.service_provider().basic_context()?;
@@ -370,12 +372,12 @@ impl EncounterNode {
                 &context,
                 at.map(|at| at.naive_utc())
                     .unwrap_or(Utc::now().naive_utc()),
-                None,
+                page.map(PaginationOption::from),
                 Some(program_filter),
-                Some(Sort {
+                Some(sort.map(ProgramEventSortInput::to_domain).unwrap_or(Sort {
                     key: ProgramEventSortField::Datetime,
                     desc: Some(true),
-                }),
+                })),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
 

--- a/server/graphql/types/src/types/program/program_enrolment.rs
+++ b/server/graphql/types/src/types/program/program_enrolment.rs
@@ -17,7 +17,7 @@ use repository::{
 use super::{
     document::DocumentNode,
     encounter::{EncounterConnector, EncounterFilterInput, EncounterNode, EncounterSortInput},
-    program_event::ProgramEventNode,
+    program_event::{ProgramEventConnector, ProgramEventNode, ProgramEventResponse},
 };
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -110,6 +110,7 @@ pub struct ProgramEventFilterInput {
     pub document_name: Option<EqualFilterStringInput>,
     /// The event type
     pub r#type: Option<EqualFilterStringInput>,
+    pub data: Option<StringFilterInput>,
     pub active_start_datetime: Option<DatetimeFilterInput>,
     pub active_end_datetime: Option<DatetimeFilterInput>,
 }
@@ -121,6 +122,7 @@ impl ProgramEventFilterInput {
             document_type,
             document_name,
             r#type,
+            data,
             active_start_datetime,
             active_end_datetime,
         } = self;
@@ -131,6 +133,7 @@ impl ProgramEventFilterInput {
             document_type: document_type.map(EqualFilter::from),
             document_name: document_name.map(EqualFilter::from),
             r#type: r#type.map(EqualFilter::from),
+            data: data.map(StringFilter::from),
             datetime: None,
             context_id: None,
         }
@@ -272,7 +275,7 @@ impl ProgramEnrolmentNode {
         ctx: &Context<'_>,
         at: Option<DateTime<Utc>>,
         filter: Option<ProgramEventFilterInput>,
-    ) -> Result<Vec<ProgramEventNode>> {
+    ) -> Result<ProgramEventResponse> {
         // TODO use loader?
         let context = ctx.service_provider().basic_context()?;
         let filter = filter
@@ -282,7 +285,7 @@ impl ProgramEnrolmentNode {
             .document_type(EqualFilter::equal_to(
                 &self.program_enrolment.0.document_type,
             ));
-        let entries = ctx
+        let list_result = ctx
             .service_provider()
             .program_event_service
             .active_events(
@@ -297,14 +300,17 @@ impl ProgramEnrolmentNode {
                 }),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
-        Ok(entries
-            .rows
-            .into_iter()
-            .map(|row| ProgramEventNode {
-                store_id: self.store_id.clone(),
-                row,
-                allowed_ctx: self.allowed_ctx.clone(),
-            })
-            .collect())
+        Ok(ProgramEventResponse::Response(ProgramEventConnector {
+            total_count: list_result.count,
+            nodes: list_result
+                .rows
+                .into_iter()
+                .map(|row| ProgramEventNode {
+                    store_id: self.store_id.clone(),
+                    row,
+                    allowed_ctx: self.allowed_ctx.clone(),
+                })
+                .collect(),
+        }))
     }
 }

--- a/server/graphql/types/src/types/program/program_enrolment.rs
+++ b/server/graphql/types/src/types/program/program_enrolment.rs
@@ -17,7 +17,9 @@ use repository::{
 use super::{
     document::DocumentNode,
     encounter::{EncounterConnector, EncounterFilterInput, EncounterNode, EncounterSortInput},
-    program_event::{ProgramEventConnector, ProgramEventNode, ProgramEventResponse},
+    program_event::{
+        ProgramEventConnector, ProgramEventNode, ProgramEventResponse, ProgramEventSortInput,
+    },
 };
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -275,6 +277,8 @@ impl ProgramEnrolmentNode {
         ctx: &Context<'_>,
         at: Option<DateTime<Utc>>,
         filter: Option<ProgramEventFilterInput>,
+        page: Option<PaginationInput>,
+        sort: Option<ProgramEventSortInput>,
     ) -> Result<ProgramEventResponse> {
         // TODO use loader?
         let context = ctx.service_provider().basic_context()?;
@@ -292,12 +296,12 @@ impl ProgramEnrolmentNode {
                 &context,
                 at.map(|at| at.naive_utc())
                     .unwrap_or(Utc::now().naive_utc()),
-                None,
+                page.map(PaginationOption::from),
                 Some(filter),
-                Some(Sort {
+                Some(sort.map(ProgramEventSortInput::to_domain).unwrap_or(Sort {
                     key: ProgramEventSortField::Datetime,
                     desc: Some(true),
-                }),
+                })),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
         Ok(ProgramEventResponse::Response(ProgramEventConnector {

--- a/server/graphql/types/src/types/program/program_event.rs
+++ b/server/graphql/types/src/types/program/program_event.rs
@@ -9,6 +9,17 @@ use repository::{ProgramEventRow, ProgramEventSort, ProgramEventSortField};
 
 use super::{document::DocumentNode, patient::PatientNode};
 
+#[derive(SimpleObject)]
+pub struct ProgramEventConnector {
+    pub total_count: u32,
+    pub nodes: Vec<ProgramEventNode>,
+}
+
+#[derive(Union)]
+pub enum ProgramEventResponse {
+    Response(ProgramEventConnector),
+}
+
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 #[graphql(rename_items = "camelCase")]
 pub enum ProgramEventSortFieldInput {
@@ -81,8 +92,12 @@ impl ProgramEventNode {
         DateTime::<Utc>::from_utc(self.row.datetime, Utc)
     }
 
-    pub async fn active_datetime(&self) -> DateTime<Utc> {
+    pub async fn active_start_datetime(&self) -> DateTime<Utc> {
         DateTime::<Utc>::from_utc(self.row.active_start_datetime, Utc)
+    }
+
+    pub async fn active_end_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(self.row.active_end_datetime, Utc)
     }
 
     pub async fn document_type(&self) -> &str {

--- a/server/repository/src/db_diesel/program_event.rs
+++ b/server/repository/src/db_diesel/program_event.rs
@@ -4,8 +4,9 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_date_time_filter, apply_equal_filter, apply_sort},
+    diesel_macros::{apply_date_time_filter, apply_equal_filter, apply_sort, apply_string_filter},
     DBType, DatetimeFilter, EqualFilter, Pagination, ProgramEventRow, RepositoryError, Sort,
+    StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
@@ -20,6 +21,7 @@ pub struct ProgramEventFilter {
     pub context_id: Option<EqualFilter<String>>,
     pub document_name: Option<EqualFilter<String>>,
     pub r#type: Option<EqualFilter<String>>,
+    pub data: Option<StringFilter>,
 }
 
 impl ProgramEventFilter {
@@ -33,6 +35,7 @@ impl ProgramEventFilter {
             context_id: None,
             document_name: None,
             r#type: None,
+            data: None,
         }
     }
 
@@ -75,6 +78,11 @@ impl ProgramEventFilter {
         self.r#type = Some(filter);
         self
     }
+
+    pub fn data(mut self, filter: StringFilter) -> Self {
+        self.data = Some(filter);
+        self
+    }
 }
 
 pub enum ProgramEventSortField {
@@ -111,6 +119,7 @@ macro_rules! apply_filters {
             apply_equal_filter!($query, f.document_type, program_event_dsl::document_type);
             apply_equal_filter!($query, f.document_name, program_event_dsl::document_name);
             apply_equal_filter!($query, f.r#type, program_event_dsl::type_);
+            apply_string_filter!($query, f.data, program_event_dsl::data);
         }
         $query
     }};


### PR DESCRIPTION
Various changes needed for reports.

- Add option to filter by data
- For consistency use ProgramEventResponse for active_program_events and program_events (all UI updates are because of this)
- Update/add active_start_datetime, active_end_datetime fields in ProgramEventNode

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of https://github.com/openmsupply/open-msupply-reports/issues/35

# Testing:
- Programs and encounters should still show without error (e.g. for HIV care)