### PR TITLE
2103 show partner htc art info

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3421,7 +3421,8 @@ export type ProgramEventFilterInput = {
 
 export type ProgramEventNode = {
   __typename: 'ProgramEventNode';
-  activeDatetime: Scalars['DateTime']['output'];
+  activeEndDatetime: Scalars['DateTime']['output'];
+  activeStartDatetime: Scalars['DateTime']['output'];
   data?: Maybe<Scalars['String']['output']>;
   datetime: Scalars['DateTime']['output'];
   /** The document associated with the document_name */

--- a/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
+++ b/client/packages/programs/src/JsonForms/components/AdherenceScore.tsx
@@ -105,7 +105,7 @@ const usePreviousCountFromEvent = (
 
   return {
     count,
-    time: new Date(event.activeDatetime),
+    time: new Date(event.activeStartDatetime),
   };
 };
 

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -240,7 +240,7 @@ const UIComponent = (props: ControlProps) => {
           inputProps={{
             value: displayOption ?? '',
             disabled: true,
-            sx: { ...DefaultFormRowSpacing },
+            sx: DefaultFormRowSpacing,
             error: !!errors,
             helperText: errors,
             multiline,

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -138,6 +138,7 @@ const useDisplayValue = (
   if (!event) return '';
 
   if (options?.display?.type === 'eventActiveStartDatetime') {
+    // 'P' is "Long localized date": https://date-fns.org/docs/format
     const format = options?.display.format ?? 'P';
     return customDate(new Date(event.activeStartDatetime), format);
   }

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { ControlProps, rankWith, uiTypeIs } from '@jsonforms/core';
-import { withJsonFormsControlProps } from '@jsonforms/react';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
 import {
   DetailInputWithLabelRow,
   NumericTextInput,
   noOtherVariants,
+  useFormatDateTime,
 } from '@openmsupply-client/common';
 import {
+  DefaultFormRowSpacing,
   DefaultFormRowSx,
   FORM_LABEL_WIDTH,
   useZodOptionsValidation,
@@ -17,9 +19,12 @@ import {
   useProgramEnrolments,
   useProgramEvents,
 } from '../../api';
-
+import { get as extractProperty } from 'lodash';
 import { z } from 'zod';
-import { ProgramEnrolmentFragment } from '../../api/operations.generated';
+import {
+  ProgramEnrolmentFragment,
+  ProgramEventFragment,
+} from '../../api/operations.generated';
 
 export const programEventTester = rankWith(10, uiTypeIs('ProgramEvent'));
 
@@ -55,6 +60,11 @@ const Options = z
     documentType: z.string().optional(),
     eventType: z.string(),
     /**
+     * Specifies a field pointing to a patientId.
+     * This patient id is then used query for the program event.
+     */
+    patientIdField: z.string().optional(),
+    /**
      * Display option based on type.
      */
     display: z
@@ -69,6 +79,12 @@ const Options = z
               .tuple([z.string(), z.string().optional()])
               .rest(z.string().optional())
           ),
+        }),
+        z.object({
+          /** Displays the event's activeStartDatetime */
+          type: z.literal('eventActiveStartDatetime'),
+          /** The date time format to display the datetime */
+          format: z.string().optional(),
         }),
       ])
       .optional(),
@@ -114,13 +130,22 @@ const extractAt = (
   return date;
 };
 
-const getDisplayOptions = (
-  data: string | null | undefined,
+const useDisplayValue = (
+  event: ProgramEventFragment | undefined,
   options?: Options
 ) => {
+  const { customDate } = useFormatDateTime();
+  if (!event) return '';
+
+  if (options?.display?.type === 'eventActiveStartDatetime') {
+    const format = options?.display.format ?? 'P';
+    return customDate(new Date(event.activeStartDatetime), format);
+  }
+
   const show =
     options?.display?.type === 'string' ? options?.display?.show : null;
 
+  const data = event.data;
   if (!show) {
     return data;
   }
@@ -131,7 +156,7 @@ const getDisplayOptions = (
 
 const UIComponent = (props: ControlProps) => {
   const { label, uischema, config } = props;
-  const patientId = config?.patientId;
+
   const [datetime, setDatetime] = useState<Date | undefined>();
 
   const { data: encounter } = useEncounter.document.byDocName(
@@ -146,9 +171,14 @@ const UIComponent = (props: ControlProps) => {
     uischema.options
   );
 
+  const { core } = useJsonForms();
+  const patientId = options?.patientIdField
+    ? extractProperty(core?.data, options?.patientIdField ?? '')
+    : config?.patientId;
+
   useEffect(() => {
     setDatetime(extractAt(encounter, program, options));
-  }, [options?.at, encounter, program]);
+  }, [options, encounter, program]);
 
   const { data: events } = useProgramEvents.document.list({
     at: datetime ?? undefined,
@@ -175,12 +205,11 @@ const UIComponent = (props: ControlProps) => {
   const multiline =
     options?.display?.type === 'string' ? options?.display?.multiline : false;
   const rows = options?.display?.type === 'string' ? options?.display?.rows : 1;
+  const displayOption = useDisplayValue(event, options);
 
   if (!props.visible) {
     return null;
   }
-
-  const displayOption = getDisplayOptions(event?.data, options);
 
   return (
     <>
@@ -208,12 +237,10 @@ const UIComponent = (props: ControlProps) => {
       ) : (
         <DetailInputWithLabelRow
           label={label}
-          sx={DefaultFormRowSx}
           inputProps={{
             value: displayOption ?? '',
             disabled: true,
-            sx: { width: '100%' },
-            style: { flexBasis: '100%' },
+            sx: { ...DefaultFormRowSpacing },
             error: !!errors,
             helperText: errors,
             multiline,

--- a/client/packages/programs/src/api/api.ts
+++ b/client/packages/programs/src/api/api.ts
@@ -11,7 +11,6 @@ import {
   PaginationInput,
   ProgramEnrolmentSortFieldInput,
   ProgramEventFilterInput,
-  ProgramEventNode,
   UpdateEncounterInput,
   UpdateProgramEnrolmentInput,
   ProgramEnrolmentFilterInput,
@@ -33,6 +32,7 @@ import {
   FormSchemaFragment,
   ProgramEnrolmentFragment,
   ProgramEnrolmentRowFragment,
+  ProgramEventFragment,
   Sdk,
 } from './operations.generated';
 
@@ -392,7 +392,7 @@ export const getProgramEventQueries = (sdk: Sdk, storeId: string) => ({
     filter,
     page,
   }: ProgramEventParams): Promise<{
-    nodes: ProgramEventNode[];
+    nodes: ProgramEventFragment[];
     totalCount: number;
   }> => {
     const result = await sdk.activeProgramEvents({

--- a/client/packages/programs/src/api/operations.generated.ts
+++ b/client/packages/programs/src/api/operations.generated.ts
@@ -53,7 +53,7 @@ export type AllocateProgramNumberMutation = { __typename: 'Mutations', allocateP
 
 export type EncounterFieldsFragment = { __typename: 'EncounterFieldsNode', fields: Array<any>, encounter: { __typename: 'EncounterNode', name: string, startDatetime: string, endDatetime?: string | null } };
 
-export type ProgramEventFragment = { __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null };
+export type ProgramEventFragment = { __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null };
 
 export type EncounterFieldsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -95,7 +95,7 @@ export type EncounterByDocNameQueryVariables = Types.Exact<{
 
 export type EncounterByDocNameQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } }> } };
 
-export type EncounterRowFragment = { __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> };
+export type EncounterRowFragment = { __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> };
 
 export type EncountersQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -107,7 +107,7 @@ export type EncountersQueryVariables = Types.Exact<{
 }>;
 
 
-export type EncountersQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> }> } };
+export type EncountersQuery = { __typename: 'Queries', encounters: { __typename: 'EncounterConnector', totalCount: number, nodes: Array<{ __typename: 'EncounterNode', id: string, contextId: string, startDatetime: string, endDatetime?: string | null, status?: Types.EncounterNodeStatus | null, name: string, type: string, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null }, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, name: string }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> }> } };
 
 export type InsertEncounterMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -125,7 +125,7 @@ export type UpdateEncounterMutationVariables = Types.Exact<{
 
 export type UpdateEncounterMutation = { __typename: 'Mutations', updateEncounter: { __typename: 'EncounterNode', id: string, contextId: string, type: string, name: string, status?: Types.EncounterNodeStatus | null, createdDatetime: string, startDatetime: string, endDatetime?: string | null, patient: { __typename: 'PatientNode', id: string, firstName?: string | null, lastName?: string | null, code: string, code2?: string | null, name: string, dateOfBirth?: string | null }, clinician?: { __typename: 'ClinicianNode', id: string, firstName?: string | null, lastName: string } | null, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } } };
 
-export type ProgramEnrolmentRowFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> };
+export type ProgramEnrolmentRowFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> };
 
 export type ProgramEnrolmentsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -136,7 +136,7 @@ export type ProgramEnrolmentsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ProgramEnrolmentsQuery = { __typename: 'Queries', programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeDatetime: string, type: string, data?: string | null }> }> } };
+export type ProgramEnrolmentsQuery = { __typename: 'Queries', programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, contextId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, name?: string | null } | null }, activeProgramEvents: Array<{ __typename: 'ProgramEventNode', activeStartDatetime: string, type: string, data?: string | null, documentName?: string | null }> }> } };
 
 export type ProgramEnrolmentFragment = { __typename: 'ProgramEnrolmentNode', type: string, programEnrolmentId?: string | null, patientId: string, name: string, enrolmentDatetime: string, status: Types.ProgramEnrolmentNodeStatus, document: { __typename: 'DocumentNode', id: string, name: string, parents: Array<string>, timestamp: string, type: string, data: any, user: { __typename: 'UserNode', userId: string, username: string, email?: string | null }, documentRegistry?: { __typename: 'DocumentRegistryNode', id: string, category: Types.DocumentRegistryCategoryNode, documentType: string, contextId: string, name?: string | null, formSchemaId: string, jsonSchema: any, uiSchemaType: string, uiSchema: any } | null } };
 
