### PR TITLE
1737 Requisitions - Confirmation message on Finalisation

### DIFF
--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -102,6 +102,7 @@
   "messages.saved": "Saved",
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.shipment-saved": "Shipment saved 🥳",
+    "messages.confirm-not-fully-supplied": "Not all items have been fully supplied - if you finalise by clicking ok, you won't be able to supply them",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -102,7 +102,7 @@
   "messages.saved": "Saved",
   "messages.select-rows-to-delete-them": "Select rows to delete them",
   "messages.shipment-saved": "Shipment saved 🥳",
-    "messages.confirm-not-fully-supplied": "Not all items have been fully supplied - if you finalise by clicking ok, you won't be able to supply them",
+  "messages.confirm-not-fully-supplied": "Not all items in this requisition have been supplied to the customer.  If you finalise you will not be able to supply any more items to the customer from this requisition. Would you still like to continue?",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Footer/Footer.tsx
@@ -44,7 +44,7 @@ export const Footer: FC = () => {
             />
 
             <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
-              <StatusChangeButton />
+              <StatusChangeButton requisition={data} />
             </Box>
           </Box>
         )


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1737

# 👩🏻‍💻 What does this PR do? 
Confirmation message suddenly started working again... but have added an extra message if the requisition hasn't been fully supplied to make it clearer to users...
![Screenshot 2023-09-14 at 9 07 45 AM](https://github.com/openmsupply/open-msupply/assets/61820074/1aaf7074-09ff-4edd-b276-4ac56b2cce72)

# 🧪 How has/should this change been tested? 
- [ ] Go to requisition
- [ ] Don't supply total requested
- [ ] Try finalise
- [ ] Should see message pop up
