### PR TITLE
Stop the data table shakes

### DIFF
--- a/client/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -11,7 +11,11 @@ import {
   Typography,
   TableCell,
 } from '@mui/material';
-import { BasicSpinner, useRegisterActions } from '@openmsupply-client/common';
+import {
+  BasicSpinner,
+  Column,
+  useRegisterActions,
+} from '@openmsupply-client/common';
 
 import { TableProps } from './types';
 import { DataRow } from './components/DataRow/DataRow';
@@ -20,6 +24,89 @@ import { ColumnPicker, HeaderCell, HeaderRow } from './components/Header';
 import { RecordWithId } from '@common/types';
 import { useFormatDateTime, useTranslation } from '@common/intl';
 import { useTableStore } from './context';
+
+interface RenderRowsProps<T extends RecordWithId> {
+  ref: React.RefObject<HTMLDivElement>;
+  data: T[];
+  ExpandContent?: React.FC<{ rowData: T }>;
+  columnsToDisplay: Column<T>[];
+  onRowClick?: ((row: T) => void) | null;
+  dense: boolean;
+  clickFocusedRow: boolean;
+  generateRowTooltip: ((row: T) => string) | undefined;
+  isRowAnimated: boolean;
+  additionalRows?: JSX.Element[];
+}
+const RenderRows = <T extends RecordWithId>({
+  ref,
+  data,
+  ExpandContent,
+  columnsToDisplay,
+  onRowClick,
+  dense,
+  clickFocusedRow,
+  generateRowTooltip,
+  isRowAnimated,
+  additionalRows,
+}: RenderRowsProps<T>) => {
+  const t = useTranslation();
+  const { localisedDate } = useFormatDateTime();
+
+  if (ExpandContent != undefined)
+    return (
+      <>
+        {data.map((row, idx) => (
+          <DataRow
+            key={row.id}
+            ExpandContent={ExpandContent}
+            rowIndex={idx}
+            columns={columnsToDisplay}
+            onClick={onRowClick ? onRowClick : undefined}
+            rowData={row}
+            rowKey={String(idx)}
+            dense={dense}
+            keyboardActivated={clickFocusedRow}
+            generateRowTooltip={generateRowTooltip}
+            localisedText={t}
+            localisedDate={localisedDate}
+            isAnimated={isRowAnimated}
+          />
+        ))}
+        {additionalRows}
+      </>
+    );
+  return (
+    <>
+      <ViewportList
+        viewportRef={ref}
+        items={data}
+        axis="y"
+        itemSize={40}
+        renderSpacer={({ ref, style }) => <tr ref={ref} style={style} />}
+        initialDelay={1}
+      >
+        {(row, idx) => (
+          <DataRow
+            key={row.id}
+            ExpandContent={ExpandContent}
+            rowIndex={idx}
+            columns={columnsToDisplay}
+            onClick={onRowClick ? onRowClick : undefined}
+            rowData={row}
+            rowKey={String(idx)}
+            dense={dense}
+            keyboardActivated={clickFocusedRow}
+            generateRowTooltip={generateRowTooltip}
+            localisedText={t}
+            localisedDate={localisedDate}
+            isAnimated={isRowAnimated}
+          />
+        )}
+      </ViewportList>
+      {additionalRows}
+    </>
+  );
+};
 
 const DataTableComponent = <T extends RecordWithId>({
   id,
@@ -41,7 +128,7 @@ const DataTableComponent = <T extends RecordWithId>({
   onRowClick,
   additionalRows,
 }: TableProps<T>): JSX.Element => {
-  const t = useTranslation('common');
+  const t = useTranslation();
   const { setRows, setDisabledRows, setFocus } = useTableStore();
   const [clickFocusedRow, setClickFocusedRow] = useState(false);
   const [displayColumns, setDisplayColumns] = useState(columns);
@@ -50,7 +137,6 @@ const DataTableComponent = <T extends RecordWithId>({
       columns.filter(c => displayColumns.map(({ key }) => key).includes(c.key)),
     [displayColumns, columns]
   );
-  const { localisedDate } = useFormatDateTime();
 
   useRegisterActions([
     {
@@ -168,34 +254,18 @@ const DataTableComponent = <T extends RecordWithId>({
           </HeaderRow>
         </TableHead>
         <TableBody>
-          <>
-            <ViewportList
-              viewportRef={ref}
-              items={data}
-              axis="y"
-              itemSize={40}
-              renderSpacer={({ ref, style }) => <tr ref={ref} style={style} />}
-            >
-              {(row, idx) => (
-                <DataRow
-                  key={row.id}
-                  ExpandContent={ExpandContent}
-                  rowIndex={idx}
-                  columns={columnsToDisplay}
-                  onClick={onRowClick ? onRowClick : undefined}
-                  rowData={row}
-                  rowKey={String(idx)}
-                  dense={dense}
-                  keyboardActivated={clickFocusedRow}
-                  generateRowTooltip={generateRowTooltip}
-                  localisedText={t}
-                  localisedDate={localisedDate}
-                  isAnimated={isRowAnimated}
-                />
-              )}
-            </ViewportList>
-            {additionalRows}
-          </>
+          <RenderRows
+            ref={ref}
+            data={data}
+            ExpandContent={ExpandContent}
+            columnsToDisplay={columnsToDisplay}
+            onRowClick={onRowClick}
+            dense={dense}
+            clickFocusedRow={clickFocusedRow}
+            generateRowTooltip={generateRowTooltip}
+            isRowAnimated={isRowAnimated}
+            additionalRows={additionalRows}
+          />
         </TableBody>
       </MuiTable>
       <Box


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2248 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Stops the shaking by disabling the viewport when expando is being used. It's the combination of having an expandable row expanded and scrolling down which triggers the viewport, this re-renders, but the expanded row isn't expanded, then it is, then it re-renders etc.

The fix is based on the assumption that the data table usages which have an expando row are smaller in size and won't need the viewport to speed up loading. The viewport renders only those rows which are visible on screen - when you scroll, the next set of rows is rendered. This greatly speeds up the render for long lists, but does have some drawbacks

Apologies for picking up a non-triaged issue.. it seemed like a serious enough one to warrant the attention.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