@@ -193,7 +193,7 @@ export type ActiveProgramEventsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ActiveProgramEventsQuery = { __typename: 'Queries', activeProgramEvents: { __typename: 'ProgramEventConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEventNode', type: string, patientId?: string | null, documentType: string, documentName?: string | null, datetime: string, data?: string | null, activeDatetime: string }> } };
+export type ActiveProgramEventsQuery = { __typename: 'Queries', activeProgramEvents: { __typename: 'ProgramEventConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEventNode', type: string, patientId?: string | null, documentType: string, documentName?: string | null, datetime: string, data?: string | null, activeStartDatetime: string }> } };
 
 export type ContactTraceRowFragment = { __typename: 'ContactTraceNode', contactTraceId?: string | null, storeId?: string | null, datetime: string, documentId: string, id: string, firstName?: string | null, lastName?: string | null, gender?: Types.GenderType | null, dateOfBirth?: string | null, age?: number | null, patientId: string, document: { __typename: 'DocumentNode', name: string, type: string, id: string }, patient: { __typename: 'PatientNode', id: string, name: string, firstName?: string | null, lastName?: string | null }, contactPatient?: { __typename: 'PatientNode', id: string, name: string, firstName?: string | null, lastName?: string | null } | null, program: { __typename: 'ProgramNode', id: string, name: string } };
 
