### PR TITLE
1117 When you add a new batch to a stocktake line, it gets added to the end (and is hard to notice)

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -51,6 +51,9 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
     useStocktakeLineEdit(currentItem);
   const { setRowStyles } = useRowStyle();
   const { error } = useNotification();
+  // Order by newly added batch since new batches are now
+  // added to the top of the stocktake list instead of the bottom
+  const reversedDraftLines = [...draftLines].reverse();
 
   const onNext = async () => {
     if (isSaving) return;
@@ -134,7 +137,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                       <StyledTabContainer>
                         <BatchTable
                           isDisabled={isDisabled}
-                          batches={draftLines}
+                          batches={reversedDraftLines}
                           update={update}
                         />
                       </StyledTabContainer>
@@ -144,7 +147,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                       <StyledTabContainer>
                         <PricingTable
                           isDisabled={isDisabled}
-                          batches={draftLines}
+                          batches={reversedDraftLines}
                           update={update}
                         />
                       </StyledTabContainer>
@@ -161,7 +164,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                         >
                           <LocationTable
                             isDisabled={isDisabled}
-                            batches={draftLines}
+                            batches={reversedDraftLines}
                             update={update}
                           />
                         </QueryParamsProvider>

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
@@ -99,7 +99,7 @@ export const useStocktakeLineEdit = (
 
   const addLine = () => {
     if (item) {
-      setDraftLines(lines => [...lines, DraftLine.fromItem(id, item)]);
+      setDraftLines(lines => [DraftLine.fromItem(id, item), ...lines]);
     }
   };
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1117

# 👩🏻‍💻 What does this PR do? 
Quick fix 😆 ... Add new batch to the top instead of the bottom

# 🧪 How has/should this change been tested? 
- [ ] Create a stocktake
- [ ] Add item 
- [ ] New batch
- [ ] New row should be at the top now instead of bottom
