### PR TITLE
2235 Rename the "Notes" field on prescriptions to be "Directions"

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -27,7 +27,7 @@
   "label.visit-end": "End",
   "label.clinician": "Clinician",
   "label.encounter-status": "Status",
-  "label.direction": "Direction",
+  "label.directions": "Directions",
   "label.additional-info": "Additional Info",
   "label.entered-by": "Entered by",
   "label.entered-on": "Entered on",

--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -27,7 +27,7 @@
   "label.visit-end": "End",
   "label.clinician": "Clinician",
   "label.encounter-status": "Status",
-  "label.note": "Note",
+  "label.direction": "Direction",
   "label.additional-info": "Additional Info",
   "label.entered-by": "Entered by",
   "label.entered-on": "Entered on",

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -152,7 +152,7 @@ export const PrescriptionLineEditForm: React.FC<
       {item && canAutoAllocate ? (
         <>
           <ModalRow>
-            <ModalLabel label={t('label.direction')} />
+            <ModalLabel label={t('label.directions')} />
             <BasicTextInput
               value={note}
               onChange={e => {

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEditForm.tsx
@@ -152,7 +152,7 @@ export const PrescriptionLineEditForm: React.FC<
       {item && canAutoAllocate ? (
         <>
           <ModalRow>
-            <ModalLabel label={t('label.note')} />
+            <ModalLabel label={t('label.direction')} />
             <BasicTextInput
               value={note}
               onChange={e => {

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -10,6 +10,7 @@ import {
   ArrayUtils,
   useCurrency,
   PositiveNumberCell,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { LocationRowFragment } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
@@ -23,9 +24,6 @@ interface UsePrescriptionColumnOptions {
 const expansionColumn = getRowExpandColumn<
   StockOutLineFragment | StockOutItem
 >();
-const notePopoverColumn = getNotePopoverColumn<
-  StockOutLineFragment | StockOutItem
->();
 
 export const usePrescriptionColumn = ({
   sortBy,
@@ -34,10 +32,12 @@ export const usePrescriptionColumn = ({
   StockOutLineFragment | StockOutItem
 >[] => {
   const { c } = useCurrency();
+  const t = useTranslation();
+
   return useColumns(
     [
       [
-        notePopoverColumn,
+        getNotePopoverColumn(t('label.direction')),
         {
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -32,12 +32,12 @@ export const usePrescriptionColumn = ({
   StockOutLineFragment | StockOutItem
 >[] => {
   const { c } = useCurrency();
-  const t = useTranslation();
+  const t = useTranslation('dispensary');
 
   return useColumns(
     [
       [
-        getNotePopoverColumn(t('label.direction')),
+        getNotePopoverColumn(t('label.directions')),
         {
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2235

# 👩🏻‍💻 What does this PR do? 
Rename note to directions

# 🧪 How has/should this change been tested? 
- [ ] Add item to prescription
- [ ] Should say direction instead of note
- [ ] Finish adding item
- [ ] Hover over speech bubble
- [ ] Should say direction instead of note