### PR TITLE
Add useDeviceDetect hook. Fix wrong navigation

### DIFF
--- a/client/packages/common/src/utils/environment/EnvUtils.ts
+++ b/client/packages/common/src/utils/environment/EnvUtils.ts
@@ -79,10 +79,13 @@ const getPlatform = () => {
 
 const platform = getPlatform();
 
+const isTouchScreen = 'ontouchstart' in document.documentElement;
+
 export const EnvUtils = {
   // Using isProduction rather than isDevelopment, as we also use a testing
   // environment while running jest, so easier to check !isProduction, generally.
   isProduction: (): boolean => process.env['NODE_ENV'] === 'production',
+  isTouchScreen,
   mapRoute,
   platform,
   printFormat: PrintFormat.Html, // platform === Platform.Android ? PrintFormat.Html : PrintFormat.Pdf,

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -162,8 +162,6 @@ export const AppDrawer: React.FC = () => {
   const onHoverOver = () => {
     // Hover events not applicable on mobile devices
     if (EnvUtils.isTouchScreen) return;
-
-    if (EnvUtils.isTouchScreen) return;
     if (drawer.isOpen) return;
 
     drawer.open();

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -33,7 +33,6 @@ import {
 } from '../Navigation';
 import { AppDrawerIcon } from './AppDrawerIcon';
 import { SyncNavLink } from './SyncNavLink';
-import { useDeviceDetect } from '../../utils';
 
 const ToolbarIconContainer = styled(Box)({
   display: 'flex',
@@ -144,7 +143,6 @@ export const AppDrawer: React.FC = () => {
   const drawer = useDrawer();
   const { logout, userHasPermission, store } = useAuthContext();
   const location = useLocation();
-  const { isMobile } = useDeviceDetect();
 
   React.useEffect(() => {
     if (drawer.hasUserSet) return;
@@ -153,7 +151,8 @@ export const AppDrawer: React.FC = () => {
   }, [isMediumScreen]);
 
   const onHoverOut = () => {
-    if (isMobile) return;
+    // Hover events not applicable on mobile devices
+    if (EnvUtils.isTouchScreen) return;
     if (!drawer.hoverOpen) return;
 
     drawer.close();
@@ -161,7 +160,10 @@ export const AppDrawer: React.FC = () => {
   };
 
   const onHoverOver = () => {
-    if (isMobile) return;
+    // Hover events not applicable on mobile devices
+    if (EnvUtils.isTouchScreen) return;
+
+    if (EnvUtils.isTouchScreen) return;
     if (drawer.isOpen) return;
 
     drawer.open();

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -33,6 +33,7 @@ import {
 } from '../Navigation';
 import { AppDrawerIcon } from './AppDrawerIcon';
 import { SyncNavLink } from './SyncNavLink';
+import { useDeviceDetect } from '../../utils';
 
 const ToolbarIconContainer = styled(Box)({
   display: 'flex',
@@ -143,6 +144,7 @@ export const AppDrawer: React.FC = () => {
   const drawer = useDrawer();
   const { logout, userHasPermission, store } = useAuthContext();
   const location = useLocation();
+  const { isMobile } = useDeviceDetect();
 
   React.useEffect(() => {
     if (drawer.hasUserSet) return;
@@ -151,6 +153,7 @@ export const AppDrawer: React.FC = () => {
   }, [isMediumScreen]);
 
   const onHoverOut = () => {
+    if (isMobile) return;
     if (!drawer.hoverOpen) return;
 
     drawer.close();
@@ -158,6 +161,7 @@ export const AppDrawer: React.FC = () => {
   };
 
   const onHoverOver = () => {
+    if (isMobile) return;
     if (drawer.isOpen) return;
 
     drawer.open();

--- a/client/packages/host/src/utils.ts
+++ b/client/packages/host/src/utils.ts
@@ -1,7 +1,24 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 
 export const getBadgeProps = (value?: number) => ({
   badgeContent: (value ?? 0) as ReactNode,
   max: 99,
   color: 'primary' as 'primary' | 'default',
 });
+
+export const useDeviceDetect = () => {
+  const [isMobile, setMobile] = useState(false);
+
+  useEffect(() => {
+    const userAgent =
+      typeof window.navigator === 'undefined' ? '' : navigator.userAgent;
+    const mobile = Boolean(
+      userAgent.match(
+        /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
+      )
+    );
+    setMobile(mobile);
+  }, []);
+
+  return { isMobile };
+};

--- a/client/packages/host/src/utils.ts
+++ b/client/packages/host/src/utils.ts
@@ -1,24 +1,7 @@
-import { ReactNode, useState, useEffect } from 'react';
+import { ReactNode } from 'react';
 
 export const getBadgeProps = (value?: number) => ({
   badgeContent: (value ?? 0) as ReactNode,
   max: 99,
   color: 'primary' as 'primary' | 'default',
 });
-
-export const useDeviceDetect = () => {
-  const [isMobile, setMobile] = useState(false);
-
-  useEffect(() => {
-    const userAgent =
-      typeof window.navigator === 'undefined' ? '' : navigator.userAgent;
-    const mobile = Boolean(
-      userAgent.match(
-        /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
-      )
-    );
-    setMobile(mobile);
-  }, []);
-
-  return { isMobile };
-};


### PR DESCRIPTION
Fixes #2243 

# 👩🏻‍💻 What does this PR do? 
Adds a custom hook to detect if the user device is mobile. Maybe there is something like this already in the app? I couldn't see it though. 

# 🧪 How has/should this change been tested? 
You can test this by going to dashboard, opening dev tools, and selecting a mobile (ipad) dimensions.
Try interacting with the appbar as outlined in the video of #2243 
You can then compare develop branch to this branch, and see the functionality difference.

## 💌 Any notes for the reviewer?
There is a risk that the mobile checking isn't an exhaustive list, so might need to be updated.

Alternatively, we could use a package like https://www.npmjs.com/package/react-device-detect

I also wondered if there were other mouse specific interactions which wouldn't be appropriate for mobile which could also benefit from this hook, but can't see anything at a glance.