### PR TITLE
Fix stocktake row highlight and placeholder colour

### DIFF
--- a/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -32,7 +32,7 @@ export interface TableStore {
   setRowStyles: (ids: string[], style: AppSxProp) => void;
 }
 
-const tableContext = createContext<UseBoundStore<StoreApi<TableStore>>>(
+export const tableContext = createContext<UseBoundStore<StoreApi<TableStore>>>(
   {} as UseBoundStore<StoreApi<TableStore>>
 );
 

--- a/client/packages/common/src/ui/layout/tables/context/hooks/index.ts
+++ b/client/packages/common/src/ui/layout/tables/context/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useIsDisabled';
 export * from './useIsFocused';
 export * from './useRowStyle';
 export * from './useIsGrouped';
+export * from './useRowHighlight';

--- a/client/packages/common/src/ui/layout/tables/context/hooks/useRowHighlight.tsx
+++ b/client/packages/common/src/ui/layout/tables/context/hooks/useRowHighlight.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import { GlobalStyles } from '@mui/material';
+import { tableContext } from '../..';
+
+/**
+ * Applies a temporary highlight animation to specified table rows
+ */
+export const useRowHighlight = () => {
+  // using the hook useRowStyle from this hook will throw a zustand error `getSnapshot is not a function`
+  const store = useContext(tableContext);
+
+  const highlightRows = ({
+    rowIds,
+  }: {
+    rowIds: string[];
+    hasPlaceholder?: boolean;
+  }) => {
+    const { setRowStyle, rowState } = store.getState();
+    const currentRowIds = Object.keys(rowState);
+    // retain the style of existing rows, while unsetting their animation prop
+    currentRowIds.forEach(id => {
+      setRowStyle(id, { ...rowState[id]?.style, animation: 'unset' });
+    });
+    // set the animation prop for the new rows, retaining the other style props
+    rowIds.forEach(id => {
+      const existingStyle = rowState[id]?.style;
+      setRowStyle(id, { ...existingStyle, animation: 'highlight 1.5s' });
+    });
+  };
+
+  const HighlightStyles = () => (
+    <GlobalStyles
+      styles={{
+        '@keyframes highlight': {
+          from: { backgroundColor: 'rgba(199, 201, 217, 1)' },
+          to: { backgroundColor: 'rgba(199, 201, 217, 0)' },
+        },
+      }}
+    />
+  );
+
+  return { highlightRows, HighlightStyles };
+};

--- a/client/packages/common/src/ui/layout/tables/index.ts
+++ b/client/packages/common/src/ui/layout/tables/index.ts
@@ -1,3 +1,4 @@
+import { AppSxProp } from '@common/styles';
 import {
   Table,
   TableBody,
@@ -25,3 +26,7 @@ export * from './utils';
 export * from './context';
 export * from './components';
 export const DEFAULT_PAGE_SIZE = 25;
+
+export const placeholderRowStyle: AppSxProp = {
+  color: theme => theme.palette.secondary.light,
+};

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -8,7 +8,7 @@ import {
   createQueryParamsStore,
   NothingHere,
   useRowStyle,
-  AppSxProp,
+  placeholderRowStyle,
 } from '@openmsupply-client/common';
 import { useStocktakeColumns, useExpansionColumns } from './columns';
 import { StocktakeLineFragment, useStocktake } from '../../api';
@@ -80,10 +80,7 @@ const useHighlightUncountedRows = (
       }
     }
 
-    const style: AppSxProp = {
-      color: theme => theme.palette.secondary.light,
-    };
-    setRowStyles(placeholders, style);
+    setRowStyles(placeholders, placeholderRowStyle);
   }, [rows, setRowStyles]);
 };
 

--- a/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -8,8 +8,8 @@ import {
   RouteBuilder,
   useNavigate,
   useTranslation,
-  GlobalStyles,
   DetailTabs,
+  useRowHighlight,
 } from '@openmsupply-client/common';
 import { ItemRowFragment, LogList } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
