### PR TITLE
Fix endless loading of sync with timezone changes

### DIFF
--- a/client/packages/host/src/components/Sync/Sync.tsx
+++ b/client/packages/host/src/components/Sync/Sync.tsx
@@ -50,6 +50,9 @@ const useHostSync = () => {
     // isLoading is reset on next result of polled api query
     setIsLoading(true);
     await manualSync();
+    if (!syncStatus?.isSyncing) {
+      setIsLoading(false);
+    }
   };
 
   return {


### PR DESCRIPTION
Fixes #2263 

# 👩🏻‍💻 What does this PR do? 
Sets loading state to false once loading is finished. This works around a hook which won't call if there is a later sync made from a future date.

However I don't know if this is needed as the case which creates this issue is very niche.

## 💌 Any notes for the reviewer?
You can see full discussion of the issue at #2263 

This change is very small and simply stops the loading.

It doesn't fix the fact that the latest sync date by datetime is not the latest sync date by greenwich time. I'm not sure what an appropriate fix would be for this, if required at all?