### PR TITLE
2278 Location function in stocktake

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -375,5 +375,6 @@
   "sync-status.push": "Push",
   "sync-status.integrate": "Integrate",
   "table.show-columns": "Show / hide columns",
-  "warning.caps-lock": "Warning: Caps lock is on"
+  "warning.caps-lock": "Warning: Caps lock is on",
+  "multiple": "[multiple]"
 }

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -9,6 +9,7 @@ import {
   SortBy,
   PositiveNumberCell,
   getLinesFromRow,
+  useTranslation,
 } from '@openmsupply-client/common';
 import {
   InventoryAdjustmentReasonRowFragment,
@@ -32,6 +33,8 @@ const expandColumn = getRowExpandColumn<
 const getStocktakeReasons = (
   rowData: StocktakeLineFragment | StocktakeSummaryItem
 ) => {
+  const t = useTranslation();
+
   if ('lines' in rowData) {
     const { lines } = rowData;
     const inventoryAdjustmentReasons = lines
@@ -42,7 +45,7 @@ const getStocktakeReasons = (
         ArrayUtils.ifTheSameElseDefault(
           inventoryAdjustmentReasons,
           'reason',
-          '[multiple]'
+          `${t('multiple')}`
         ) ?? ''
       );
     } else {
@@ -60,6 +63,7 @@ export const useStocktakeColumns = ({
   StocktakeLineFragment | StocktakeSummaryItem
 >[] => {
   const { getError } = useStocktakeLineErrorContext();
+  const t = useTranslation();
 
   return useColumns<StocktakeLineFragment | StocktakeSummaryItem>(
     [
@@ -103,8 +107,11 @@ export const useStocktakeColumns = ({
             if ('lines' in row) {
               const { lines } = row;
               return (
-                ArrayUtils.ifTheSameElseDefault(lines, 'batch', '[multiple]') ??
-                ''
+                ArrayUtils.ifTheSameElseDefault(
+                  lines,
+                  'batch',
+                  `${t('multiple')}`
+                ) ?? ''
               );
             } else {
               return row.batch ?? '';
@@ -116,7 +123,7 @@ export const useStocktakeColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return rowData.batch;
@@ -135,7 +142,7 @@ export const useStocktakeColumns = ({
                 '';
               return (
                 (expiryDate && Formatter.expiryDate(new Date(expiryDate))) ||
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return row.expiryDate
@@ -149,7 +156,7 @@ export const useStocktakeColumns = ({
               const expiryDate = ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'expiryDate',
-                '[multiple]'
+                `${t('multiple')}`
               );
               return expiryDate;
             } else {
@@ -170,7 +177,7 @@ export const useStocktakeColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  '[multiple]'
+                  `${t('multiple')}`
                 );
               } else {
                 return '';
@@ -189,7 +196,7 @@ export const useStocktakeColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  '[multiple]'
+                  `${t('multiple')}`
                 );
               }
             } else {
@@ -208,7 +215,7 @@ export const useStocktakeColumns = ({
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'packSize',
-                  '[multiple]'
+                  `${t('multiple')}`
                 ) ?? ''
               );
             } else {
@@ -221,7 +228,7 @@ export const useStocktakeColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'packSize',
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return rowData.packSize;
@@ -359,8 +366,11 @@ export const useStocktakeColumns = ({
           if ('lines' in row) {
             const { lines } = row;
             return (
-              ArrayUtils.ifTheSameElseDefault(lines, 'comment', '[multiple]') ??
-              ''
+              ArrayUtils.ifTheSameElseDefault(
+                lines,
+                'comment',
+                `${t('multiple')}`
+              ) ?? ''
             );
           } else {
             return row.comment ?? '';
@@ -372,7 +382,7 @@ export const useStocktakeColumns = ({
             return ArrayUtils.ifTheSameElseDefault(
               lines,
               'comment',
-              '[multiple]'
+              `${t('multiple')}`
             );
           } else {
             return rowData.comment;

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -42,7 +42,7 @@ const getStocktakeReasons = (
         ArrayUtils.ifTheSameElseDefault(
           inventoryAdjustmentReasons,
           'reason',
-          `${t('multiple')}`
+          t('multiple')
         ) ?? ''
       );
     } else {
@@ -107,7 +107,7 @@ export const useStocktakeColumns = ({
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'batch',
-                  `${t('multiple')}`
+                  t('multiple')
                 ) ?? ''
               );
             } else {
@@ -120,7 +120,7 @@ export const useStocktakeColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return rowData.batch;
@@ -139,7 +139,7 @@ export const useStocktakeColumns = ({
                 '';
               return (
                 (expiryDate && Formatter.expiryDate(new Date(expiryDate))) ||
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return row.expiryDate
@@ -153,7 +153,7 @@ export const useStocktakeColumns = ({
               const expiryDate = ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'expiryDate',
-                `${t('multiple')}`
+                t('multiple')
               );
               return expiryDate;
             } else {
@@ -174,7 +174,7 @@ export const useStocktakeColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               } else {
                 return '';
@@ -193,7 +193,7 @@ export const useStocktakeColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               }
             } else {
@@ -212,7 +212,7 @@ export const useStocktakeColumns = ({
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'packSize',
-                  `${t('multiple')}`
+                  t('multiple')
                 ) ?? ''
               );
             } else {
@@ -225,7 +225,7 @@ export const useStocktakeColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'packSize',
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return rowData.packSize;
@@ -366,7 +366,7 @@ export const useStocktakeColumns = ({
               ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'comment',
-                `${t('multiple')}`
+                t('multiple')
               ) ?? ''
             );
           } else {
@@ -379,7 +379,7 @@ export const useStocktakeColumns = ({
             return ArrayUtils.ifTheSameElseDefault(
               lines,
               'comment',
-              `${t('multiple')}`
+              t('multiple')
             );
           } else {
             return rowData.comment;

--- a/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -11,10 +11,7 @@ import {
   getLinesFromRow,
   useTranslation,
 } from '@openmsupply-client/common';
-import {
-  InventoryAdjustmentReasonRowFragment,
-  LocationRowFragment,
-} from '@openmsupply-client/system';
+import { InventoryAdjustmentReasonRowFragment } from '@openmsupply-client/system';
 import { StocktakeSummaryItem } from '../../../types';
 import { StocktakeLineFragment } from '../../api';
 import { useStocktakeLineErrorContext } from '../../context';
@@ -170,9 +167,9 @@ export const useStocktakeColumns = ({
         {
           getSortValue: row => {
             if ('lines' in row) {
-              const locations = row.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = row.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
@@ -188,9 +185,9 @@ export const useStocktakeColumns = ({
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
-              const locations = rowData.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = rowData.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
 
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -129,7 +129,7 @@ export const useInboundShipmentColumns = () => {
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return rowData.batch;
@@ -142,7 +142,7 @@ export const useInboundShipmentColumns = () => {
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'batch',
-                  `${t('multiple')}`
+                  t('multiple')
                 ) ?? ''
               );
             } else {
@@ -196,7 +196,7 @@ export const useInboundShipmentColumns = () => {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               } else {
                 return '';
@@ -215,7 +215,7 @@ export const useInboundShipmentColumns = () => {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               }
             } else {

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -10,6 +10,7 @@ import {
   useUrlQueryParams,
   ColumnAlign,
   PositiveNumberCell,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { LocationRowFragment } from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
@@ -27,6 +28,7 @@ export const useInboundShipmentColumns = () => {
   const { c } = useCurrency();
   const getSellPrice = (row: InboundLineFragment) =>
     isInboundPlaceholderRow(row) ? '' : c(row.sellPricePerPack).format();
+  const t = useTranslation();
 
   const columns = useColumns<InboundLineFragment | InboundItem>(
     [
@@ -128,7 +130,7 @@ export const useInboundShipmentColumns = () => {
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return rowData.batch;
@@ -138,8 +140,11 @@ export const useInboundShipmentColumns = () => {
             if ('lines' in rowData) {
               const { lines } = rowData;
               return (
-                ArrayUtils.ifTheSameElseDefault(lines, 'batch', '[multiple]') ??
-                ''
+                ArrayUtils.ifTheSameElseDefault(
+                  lines,
+                  'batch',
+                  `${t('multiple')}`
+                ) ?? ''
               );
             } else {
               return rowData.batch ?? '';
@@ -183,24 +188,37 @@ export const useInboundShipmentColumns = () => {
       [
         'locationName',
         {
-          accessor: ({ rowData }) => {
-            if ('lines' in rowData) {
-              const { lines } = rowData;
-              const locations = lines
+          getSortValue: row => {
+            if ('lines' in row) {
+              const locations = row.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              } else {
+                return '';
+              }
             } else {
-              return rowData.location?.name ?? '';
+              return row.location?.name ?? '';
             }
           },
-          getSortValue: rowData => {
+          accessor: ({ rowData }) => {
             if ('lines' in rowData) {
-              const { lines } = rowData;
-              const locations = lines
+              const locations = rowData.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              }
             } else {
               return rowData.location?.name ?? '';
             }

--- a/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -12,7 +12,6 @@ import {
   PositiveNumberCell,
   useTranslation,
 } from '@openmsupply-client/common';
-import { LocationRowFragment } from '@openmsupply-client/system';
 import { InboundItem } from './../../../types';
 import { InboundLineFragment } from '../../api';
 import { isInboundPlaceholderRow } from '../../../utils';
@@ -190,9 +189,9 @@ export const useInboundShipmentColumns = () => {
         {
           getSortValue: row => {
             if ('lines' in row) {
-              const locations = row.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = row.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
@@ -208,9 +207,9 @@ export const useInboundShipmentColumns = () => {
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
-              const locations = rowData.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = rowData.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
 
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -147,7 +147,7 @@ export const useOutboundColumns = ({
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'batch',
-                  `${t('multiple')}`
+                  t('multiple')
                 ) ?? ''
               );
             } else {
@@ -160,7 +160,7 @@ export const useOutboundColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return rowData.batch;
@@ -209,7 +209,7 @@ export const useOutboundColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               } else {
                 return '';
@@ -228,7 +228,7 @@ export const useOutboundColumns = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               }
             } else {

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -13,7 +13,6 @@ import {
   PositiveNumberCell,
   useTranslation,
 } from '@openmsupply-client/common';
-import { LocationRowFragment } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -203,9 +202,9 @@ export const useOutboundColumns = ({
         {
           getSortValue: row => {
             if ('lines' in row) {
-              const locations = row.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = row.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
@@ -221,9 +220,9 @@ export const useOutboundColumns = ({
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
-              const locations = rowData.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = rowData.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
 
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -11,6 +11,7 @@ import {
   useCurrency,
   InvoiceLineNodeType,
   PositiveNumberCell,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { LocationRowFragment } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
@@ -45,6 +46,7 @@ export const useOutboundColumns = ({
   onChangeSortBy,
 }: UseOutboundColumnOptions): Column<StockOutLineFragment | StockOutItem>[] => {
   const { c } = useCurrency();
+  const t = useTranslation();
   return useColumns(
     [
       [
@@ -143,8 +145,11 @@ export const useOutboundColumns = ({
             if ('lines' in row) {
               const { lines } = row;
               return (
-                ArrayUtils.ifTheSameElseDefault(lines, 'batch', '[multiple]') ??
-                ''
+                ArrayUtils.ifTheSameElseDefault(
+                  lines,
+                  'batch',
+                  `${t('multiple')}`
+                ) ?? ''
               );
             } else {
               return row.batch ?? '';
@@ -156,7 +161,7 @@ export const useOutboundColumns = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return rowData.batch;
@@ -201,7 +206,15 @@ export const useOutboundColumns = ({
               const locations = row.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              } else {
+                return '';
+              }
             } else {
               return row.location?.name ?? '';
             }
@@ -211,7 +224,14 @@ export const useOutboundColumns = ({
               const locations = rowData.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              }
             } else {
               return rowData.location?.name ?? '';
             }

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -134,7 +134,7 @@ export const usePrescriptionColumn = ({
                 ArrayUtils.ifTheSameElseDefault(
                   lines,
                   'batch',
-                  `${t('multiple')}`
+                  t('multiple')
                 ) ?? ''
               );
             } else {
@@ -147,7 +147,7 @@ export const usePrescriptionColumn = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                `${t('multiple')}`
+                t('multiple')
               );
             } else {
               return rowData.batch;
@@ -196,7 +196,7 @@ export const usePrescriptionColumn = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               } else {
                 return '';
@@ -215,7 +215,7 @@ export const usePrescriptionColumn = ({
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
                   'name',
-                  `${t('multiple')}`
+                  t('multiple')
                 );
               }
             } else {

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -12,7 +12,6 @@ import {
   PositiveNumberCell,
   useTranslation,
 } from '@openmsupply-client/common';
-import { LocationRowFragment } from '@openmsupply-client/system';
 import { StockOutLineFragment } from '../../StockOut';
 import { StockOutItem } from '../../types';
 
@@ -190,9 +189,9 @@ export const usePrescriptionColumn = ({
         {
           getSortValue: row => {
             if ('lines' in row) {
-              const locations = row.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = row.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(
                   locations,
@@ -208,9 +207,9 @@ export const usePrescriptionColumn = ({
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
-              const locations = rowData.lines
-                .map(({ location }) => location)
-                .filter(Boolean) as LocationRowFragment[];
+              const locations = rowData.lines.flatMap(({ location }) =>
+                !!location ? [location] : []
+              );
 
               if (locations.length !== 0) {
                 return ArrayUtils.ifTheSameElseDefault(

--- a/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
+++ b/client/packages/invoices/src/Prescriptions/DetailView/columns.ts
@@ -132,8 +132,11 @@ export const usePrescriptionColumn = ({
             if ('lines' in row) {
               const { lines } = row;
               return (
-                ArrayUtils.ifTheSameElseDefault(lines, 'batch', '[multiple]') ??
-                ''
+                ArrayUtils.ifTheSameElseDefault(
+                  lines,
+                  'batch',
+                  `${t('multiple')}`
+                ) ?? ''
               );
             } else {
               return row.batch ?? '';
@@ -145,7 +148,7 @@ export const usePrescriptionColumn = ({
               return ArrayUtils.ifTheSameElseDefault(
                 lines,
                 'batch',
-                '[multiple]'
+                `${t('multiple')}`
               );
             } else {
               return rowData.batch;
@@ -190,7 +193,15 @@ export const usePrescriptionColumn = ({
               const locations = row.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              } else {
+                return '';
+              }
             } else {
               return row.location?.name ?? '';
             }
@@ -200,7 +211,14 @@ export const usePrescriptionColumn = ({
               const locations = rowData.lines
                 .map(({ location }) => location)
                 .filter(Boolean) as LocationRowFragment[];
-              return ArrayUtils.ifTheSameElseDefault(locations, 'name', '');
+
+              if (locations.length !== 0) {
+                return ArrayUtils.ifTheSameElseDefault(
+                  locations,
+                  'name',
+                  `${t('multiple')}`
+                );
+              }
             } else {
               return rowData.location?.name ?? '';
             }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2278

# 👩🏻‍💻 What does this PR do? 
Adds a location column to the stocktake detail view, fixed [multiple] showing up for empty reasons, added [multiple] to translation and show [multiple] for invoice lines that have batches in different locations in inbound, outbound and prescriptions
![Screenshot 2023-09-29 at 2 46 35 PM](https://github.com/openmsupply/open-msupply/assets/61820074/b97a62b9-1986-48b3-81eb-515278b424da)


# 🧪 How has/should this change been tested? 
- [ ] Have an item with multiple stock lines in different locations 
- [ ] Do a stocktake with that line, see location column and grouping.

## 💌 Any notes for the reviewer?
Louisa suggested that the locations column for stocktake be moved to the left of `code`, but that would be inconsistent with our other views, so unsure if we should move or not... Locations still seem viewable when I view on a tablet screen size, so might be alright?