@@ -31,6 +31,7 @@ export const DetailView: FC = () => {
   const { data, isLoading } = useStocktake.document.get();
   const navigate = useNavigate();
   const t = useTranslation('inventory');
+  const { HighlightStyles } = useRowHighlight();
 
   const onRowClick = useCallback(
     (item: StocktakeLineFragment | StocktakeSummaryItem) => {
@@ -60,14 +61,7 @@ export const DetailView: FC = () => {
   return !!data ? (
     <TableProvider createStore={createTableStore}>
       <StocktakeLineErrorProvider>
-        <GlobalStyles
-          styles={{
-            '@keyframes highlight': {
-              from: { backgroundColor: 'rgba(199, 201, 217, 1)' },
-              to: { backgroundColor: 'rgba(199, 201, 217, 0)' },
-            },
-          }}
-        />
+        <HighlightStyles />
         <AppBarButtons onAddItem={() => onOpen()} />
         <Toolbar />
 

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -15,6 +15,8 @@ import {
   QueryParamsProvider,
   useRowStyle,
   useNotification,
+  useIsGrouped,
+  AppSxProp,
 } from '@openmsupply-client/common';
 import { StocktakeLineEditForm } from './StocktakeLineEditForm';
 import { useStocktakeLineEdit } from './hooks';
@@ -49,8 +51,9 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const isMediumScreen = useIsMediumScreen();
   const { draftLines, update, addLine, isSaving, save, nextItem } =
     useStocktakeLineEdit(currentItem);
-  const { setRowStyles } = useRowStyle();
+  const { setRowStyle } = useRowStyle();
   const { error } = useNotification();
+  const { isGrouped } = useIsGrouped('stocktake');
 
   const onNext = async () => {
     if (isSaving) return;
@@ -76,12 +79,20 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
     }
 
     if (item) {
-      setRowStyles(
-        draftLines.map(line => line.id),
-        {
-          animation: 'highlight 1.5s',
-        }
+      const hasPlaceholder = draftLines.some(
+        line => line.countedNumberOfPacks === null
       );
+
+      const highlight: AppSxProp = {
+        animation: 'highlight 1.5s',
+        color: hasPlaceholder
+          ? theme => theme.palette.secondary.light
+          : undefined,
+      };
+      const rowIds = draftLines.map(line =>
+        isGrouped ? line.itemId : line.id
+      );
+      rowIds.forEach(id => setRowStyle(id, highlight));
     }
     onClose();
   };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -13,10 +13,9 @@ import {
   createTableStore,
   createQueryParamsStore,
   QueryParamsProvider,
-  useRowStyle,
+  useRowHighlight,
   useNotification,
   useIsGrouped,
-  AppSxProp,
 } from '@openmsupply-client/common';
 import { StocktakeLineEditForm } from './StocktakeLineEditForm';
 import { useStocktakeLineEdit } from './hooks';
@@ -51,7 +50,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const isMediumScreen = useIsMediumScreen();
   const { draftLines, update, addLine, isSaving, save, nextItem } =
     useStocktakeLineEdit(currentItem);
-  const { setRowStyle } = useRowStyle();
+  const { highlightRows } = useRowHighlight();
   const { error } = useNotification();
   const { isGrouped } = useIsGrouped('stocktake');
 
@@ -79,20 +78,11 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
     }
 
     if (item) {
-      const hasPlaceholder = draftLines.some(
-        line => line.countedNumberOfPacks === null
-      );
-
-      const highlight: AppSxProp = {
-        animation: 'highlight 1.5s',
-        color: hasPlaceholder
-          ? theme => theme.palette.secondary.light
-          : undefined,
-      };
       const rowIds = draftLines.map(line =>
         isGrouped ? line.itemId : line.id
       );
-      rowIds.forEach(id => setRowStyle(id, highlight));
+
+      highlightRows({ rowIds });
     }
     onClose();
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2226 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
A change was made to the highlighting of row styles in the `StocktakeLineEdit` which reset the styles of all rows.
I've reverted that change to fix the problem raised in the issue.

The change had also broken the 'highlight on Ok' feature, so I've fixed that.

As a bonus, I've fixed the highlighting so that it now works when the rows are grouped by item too.

I then went and refactored to make the highlighting function available for other lists of data, because I think the highlight is pretty neat.


https://github.com/openmsupply/open-msupply/assets/9192912/0cb863bd-79dd-4ae4-88b3-3ca3a373d3a3



# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Edit a stocktake which has placeholder rows. Click on a row and then click `OK` on the modal.
This will
- retain the blue for placeholder rows
- show a 1.5s highlight animation on the edited row

You can edit a different row, click OK and that one will be highlighted (and not the first row which you edited)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2