### PR TITLE
2106 Separate QueryPatient permission from EditPatient

### DIFF
--- a/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
@@ -10,6 +10,8 @@ import {
   FileUtils,
   LoadingButton,
   SortBy,
+  useAuthContext,
+  UserPermission,
 } from '@openmsupply-client/common';
 import { PatientRowFragment, usePatient } from '../api';
 import { patientsToCsv } from '../utils';
@@ -21,6 +23,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
   const { success, error } = useNotification();
   const t = useTranslation('dispensary');
   const { isLoading, mutateAsync } = usePatient.document.listAll(sortBy);
+  const { userHasPermission } = useAuthContext();
   const [open, setOpen] = useState(false);
 
   const csvExport = async () => {
@@ -41,6 +44,7 @@ export const AppBarButtons: FC<{ sortBy: SortBy<PatientRowFragment> }> = ({
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.new-patient')}
+          disabled={!userHasPermission(UserPermission.PatientMutate)}
           onClick={() => setOpen(true)}
         />
         <LoadingButton

--- a/client/packages/system/src/Patient/PatientView/Footer.tsx
+++ b/client/packages/system/src/Patient/PatientView/Footer.tsx
@@ -11,6 +11,8 @@ import {
   useDialog,
   LoadingButton,
   useNavigate,
+  useAuthContext,
+  UserPermission,
 } from '@openmsupply-client/common';
 import { FormInputData, DocumentHistory } from '@openmsupply-client/programs';
 
@@ -34,6 +36,7 @@ export const Footer: FC<FooterProps> = ({
   const t = useTranslation('common');
   const { Modal, showDialog, hideDialog } = useDialog();
   const navigate = useNavigate();
+  const { userHasPermission } = useAuthContext();
 
   return (
     <AppFooterPortal
@@ -68,7 +71,11 @@ export const Footer: FC<FooterProps> = ({
             />
             <LoadingButton
               color="secondary"
-              disabled={!isDirty || !!validationError}
+              disabled={
+                !isDirty ||
+                !!validationError ||
+                !userHasPermission(UserPermission.PatientMutate)
+              }
               isLoading={isSaving}
               onClick={showSaveConfirmation}
             >

--- a/server/service/src/apis/permissions.rs
+++ b/server/service/src/apis/permissions.rs
@@ -47,6 +47,7 @@ pub enum Permissions {
     AddEditGoodsReceived,
     ManageTenders,
     AddPatients,
+    ViewPatients,
     /// not used
     EditRemoteData,
     ChooseDispensaryModeByDefaultOnLogIn,
@@ -377,6 +378,7 @@ pub fn permission_mapping() -> HashMap<i16, Permissions> {
         (177, Permissions::EditStoreCredentials),
         (178, Permissions::ChangeAssetStatus),
         (179, Permissions::AddEditVaccinators),
+        (190, Permissions::ViewPatients),
         (200, Permissions::ConfirmInternalOrderSent),
         (501, Permissions::HISAddPatients),
         (502, Permissions::HISEditPatientsInfo),

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -380,12 +380,13 @@ fn permissions_to_domain(permissions: Vec<Permissions>) -> HashSet<Permission> {
             }
             // patient
             Permissions::AddPatients => {
-                output.insert(Permission::PatientQuery);
                 output.insert(Permission::PatientMutate);
             }
             Permissions::EditPatientDetails => {
-                output.insert(Permission::PatientQuery);
                 output.insert(Permission::PatientMutate);
+            }
+            Permissions::ViewPatients => {
+                output.insert(Permission::PatientQuery);
             }
             // items
             Permissions::EditItems => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2106

# 👩🏻‍💻 What does this PR do? 
Separates the QueryPatient Permission from MutatePatient Permission.

# 🧪 How has/should this change been tested? 
Needs [this branch from mSupply](https://github.com/openmsupply/msupply/tree/%2313592-View-patient-permission-based-on-Edit-patient-details-user-permission) to test. Should still be able to view patients

## 💌 Any notes for the reviewer?
Probably should be merged into main? And needs above branch before merge