### PR TITLE
2212 add links to headings in dashboard

### DIFF
--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -3,7 +3,7 @@ import { Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { InlineSpinner, StockIcon } from '../../../';
 import { useTranslation } from '@common/intl';
 import { ApiException, isPermissionDeniedException } from '@common/types';
-import { StyleFreeLink } from '../../navigation/AppNavLink/StyleFreeLink';
+import { SimpleLink } from '../../navigation/AppNavLink/SimpleLink';
 
 export type Stat = {
   label: string;
@@ -129,7 +129,7 @@ export const StatsPanel: FC<StatsPanelProps> = ({
             color="secondary"
             style={{ fontSize: 12, fontWeight: 500 }}
           >
-            {link ? <StyleFreeLink href={link}>{title}</StyleFreeLink> : title}
+            {link ? <SimpleLink href={link}>{title}</SimpleLink> : title}
           </Typography>
         </Grid>
       </Grid>

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -102,53 +102,45 @@ export const StatsPanel: FC<StatsPanelProps> = ({
   title,
   width,
   link,
-}) => {
-  console.log('title', title);
-  console.log('link', link);
-  return (
-    <Paper
-      sx={{
-        borderRadius: '16px',
-        marginTop: '14px',
-        marginBottom: '21px',
-        boxShadow: theme => theme.shadows[1],
-        padding: '14px 24px',
-        width: width ? `${width}px` : undefined,
-      }}
-    >
-      <Grid container>
-        <Grid alignItems="center" display="flex">
-          <Grid item style={{ marginInlineEnd: 8 }}>
-            <StockIcon
-              sx={theme => ({
-                fill: theme.palette.secondary.main,
-                height: 16,
-                width: 16,
-              })}
-            />
-          </Grid>
-          <Grid item>
-            <Typography
-              color="secondary"
-              style={{ fontSize: 12, fontWeight: 500 }}
-            >
-              {link ? (
-                <StyleFreeLink href={link}>{title}</StyleFreeLink>
-              ) : (
-                title
-              )}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Grid container justifyContent="space-between" alignItems="flex-end">
-          <Content
-            isError={isError}
-            isLoading={isLoading}
-            stats={stats}
-            error={error}
+}) => (
+  <Paper
+    sx={{
+      borderRadius: '16px',
+      marginTop: '14px',
+      marginBottom: '21px',
+      boxShadow: theme => theme.shadows[1],
+      padding: '14px 24px',
+      width: width ? `${width}px` : undefined,
+    }}
+  >
+    <Grid container>
+      <Grid alignItems="center" display="flex">
+        <Grid item style={{ marginInlineEnd: 8 }}>
+          <StockIcon
+            sx={theme => ({
+              fill: theme.palette.secondary.main,
+              height: 16,
+              width: 16,
+            })}
           />
         </Grid>
+        <Grid item>
+          <Typography
+            color="secondary"
+            style={{ fontSize: 12, fontWeight: 500 }}
+          >
+            {link ? <StyleFreeLink href={link}>{title}</StyleFreeLink> : title}
+          </Typography>
+        </Grid>
       </Grid>
-    </Paper>
-  );
-};
+      <Grid container justifyContent="space-between" alignItems="flex-end">
+        <Content
+          isError={isError}
+          isLoading={isLoading}
+          stats={stats}
+          error={error}
+        />
+      </Grid>
+    </Grid>
+  </Paper>
+);

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -3,6 +3,7 @@ import { Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { InlineSpinner, StockIcon } from '../../../';
 import { useTranslation } from '@common/intl';
 import { ApiException, isPermissionDeniedException } from '@common/types';
+import { StyleFreeLink } from '../../navigation/AppNavLink/StyleFreeLink';
 
 export type Stat = {
   label: string;
@@ -15,6 +16,7 @@ export interface StatsPanelProps {
   stats: Stat[];
   title: string;
   width?: number;
+  link?: string;
 }
 
 const Statistic: FC<Stat> = ({ label, value }) => {
@@ -99,45 +101,54 @@ export const StatsPanel: FC<StatsPanelProps> = ({
   stats,
   title,
   width,
-}) => (
-  <Paper
-    sx={{
-      borderRadius: '16px',
-      marginTop: '14px',
-      marginBottom: '21px',
-      boxShadow: theme => theme.shadows[1],
-      padding: '14px 24px',
-      width: width ? `${width}px` : undefined,
-    }}
-  >
-    <Grid container>
-      <Grid alignItems="center" display="flex">
-        <Grid item style={{ marginInlineEnd: 8 }}>
-          <StockIcon
-            sx={theme => ({
-              fill: theme.palette.secondary.main,
-              height: 16,
-              width: 16,
-            })}
+  link,
+}) => {
+  console.log('title', title);
+  console.log('link', link);
+  return (
+    <Paper
+      sx={{
+        borderRadius: '16px',
+        marginTop: '14px',
+        marginBottom: '21px',
+        boxShadow: theme => theme.shadows[1],
+        padding: '14px 24px',
+        width: width ? `${width}px` : undefined,
+      }}
+    >
+      <Grid container>
+        <Grid alignItems="center" display="flex">
+          <Grid item style={{ marginInlineEnd: 8 }}>
+            <StockIcon
+              sx={theme => ({
+                fill: theme.palette.secondary.main,
+                height: 16,
+                width: 16,
+              })}
+            />
+          </Grid>
+          <Grid item>
+            <Typography
+              color="secondary"
+              style={{ fontSize: 12, fontWeight: 500 }}
+            >
+              {link ? (
+                <StyleFreeLink href={link}>{title}</StyleFreeLink>
+              ) : (
+                title
+              )}
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid container justifyContent="space-between" alignItems="flex-end">
+          <Content
+            isError={isError}
+            isLoading={isLoading}
+            stats={stats}
+            error={error}
           />
         </Grid>
-        <Grid item>
-          <Typography
-            color="secondary"
-            style={{ fontSize: 12, fontWeight: 500 }}
-          >
-            {title}
-          </Typography>
-        </Grid>
       </Grid>
-      <Grid container justifyContent="space-between" alignItems="flex-end">
-        <Content
-          isError={isError}
-          isLoading={isLoading}
-          stats={stats}
-          error={error}
-        />
-      </Grid>
-    </Grid>
-  </Paper>
-);
+    </Paper>
+  );
+};

--- a/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/client/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -129,7 +129,7 @@ export const StatsPanel: FC<StatsPanelProps> = ({
             color="secondary"
             style={{ fontSize: 12, fontWeight: 500 }}
           >
-            {link ? <SimpleLink href={link}>{title}</SimpleLink> : title}
+            {link ? <SimpleLink to={link}>{title}</SimpleLink> : title}
           </Typography>
         </Grid>
       </Grid>

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/SimpleLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/SimpleLink.tsx
@@ -1,8 +1,9 @@
 import Link, { LinkProps } from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 
-export const StyleFreeLink = styled(Link)<LinkProps>(({}) => ({
+export const SimpleLink = styled(Link)<LinkProps>(({}) => ({
   textDecoration: 'inherit',
   color: 'inherit',
   style: 'inherit',
+  '&:hover': { textDecoration: 'underline' },
 }));

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/SimpleLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/SimpleLink.tsx
@@ -1,7 +1,7 @@
-import Link, { LinkProps } from '@mui/material/Link';
+import { Link } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 
-export const SimpleLink = styled(Link)<LinkProps>(({}) => ({
+export const SimpleLink = styled(Link)(({}) => ({
   textDecoration: 'inherit',
   color: 'inherit',
   style: 'inherit',

--- a/client/packages/common/src/ui/components/navigation/AppNavLink/StyleFreeLink.tsx
+++ b/client/packages/common/src/ui/components/navigation/AppNavLink/StyleFreeLink.tsx
@@ -1,0 +1,8 @@
+import Link, { LinkProps } from '@mui/material/Link';
+import { styled } from '@mui/material/styles';
+
+export const StyleFreeLink = styled(Link)<LinkProps>(({}) => ({
+  textDecoration: 'inherit',
+  color: 'inherit',
+  style: 'inherit',
+}));

--- a/client/packages/dashboard/src/widgets/DistributionWidget.tsx
+++ b/client/packages/dashboard/src/widgets/DistributionWidget.tsx
@@ -15,7 +15,7 @@ import {
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useDashboard } from '../api';
 import { useOutbound } from '@openmsupply-client/invoices';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from 'packages/config';
 
 export const DistributionWidget: React.FC = () => {
   const modalControl = useToggle(false);

--- a/client/packages/dashboard/src/widgets/DistributionWidget.tsx
+++ b/client/packages/dashboard/src/widgets/DistributionWidget.tsx
@@ -10,10 +10,12 @@ import {
   FnUtils,
   useToggle,
   ApiException,
+  RouteBuilder,
 } from '@openmsupply-client/common';
 import { useFormatNumber, useTranslation } from '@common/intl';
 import { useDashboard } from '../api';
 import { useOutbound } from '@openmsupply-client/invoices';
+import { AppRoute } from 'packages/config/src';
 
 export const DistributionWidget: React.FC = () => {
   const modalControl = useToggle(false);
@@ -79,6 +81,9 @@ export const DistributionWidget: React.FC = () => {
                   value: formatNumber.round(outboundCount?.notShipped),
                 },
               ]}
+              link={RouteBuilder.create(AppRoute.Distribution)
+                .addPart(AppRoute.OutboundShipment)
+                .build()}
             />
           </Grid>
           <Grid item>
@@ -93,6 +98,9 @@ export const DistributionWidget: React.FC = () => {
                   value: formatNumber.round(requisitionCount?.response?.new),
                 },
               ]}
+              link={RouteBuilder.create(AppRoute.Distribution)
+                .addPart(AppRoute.CustomerRequisition)
+                .build()}
             />
           </Grid>
           <Grid

--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -15,7 +15,7 @@ import { ApiException, PropsWithChildrenOnly } from '@common/types';
 import { useDashboard } from '../api';
 import { useInbound } from '@openmsupply-client/invoices';
 import { InternalSupplierSearchModal } from '@openmsupply-client/system';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from 'packages/config';
 
 export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   const modalControl = useToggle(false);

--- a/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
+++ b/client/packages/dashboard/src/widgets/ReplenishmentWidget.tsx
@@ -4,6 +4,7 @@ import {
   FnUtils,
   Grid,
   PlusCircleIcon,
+  RouteBuilder,
   StatsPanel,
   useNotification,
   useToggle,
@@ -14,6 +15,7 @@ import { ApiException, PropsWithChildrenOnly } from '@common/types';
 import { useDashboard } from '../api';
 import { useInbound } from '@openmsupply-client/invoices';
 import { InternalSupplierSearchModal } from '@openmsupply-client/system';
+import { AppRoute } from 'packages/config/src';
 
 export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
   const modalControl = useToggle(false);
@@ -82,6 +84,9 @@ export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
                   value: formatNumber.round(data?.notDelivered),
                 },
               ]}
+              link={RouteBuilder.create(AppRoute.Replenishment)
+                .addPart(AppRoute.InboundShipment)
+                .build()}
             />
           </Grid>
           <Grid item>
@@ -96,6 +101,9 @@ export const ReplenishmentWidget: React.FC<PropsWithChildrenOnly> = () => {
                   value: formatNumber.round(requisitionCount?.request?.draft),
                 },
               ]}
+              link={RouteBuilder.create(AppRoute.Replenishment)
+                .addPart(AppRoute.InternalOrder)
+                .build()}
             />
           </Grid>
           <Grid

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -16,7 +16,7 @@ import {
 import { useDashboard } from '../api';
 import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 import { useRequest } from '@openmsupply-client/requisitions';
-import { AppRoute } from 'packages/config/src';
+import { AppRoute } from 'packages/config';
 
 const LOW_MOS_THRESHOLD = 3;
 

--- a/client/packages/dashboard/src/widgets/StockWidget.tsx
+++ b/client/packages/dashboard/src/widgets/StockWidget.tsx
@@ -5,6 +5,7 @@ import {
   FnUtils,
   Grid,
   PlusCircleIcon,
+  RouteBuilder,
   StatsPanel,
   useFormatNumber,
   useNotification,
@@ -15,6 +16,7 @@ import {
 import { useDashboard } from '../api';
 import { InternalSupplierSearchModal } from '@openmsupply-client/system';
 import { useRequest } from '@openmsupply-client/requisitions';
+import { AppRoute } from 'packages/config/src';
 
 const LOW_MOS_THRESHOLD = 3;
 
@@ -90,7 +92,10 @@ export const StockWidget: React.FC = () => {
                   value: formatNumber.round(expiryData?.expiringSoon),
                 },
               ]}
-            />            
+              link={RouteBuilder.create(AppRoute.Inventory)
+                .addPart(AppRoute.Stock)
+                .build()}
+            />
             <StatsPanel
               error={itemCountsError as ApiException}
               isError={hasItemStatsError}
@@ -117,11 +122,18 @@ export const StockWidget: React.FC = () => {
                 },
                 {
                   label: t('label.more-than-six-months-stock-items', {
-                    count: Math.round(itemCountsData?.moreThanSixMonthsStock || 0),
+                    count: Math.round(
+                      itemCountsData?.moreThanSixMonthsStock || 0
+                    ),
                   }),
-                  value: formatNumber.round(itemCountsData?.moreThanSixMonthsStock || 0),
+                  value: formatNumber.round(
+                    itemCountsData?.moreThanSixMonthsStock || 0
+                  ),
                 },
               ]}
+              link={RouteBuilder.create(AppRoute.Inventory)
+                .addPart(AppRoute.Stock)
+                .build()}
             />
           </Grid>
           <Grid


### PR DESCRIPTION
Fixes #2212 

# 👩🏻‍💻 What does this PR do? 
Adds links to dashboard 

# 🧪 How has/should this change been tested? 
- [ ] go to dashboard
- [ ] See that headers of the widgets navigate to the appropriate part of the app
- [ ] Styling remains unchanged

## 💌 Any notes for the reviewer?
I've made a generic link component which doesn't add the usual mui Link styling.
Maybe it is better to put this only in the StatsPanel component as this is the only place it is being used currently.