### PR TITLE
2236 Edits to patient names don't seem to update on past prescriptions

### DIFF
--- a/server/service/src/programs/patient/insert_patient.rs
+++ b/server/service/src/programs/patient/insert_patient.rs
@@ -1,12 +1,24 @@
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 use repository::{
-    EqualFilter, NameRow, NameRowRepository, NameType, Patient, PatientFilter, RepositoryError,
-    StorageConnection, TransactionError,
+    EqualFilter, Gender, NameRow, NameRowRepository, NameType, Patient, PatientFilter,
+    RepositoryError, StorageConnection, TransactionError,
 };
 
 use crate::service_provider::{ServiceContext, ServiceProvider};
 
-use super::patient_updated::create_patient_name_store_join;
+use super::patient_updated::{create_patient_name_store_join, patient_name};
+
+#[derive(Default)]
+pub struct InsertPatient {
+    pub id: String,
+    pub code: String,
+    pub code_2: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub gender: Option<Gender>,
+    pub date_of_birth: Option<NaiveDate>,
+    pub r#type: NameType,
+}
 
 #[derive(PartialEq, Debug)]
 pub enum InsertPatientError {
@@ -18,13 +30,13 @@ pub enum InsertPatientError {
 
 fn validate_patient_does_not_exist(
     con: &StorageConnection,
-    input: &NameRow,
+    input: &InsertPatient,
 ) -> Result<bool, RepositoryError> {
     let existing = NameRowRepository::new(con).find_one_by_id(&input.id)?;
     Ok(existing.is_none())
 }
 
-fn validate(con: &StorageConnection, input: &NameRow) -> Result<(), InsertPatientError> {
+fn validate(con: &StorageConnection, input: &InsertPatient) -> Result<(), InsertPatientError> {
     if input.r#type != NameType::Patient {
         return Err(InsertPatientError::NotAPatient);
     }
@@ -35,10 +47,33 @@ fn validate(con: &StorageConnection, input: &NameRow) -> Result<(), InsertPatien
     Ok(())
 }
 
-fn generate(input: NameRow) -> NameRow {
+fn generate(input: InsertPatient, store_id: &str) -> NameRow {
+    let InsertPatient {
+        id,
+        code,
+        code_2,
+        first_name,
+        last_name,
+        gender,
+        date_of_birth,
+        r#type,
+    } = input;
+
     NameRow {
-        created_datetime: Some(input.created_datetime.unwrap_or(Utc::now().naive_utc())),
-        ..input
+        id,
+        name: patient_name(&first_name, &last_name),
+        code,
+        r#type,
+        is_customer: true,
+        is_supplier: false,
+        supplying_store_id: Some(store_id.to_string()),
+        first_name,
+        last_name,
+        gender,
+        date_of_birth,
+        national_health_number: code_2,
+        created_datetime: Some(Utc::now().naive_utc()),
+        ..Default::default()
     }
 }
 
@@ -46,13 +81,13 @@ pub(crate) fn insert_patient(
     ctx: &ServiceContext,
     service_provider: &ServiceProvider,
     store_id: &str,
-    input: NameRow,
+    input: InsertPatient,
 ) -> Result<Patient, InsertPatientError> {
     let patient = ctx
         .connection
         .transaction_sync(|con| {
             validate(con, &input)?;
-            let row = generate(input);
+            let row = generate(input, store_id);
 
             let name_repo = NameRowRepository::new(con);
             name_repo.upsert_one(&row)?;
@@ -71,7 +106,7 @@ pub(crate) fn insert_patient(
                 .rows
                 .pop()
                 .ok_or(InsertPatientError::InternalError(
-                    "Can't find the just inserted patient".to_string(),
+                    "Can't find the newly created patient".to_string(),
                 ))?;
             Ok(patient)
         })

--- a/server/service/src/programs/patient/mod.rs
+++ b/server/service/src/programs/patient/mod.rs
@@ -1,4 +1,3 @@
-use repository::NameRow;
 use repository::{PaginationOption, Patient, PatientFilter, PatientSort, RepositoryError};
 use util::constants::PATIENT_TYPE;
 
@@ -74,7 +73,7 @@ pub trait PatientServiceTrait: Sync + Send {
         ctx: &ServiceContext,
         service_provider: &ServiceProvider,
         store_id: &str,
-        input: NameRow,
+        input: InsertPatient,
     ) -> Result<Patient, InsertPatientError> {
         insert_patient(ctx, service_provider, store_id, input)
     }

--- a/server/service/src/programs/patient/update_patient.rs
+++ b/server/service/src/programs/patient/update_patient.rs
@@ -6,6 +6,8 @@ use repository::{
 
 use crate::service_provider::{ServiceContext, ServiceProvider};
 
+use super::patient_updated::patient_name;
+
 #[derive(PartialEq, Debug)]
 pub enum UpdatePatientError {
     PatientDoesNotExists,
@@ -46,11 +48,12 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
 
     NameRow {
         code,
-        first_name,
-        last_name,
+        first_name: first_name.clone(),
+        last_name: last_name.clone(),
         gender,
         date_of_birth,
         national_health_number: code_2,
+        name: patient_name(&first_name, &last_name),
         ..existing
     }
 }
@@ -93,7 +96,7 @@ pub(crate) fn update_patient(
                 .rows
                 .pop()
                 .ok_or(UpdatePatientError::InternalError(
-                    "Can't find the just inserted patient".to_string(),
+                    "Can't find the newly created patient".to_string(),
                 ))?;
             Ok(patient)
         })

--- a/server/service/src/programs/patient/update_patient.rs
+++ b/server/service/src/programs/patient/update_patient.rs
@@ -48,12 +48,12 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
 
     NameRow {
         code,
-        first_name: first_name.clone(),
-        last_name: last_name.clone(),
+        name: patient_name(&first_name, &last_name),
+        first_name,
+        last_name,
         gender,
         date_of_birth,
         national_health_number: code_2,
-        name: patient_name(&first_name, &last_name),
         ..existing
     }
 }
@@ -96,7 +96,7 @@ pub(crate) fn update_patient(
                 .rows
                 .pop()
                 .ok_or(UpdatePatientError::InternalError(
-                    "Can't find the newly created patient".to_string(),
+                    "Can't find the updated patient".to_string(),
                 ))?;
             Ok(patient)
         })


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2236

# 👩🏻‍💻 What does this PR do? 
The patient's full name wasn't being updated even though their first name and last name have, so have updated their full name too. 

# 🧪 How has/should this change been tested? 
- [ ] Create a prescription for a patient
- [ ] Go to patient view and change their first or last name
- [ ] Go back to prescriptions and see that their name has been changed