### PR TITLE
2289 Stocktake : Modifiable stocktake date

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -33,7 +33,7 @@ export const Toolbar: FC = () => {
     ? t('messages.on-hold-stock-take')
     : t('messages.finalised-stock-take');
 
-    return (
+  return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
       <Grid
         container
@@ -62,10 +62,10 @@ export const Toolbar: FC = () => {
             label={t('label.stocktake-date')}
             Input={
               <DatePickerInput
-                disabled={isDisabled}
+                disabled={true}
                 value={DateUtils.getDateOrNull(stocktakeDate)}
                 onChange={date => {
-                  if(DateUtils.isValid(date))
+                  if (DateUtils.isValid(date))
                     update({ stocktakeDate: Formatter.naiveDate(date) });
                 }}
               />

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -139,7 +139,9 @@ fn generate(
             stocktake_number,
             comment,
             description,
-            stocktake_date,
+            // TODO: Changing this to be same as created datetime for now since function is disabled in frontend
+            // but will need to remove this later when functionality is implemented.
+            stocktake_date: Utc::now().naive_utc(),
             status: StocktakeStatus::New,
             created_datetime: Utc::now().naive_utc(),
             user_id: user_id.to_string(),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2289

# 👩🏻‍💻 What does this PR do? 
Disable stocktake date in stocktake detail view.. Also noted that the date isn't being saved right now... Should it be the same as created datetime for now? 

# 🧪 How has/should this change been tested? 
- [ ] Go to stocktake 
- [ ] Click on a stocktake
- [ ] See disabled stocktake date
