### PR TITLE
2227 add alert if line isn't allocated

### DIFF
--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -86,5 +86,5 @@
   "placeholder.search-by-identifier": "Search by id",
   "warning.cannot-create-placeholder-packs": "There is a total of {{quantity}} packs available. Unable to allocate the full amount requested.",
   "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested.",
-  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or click 'Cancel'"
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or cancel"
 }

--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -85,6 +85,5 @@
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id",
   "warning.cannot-create-placeholder-packs": "There is a total of {{quantity}} packs available. Unable to allocate the full amount requested.",
-  "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested.",
-  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or Cancel"
+  "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested."
 }

--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -85,5 +85,6 @@
   "placeholder.search-by-last-name": "Search by last name",
   "placeholder.search-by-identifier": "Search by id",
   "warning.cannot-create-placeholder-packs": "There is a total of {{quantity}} packs available. Unable to allocate the full amount requested.",
-  "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested."
+  "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested.",
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or click 'Cancel'"
 }

--- a/client/packages/common/src/intl/locales/en/dispensary.json
+++ b/client/packages/common/src/intl/locales/en/dispensary.json
@@ -86,5 +86,5 @@
   "placeholder.search-by-identifier": "Search by id",
   "warning.cannot-create-placeholder-packs": "There is a total of {{quantity}} packs available. Unable to allocate the full amount requested.",
   "warning.cannot-create-placeholder-units": "There is a total of {{quantity}} units available. Unable to allocate the full amount requested.",
-  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or cancel"
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or Cancel"
 }

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -106,5 +106,5 @@
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it.",
-  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock cancel"
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or Cancel"
 }

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -105,5 +105,6 @@
   "messages.confirm-not-fully-supplied": "Not all items in this requisition have been supplied to the customer.  If you finalise you will not be able to supply any more items to the customer from this requisition. Would you still like to continue?",
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
-  "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it."
+  "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it.",
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or click 'Cancel'"
 }

--- a/client/packages/common/src/intl/locales/en/distribution.json
+++ b/client/packages/common/src/intl/locales/en/distribution.json
@@ -106,5 +106,5 @@
   "stocktake.description-template": "Created by {{username}} on {{date}}",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it.",
