### PR TITLE
#2294 Fix Encounter layout regression

### DIFF
--- a/client/packages/programs/src/JsonForms/common/JsonForm.tsx
+++ b/client/packages/programs/src/JsonForms/common/JsonForm.tsx
@@ -234,8 +234,8 @@ export const JsonForm: FC<PropsWithChildren<JsonFormProps>> = ({
       gap={2}
       paddingX={5}
       sx={{
-        alignItems: 'flex-start',
         '& .input-with-label-row': {
+          alignItems: 'flex-start',
           maxWidth: FORM_COLUMN_MAX_WIDTH,
         },
         '& h1, h2, h3, h4, h5, h6': {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2294

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Very small tweak to address an oversight from #2259. I've now moved the `alignItems: 'flex-start'` property inside the "class" definition so it doesn't affect everything, only the actual input elements.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Checked visually the layout of:
- Encounter summary bubbles -- displays at it did before
- Patient view when limited patient data (base info only) -- displays as it did as a result of #2259 