@@ -312,9 +312,10 @@ export const EncounterFragmentDoc = gql`
     ${DocumentFragmentDoc}`;
 export const ProgramEventFragmentDoc = gql`
     fragment ProgramEvent on ProgramEventNode {
-  activeDatetime
+  activeStartDatetime
   type
   data
+  documentName
 }
     `;
 export const EncounterRowFragmentDoc = gql`
@@ -708,7 +709,7 @@ export const ActiveProgramEventsDocument = gql`
         documentName
         datetime
         data
-        activeDatetime
+        activeStartDatetime
       }
     }
   }

--- a/client/packages/programs/src/api/operations.graphql
+++ b/client/packages/programs/src/api/operations.graphql
@@ -111,9 +111,10 @@ fragment EncounterFields on EncounterFieldsNode {
 }
 
 fragment ProgramEvent on ProgramEventNode {
-  activeDatetime
+  activeStartDatetime
   type
   data
+  documentName
 }
 
 query encounterFields(
@@ -467,7 +468,7 @@ query activeProgramEvents(
         documentName
         datetime
         data
-        activeDatetime
+        activeStartDatetime
       }
     }
   }

--- a/server/graphql/types/src/types/program/program_event.rs
+++ b/server/graphql/types/src/types/program/program_event.rs
@@ -81,8 +81,12 @@ impl ProgramEventNode {
         DateTime::<Utc>::from_utc(self.row.datetime, Utc)
     }
 
-    pub async fn active_datetime(&self) -> DateTime<Utc> {
+    pub async fn active_start_datetime(&self) -> DateTime<Utc> {
         DateTime::<Utc>::from_utc(self.row.active_start_datetime, Utc)
+    }
+
+    pub async fn active_end_datetime(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(self.row.active_end_datetime, Utc)
     }
 
     pub async fn document_type(&self) -> &str {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes more points of #2103

- Display partner HTC number (currently not working because we don't record a number right now, please ignore for now...)
- Display partner ART number
- Display HTC testing result
- Display HTC testing result date

# Testing
**please use the `2103-show-partner-htc-art-info` branch in the schema repo**

- Enrol a patient A into an ART program and assign an enrolment id
- Enrol patient A into testing program, create a testing encounter (encounter must be in the past) and enter HIV test results
- Go to a second patient B and add a contact tracing entry
- Link patient A to the contact trace of patient B
-  Go to the Tracking Outcome section of the contact tracing form. There should be three new controls displaying the previously entered information about the partner

![image](https://github.com/openmsupply/open-msupply/assets/88299195/15edbf45-3be1-4bb2-af24-f179a426ca6b)