-  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock or click 'Cancel'"
+  "warning.no-quantity-allocated": "No stock has been allocated. Please allocate some stock cancel"
 }

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -160,11 +160,10 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
 
   const handleClick = async () => {
-    const allocated = draftStockOutLines?.reduce(
-      (accumulator, stockOutLine) => accumulator + stockOutLine.numberOfPacks,
-      0
-    );
-    if (allocated === 0) {
+    const nonAllocated =
+      draftStockOutLines.filter(line => line.numberOfPacks > 0).length === 0;
+
+    if (nonAllocated) {
       const warningSnack = warning(t('warning.no-quantity-allocated'));
       warningSnack();
       return;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -200,7 +200,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
         <DialogButton
           disabled={!currentItem}
           variant="ok"
-          onClick={() => handleClick()}
+          onClick={handleClick}
         />
       }
       height={height}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -167,18 +167,17 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
       const warningSnack = warning(t('warning.no-quantity-allocated'));
       warningSnack();
       return;
-    } else {
-      try {
-        onSave();
-        setIsDirty(false);
-        if (!!placeholder) {
-          const infoSnack = info(t('message.placeholder-line'));
-          infoSnack();
-        }
-        onClose();
-      } catch (e) {
-        // console.log(e);
+    }
+    try {
+      onSave();
+      setIsDirty(false);
+      if (!!placeholder) {
+        const infoSnack = info(t('message.placeholder-line'));
+        infoSnack();
       }
+      onClose();
+    } catch (e) {
+      // console.log(e);
     }
   };
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -159,6 +159,30 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
   const okNextDisabled =
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
 
+  const handleClick = async () => {
+    const allocated = draftStockOutLines?.reduce(
+      (accumulator, stockOutLine) => accumulator + stockOutLine.numberOfPacks,
+      0
+    );
+    if (allocated === 0) {
+      const warningSnack = warning(t('warning.no-quantity-allocated'));
+      warningSnack();
+      return;
+    } else {
+      try {
+        onSave();
+        setIsDirty(false);
+        if (!!placeholder) {
+          const infoSnack = info(t('message.placeholder-line'));
+          infoSnack();
+        }
+        onClose();
+      } catch (e) {
+        // console.log(e);
+      }
+    }
+  };
+
   return (
     <Modal
       title={t(
@@ -176,19 +200,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
         <DialogButton
           disabled={!currentItem}
           variant="ok"
-          onClick={async () => {
-            try {
-              onSave();
-              setIsDirty(false);
-              if (!!placeholder) {
-                const infoSnack = info(t('message.placeholder-line'));
-                infoSnack();
-              }
-              onClose();
-            } catch (e) {
-              // console.log(e);
-            }
-          }}
+          onClick={() => handleClick()}
         />
       }
       height={height}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -184,7 +184,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
         <DialogButton
           disabled={!currentItem}
           variant="ok"
-          onClick={() => handleClick()}
+          onClick={handleClick}
         />
       }
       height={height}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -144,11 +144,10 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
 
   const handleClick = async () => {
-    const allocated = draftStockOutLines?.reduce(
-      (accumulator, stockOutLine) => accumulator + stockOutLine.numberOfPacks,
-      0
-    );
-    if (allocated === 0) {
+    const nonAllocated =
+      draftStockOutLines.filter(line => line.numberOfPacks > 0).length === 0;
+
+    if (nonAllocated) {
       const warningSnack = warning(
         t('warning.no-quantity-allocated', { ns: 'distribution' })
       );

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -153,18 +153,17 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
       );
       warningSnack();
       return;
-    } else {
-      try {
-        onSave();
-        setIsDirty(false);
-        if (!!placeholder) {
-          const infoSnack = info(t('message.placeholder-line'));
-          infoSnack();
-        }
-        onClose();
-      } catch (e) {
-        // console.log(e);
+    }
+    try {
+      onSave();
+      setIsDirty(false);
+      if (!!placeholder) {
+        const infoSnack = info(t('message.placeholder-line'));
+        infoSnack();
       }
+      onClose();
+    } catch (e) {
+      // console.log(e);
     }
   };
 

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -148,7 +148,6 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
       (accumulator, stockOutLine) => accumulator + stockOutLine.numberOfPacks,
       0
     );
-    console.log('allocated', allocated);
     if (allocated === 0) {
       const warningSnack = warning(t('warning.no-quantity-allocated'));
       warningSnack();

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -143,6 +143,31 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
   const okNextDisabled =
     (mode === ModalMode.Update && nextDisabled) || !currentItem;
 
+  const handleClick = async () => {
+    const allocated = draftStockOutLines?.reduce(
+      (accumulator, stockOutLine) => accumulator + stockOutLine.numberOfPacks,
+      0
+    );
+    console.log('allocated', allocated);
+    if (allocated === 0) {
+      const warningSnack = warning(t('warning.no-quantity-allocated'));
+      warningSnack();
+      return;
+    } else {
+      try {
+        onSave();
+        setIsDirty(false);
+        if (!!placeholder) {
+          const infoSnack = info(t('message.placeholder-line'));
+          infoSnack();
+        }
+        onClose();
+      } catch (e) {
+        // console.log(e);
+      }
+    }
+  };
+
   return (
     <Modal
       title={t(
@@ -160,19 +185,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
         <DialogButton
           disabled={!currentItem}
           variant="ok"
-          onClick={async () => {
-            try {
-              onSave();
-              setIsDirty(false);
-              if (!!placeholder) {
-                const infoSnack = info(t('message.placeholder-line'));
-                infoSnack();
-              }
-              onClose();
-            } catch (e) {
-              // console.log(e);
-            }
-          }}
+          onClick={() => handleClick()}
         />
       }
       height={height}

--- a/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/PrescriptionLineEdit/PrescriptionLineEdit.tsx
@@ -46,7 +46,7 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
   mode,
 }) => {
   const item = !draft ? null : draft.item ?? null;
-  const t = useTranslation(['dispensary']);
+  const t = useTranslation(['dispensary', 'distribution']);
   const { info, warning } = useNotification();
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
   const [currentItem, setCurrentItem] = useBufferState(item);
@@ -149,7 +149,9 @@ export const PrescriptionLineEdit: React.FC<PrescriptionLineEditModalProps> = ({
       0
     );
     if (allocated === 0) {
-      const warningSnack = warning(t('warning.no-quantity-allocated'));
+      const warningSnack = warning(
+        t('warning.no-quantity-allocated', { ns: 'distribution' })
+      );
       warningSnack();
       return;
     } else {


### PR DESCRIPTION
Fixes #2227 

# 👩🏻‍💻 What does this PR do? 
Adds an alert snack when attempting to close a prescription line edit modal or outbound shipment line edit modal without allocating any stock.

# 🧪 How has/should this change been tested? 
As server admin
- [ ] Navigate to 'Distribution' > 'Outbound shipments'
- [ ] Open or create a shipment
- [ ] Open the add item modal by clicking 'add item'
- [ ] Select a medicine
- [ ] Click 'OK' without allocating any medicine
- [ ] See that a warning snack appears and that the modal does not close
- [ ] You can try this also after attempting to automatically allocate medication when there is non available (due to expiry)

The above fix is also implemented in Dispensary > Prescriptions

## 💌 Any notes for the reviewer?

Note that this slightly changes behaviour of the modal as users can no longer delete a line item by setting the amount to be issued to 0. Previously a user could manually set the amount to be issued to 0, which would delete the line upon clicking 'ok'.

Lines can still be deleted, but they have to be selected and deleted via dropdown.
I imagine this is the intended way to delete lines - but am just flagging as this could be considered a loss of functionality.
