### PR TITLE
#2128 Improve JSON Forms column layout

### DIFF
--- a/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/forms/Detail/InputWithLabelRow.tsx
@@ -38,7 +38,14 @@ export const DetailInputWithLabelRow: FC<InputWithLabelRowProps> = ({
   const justify = `flex-${inputAlignment}`;
 
   return (
-    <Box display="flex" alignItems="center" gap={1} sx={{ ...sx }}>
+    <Box
+      display="flex"
+      // This class allows JSONForms to target the layout styling :)
+      className="input-with-label-row"
+      alignItems="center"
+      gap={1}
+      sx={{ ...sx }}
+    >
       <Box style={{ textAlign: 'end' }} flexBasis={labelFlexBasis}>
         <FormLabel sx={{ fontWeight: 'bold', ...labelSx }} {...labelPropsRest}>
           {labelWithPunctuation(label)}

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -53,6 +53,10 @@ import {
 import { NumberField, numberTester } from './components/Number';
 import { DateTime, datetimeTester } from './components/DateTime';
 import { Header, headerTester } from './components/Header';
+import {
+  FORM_COLUMN_MAX_WIDTH,
+  FORM_LABEL_COLUMN_WIDTH,
+} from './styleConstants';
 
 export type JsonType = string | number | boolean | null | undefined;
 
@@ -233,13 +237,13 @@ export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
           '& .MuiGrid-grid-xs-true': {
             '& .MuiGrid-container': {
               '& .MuiGrid-grid-xs-true': {
-                maxWidth: 600,
+                maxWidth: FORM_COLUMN_MAX_WIDTH,
               },
             },
           },
         },
-        '& .MuiTypography-root': {
-          width: '40%',
+        '& h1, h2, h3, h4, h5, h6': {
+          width: FORM_LABEL_COLUMN_WIDTH,
           textAlign: 'right',
           whiteSpace: 'nowrap',
         },

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -227,6 +227,23 @@ export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
       width="100%"
       gap={2}
       paddingX={10}
+      sx={{
+        alignItems: 'flex-start',
+        '& .MuiGrid-container': {
+          '& .MuiGrid-grid-xs-true': {
+            '& .MuiGrid-container': {
+              '& .MuiGrid-grid-xs-true': {
+                maxWidth: 600,
+              },
+            },
+          },
+        },
+        '& .MuiTypography-root': {
+          width: '40%',
+          textAlign: 'right',
+          whiteSpace: 'nowrap',
+        },
+      }}
     >
       <ScrollFix />
       {isLoading ? (

--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -230,17 +230,11 @@ export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
       alignItems="center"
       width="100%"
       gap={2}
-      paddingX={10}
+      paddingX={5}
       sx={{
         alignItems: 'flex-start',
-        '& .MuiGrid-container': {
-          '& .MuiGrid-grid-xs-true': {
-            '& .MuiGrid-container': {
-              '& .MuiGrid-grid-xs-true': {
-                maxWidth: FORM_COLUMN_MAX_WIDTH,
-              },
-            },
-          },
+        '& .input-with-label-row': {
+          maxWidth: FORM_COLUMN_MAX_WIDTH,
         },
         '& h1, h2, h3, h4, h5, h6': {
           width: FORM_LABEL_COLUMN_WIDTH,

--- a/client/packages/programs/src/JsonForms/common/styleConstants.ts
+++ b/client/packages/programs/src/JsonForms/common/styleConstants.ts
@@ -1,5 +1,6 @@
 import { Theme, SxProps } from '@openmsupply-client/common';
 
+export const FORM_COLUMN_MAX_WIDTH = 600;
 export const FORM_LABEL_WIDTH = 40;
 export const FORM_LABEL_COLUMN_WIDTH = `${FORM_LABEL_WIDTH}%`;
 export const FORM_INPUT_COLUMN_WIDTH = `${100 - FORM_LABEL_WIDTH}%`;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2128

I'm not particularly thrilled with this approach, but I can't see a better way to target the JSONForms Material-UI containers without creating custom renderers for each, which would be overkill for such minor tweaks.

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Adds a maxWidth to the form columns so it looks a bit better when there's only one column.

Have also played with the heading styles a bit so they stay more closely tied to their contents. Open to suggestions as to whether this is better or not (I think it is in most cases, but there's bound to be exceptions).

How it looks now with a single column:

<img width="1462" alt="Screenshot 2023-09-20 at 12 35 09 PM" src="https://github.com/openmsupply/open-msupply/assets/5456533/3dd47519-43fa-4fd8-8606-87989b050755">

And with multiple columns:

<img width="1461" alt="Screenshot 2023-09-20 at 12 36 49 PM" src="https://github.com/openmsupply/open-msupply/assets/5456533/a92e3b05-8717-48a2-a10e-43dad4350f62">

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Test single column by re-initialising DB with no Programs data.
Test multi-column by running the programschema script to add Programs data

Check that this hasn't caused problems elsewhere.

