### PR TITLE
2221 Remove placeholder on editing outbound shipment stock

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -371,10 +371,9 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
         .map(outboundParsers.toUpdatePlaceholder),
       deleteOutboundShipmentUnallocatedLines: draftOutboundLines
         .filter(
-          ({ type, numberOfPacks, isUpdated, isCreated }) =>
+          ({ type, numberOfPacks, isCreated }) =>
             type === InvoiceLineNodeType.UnallocatedStock &&
             numberOfPacks === 0 &&
-            !isUpdated &&
             !isCreated
         )
         .map(outboundParsers.toDeletePlaceholder),

--- a/client/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/api.ts
@@ -374,7 +374,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
           ({ type, numberOfPacks, isUpdated, isCreated }) =>
             type === InvoiceLineNodeType.UnallocatedStock &&
             numberOfPacks === 0 &&
-            isUpdated &&
+            !isUpdated &&
             !isCreated
         )
         .map(outboundParsers.toDeletePlaceholder),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2221 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Fix the logic for getting `deleteOutboundShipmentUnallocatedLines` array to delete placeholder while saving outbound shipment line with stock.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
1. Go to outbound shipments
2. Add items from master list
3. Edit item that has stock, allocate quantity
4. Click OK > back in the list the placeholder will be replaced by the line with stock filled in
