### PR TITLE
Fix lookup when patient id is not found

### DIFF
--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -96,6 +96,8 @@ const ScrollFix = () => {
 
 /** Config data to pass to all json form controls */
 export type JsonFormsConfig = {
+  documentName?: string;
+  patientId?: string;
   store?: UserStoreNodeFragment;
   user?: {
     id: string;

--- a/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Array/Notes.tsx
@@ -22,7 +22,7 @@ import { z } from 'zod';
 import { useZodOptionsValidation } from '../../hooks/useZodOptionsValidation';
 
 import { DateUtils } from '@common/intl';
-import { JsonData } from '../../JsonForm';
+import { JsonData, JsonFormsConfig } from '../../JsonForm';
 import {
   CommonOptions,
   ArrayControlCustomProps,
@@ -59,7 +59,8 @@ const NotesOptions = CommonOptions.extend({
 });
 
 const NotesComponent = (props: ArrayControlCustomProps) => {
-  const { enabled, data, config } = props;
+  const { enabled, data } = props;
+  const config: JsonFormsConfig = props.config;
   const { localisedDateTime } = useFormatDateTime();
 
   const options = NotesOptions.parse(props.uischema.options);
@@ -139,7 +140,7 @@ const NotesComponent = (props: ArrayControlCustomProps) => {
     if (
       restrictions?.isCurrentUser &&
       child['authorId'] &&
-      child['authorId'] !== config.user.id
+      child['authorId'] !== config.user?.id
     )
       return false;
 

--- a/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
+++ b/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
@@ -16,7 +16,8 @@ const Options = z
     programEnrolmentType: z.string(),
     /**
      * Specifies a field pointing to a patientId.
-     * This patient id is then used query for the program enrolment.
+     * This patient id is then used to query for the program enrolment.
+     * If there is no data at patientIdField nothing is displayed.
      */
     patientIdField: z.string().optional(),
   })
@@ -33,7 +34,7 @@ const UIComponent = (props: ControlProps) => {
 
   const { core } = useJsonForms();
   const patientId = options?.patientIdField
-    ? extractProperty(core?.data, options?.patientIdField ?? '')
+    ? extractProperty(core?.data, options?.patientIdField ?? '') ?? '' // use empty/invalid id if field is not set
     : config?.patientId;
 
   // fetch matching program enrolment

--- a/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
+++ b/client/packages/programs/src/JsonForms/components/EnrolmentId.tsx
@@ -34,7 +34,7 @@ const UIComponent = (props: ControlProps) => {
 
   const { core } = useJsonForms();
   const patientId = options?.patientIdField
-    ? extractProperty(core?.data, options?.patientIdField ?? '') ?? '' // use empty/invalid id if field is not set
+    ? extractProperty(core?.data, options.patientIdField, '') // use empty/invalid id if field is not set
     : config?.patientId;
 
   // fetch matching program enrolment

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -11,6 +11,7 @@ import {
   DefaultFormRowSpacing,
   DefaultFormRowSx,
   FORM_LABEL_WIDTH,
+  JsonFormsConfig,
   useZodOptionsValidation,
 } from '../common';
 import {
@@ -157,7 +158,8 @@ const useDisplayValue = (
 };
 
 const UIComponent = (props: ControlProps) => {
-  const { label, uischema, config } = props;
+  const { label, uischema } = props;
+  const config: JsonFormsConfig = props.config;
 
   const [datetime, setDatetime] = useState<Date | undefined>();
 

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -175,7 +175,7 @@ const UIComponent = (props: ControlProps) => {
 
   const { core } = useJsonForms();
   const patientId = options?.patientIdField
-    ? extractProperty(core?.data, options?.patientIdField ?? '') ?? '' // use empty/invalid id if field is not set
+    ? extractProperty(core?.data, options.patientIdField, '') // use empty/invalid id if field is not set
     : config?.patientId;
 
   useEffect(() => {

--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -61,7 +61,8 @@ const Options = z
     eventType: z.string(),
     /**
      * Specifies a field pointing to a patientId.
-     * This patient id is then used query for the program event.
+     * This patient id is then used to query for the program event.
+     * If there is no data at patientIdField nothing is displayed.
      */
     patientIdField: z.string().optional(),
     /**
@@ -174,7 +175,7 @@ const UIComponent = (props: ControlProps) => {
 
   const { core } = useJsonForms();
   const patientId = options?.patientIdField
-    ? extractProperty(core?.data, options?.patientIdField ?? '')
+    ? extractProperty(core?.data, options?.patientIdField ?? '') ?? '' // use empty/invalid id if field is not set
     : config?.patientId;
 
   useEffect(() => {

--- a/client/packages/programs/src/JsonForms/useJsonForms.tsx
+++ b/client/packages/programs/src/JsonForms/useJsonForms.tsx
@@ -4,7 +4,7 @@ import {
   useNotification,
   useConfirmOnLeaving,
 } from '@openmsupply-client/common';
-import { JsonData, JsonForm } from './common';
+import { JsonData, JsonForm, JsonFormsConfig } from './common';
 import _ from 'lodash';
 import {
   JsonFormsRendererRegistryEntry,
@@ -124,12 +124,8 @@ export type JsonFormData<R> = {
  * What data is shown and how it is saved can be customized through the `jsonFormData` form
  * parameter.
  */
-
 export const useJsonForms = <R,>(
-  config: {
-    documentName?: string;
-    patientId?: string;
-  },
+  config: JsonFormsConfig,
   jsonFormData: JsonFormData<R>
 ) => {
   const { loadedData, isLoading, error, save, isCreating } = jsonFormData;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Bug fix from #2067

For contact tracing, the components displayed the data from a random patient if the patient wasn't linked yet...

![image](https://github.com/openmsupply/open-msupply/assets/88299195/ab7f7323-b84b-45c7-a30c-be1c824b80f0)

# Testing:

- Enrol at least one patient into ART program enrolment.
- Create a contact trace for this patient (or a different patient) without linking it to a patient
- In the "Tracking Outcome" section the last four field should be empty (not like in the screenshot)

