### PR TITLE
Remove whitespace from location name and code

### DIFF
--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -90,7 +90,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
   const t = useTranslation('inventory');
   const { draft, onUpdate, onChangeLocation, onSave, isLoading } =
     useDraftLocation(location, mode);
-  const isInvalid = !draft.code || !draft.name;
+  const isInvalid = !draft.code.trim() || !draft.name.trim();
 
   return (
     <Modal


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1605 

# 👩🏻‍💻 What does this PR do? 
Remove leading and trailing whitespaces from location name and code to ensure that the Ok/Ok & Next button still stays disabled if users just put whitespace for name and code

# 🧪 How has/should this change been tested? 
- [ ] Go to `Locations`
- [ ] Click `New Location`
- [ ] Press space for however long you want for name and code
- [ ] See buttons are still disabled