### PR TITLE
1493 remove event from activity log and add a from and to field for better translatability

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -302,6 +302,8 @@
   "label.add-another": "Add another",
   "label.remove": "Remove",
   "link.copy-to-clipboard": "Copy to Clipboard",
+  "log.changed-to": "to",
+  "log.changed-from": "From",
   "log.invoice-created": "Shipment created",
   "log.user-logged-in": "User logged in",
   "log.invoice-deleted": "Shipment deleted",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -60,11 +60,12 @@ export type ActivityLogFilterInput = {
 export type ActivityLogNode = {
   __typename: 'ActivityLogNode';
   datetime: Scalars['DateTime']['output'];
-  event?: Maybe<Scalars['String']['output']>;
+  from?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   recordId?: Maybe<Scalars['String']['output']>;
   store?: Maybe<StoreNode>;
   storeId?: Maybe<Scalars['String']['output']>;
+  to?: Maybe<Scalars['String']['output']>;
   type: ActivityLogNodeType;
   user?: Maybe<UserNode>;
 };

--- a/client/packages/system/src/Log/Components/ListView.tsx
+++ b/client/packages/system/src/Log/Components/ListView.tsx
@@ -42,8 +42,15 @@ export const LogList: FC<{ recordId: string }> = ({ recordId }) => {
         }),
     },
     {
-      key: 'event',
+      key: 'changeDetails',
       label: 'label.details',
+      accessor: ({ rowData }) => {
+        if (rowData?.from && rowData.to) {
+          return `[${rowData.from}] ${t('log.changed-to')} [${rowData.to}]`;
+        } else if (rowData?.from) {
+          return `${t('log.changed-from')} [${rowData.from}]`;
+        }
+      },
     },
   ]);
 

--- a/client/packages/system/src/Log/api/operations.generated.ts
+++ b/client/packages/system/src/Log/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
+export type ActivityLogRowFragment = { __typename: 'ActivityLogNode', id: string, datetime: string, to?: string | null, from?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null };
 
 export type ActivityLogsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
@@ -14,13 +14,14 @@ export type ActivityLogsQueryVariables = Types.Exact<{
 }>;
 
 
-export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: string, event?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
+export type ActivityLogsQuery = { __typename: 'Queries', activityLogs: { __typename: 'ActivityLogConnector', totalCount: number, nodes: Array<{ __typename: 'ActivityLogNode', id: string, datetime: string, to?: string | null, from?: string | null, recordId?: string | null, storeId?: string | null, type: Types.ActivityLogNodeType, user?: { __typename: 'UserNode', username: string } | null }> } };
 
 export const ActivityLogRowFragmentDoc = gql`
     fragment ActivityLogRow on ActivityLogNode {
   id
   datetime
-  event
+  to
+  from
   recordId
   storeId
   type

--- a/client/packages/system/src/Log/api/operations.graphql
+++ b/client/packages/system/src/Log/api/operations.graphql
@@ -1,7 +1,8 @@
 fragment ActivityLogRow on ActivityLogNode {
   id
   datetime
-  event
+  to
+  from
   recordId
   storeId
   type

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -190,7 +190,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
           </Typography>
           {showLogEvent && (
             <Typography sx={{ fontWeight: 'bold', marginBottom: 3 }}>
-              {`${t('messages.repack-log-info')} : ${logData?.nodes[0]?.event}`}
+              {`${t('messages.repack-log-info')} : ${logData?.nodes[0]?.to}`}
             </Typography>
           )}
         </Grid>

--- a/server/graphql/types/src/types/activity_log.rs
+++ b/server/graphql/types/src/types/activity_log.rs
@@ -77,11 +77,11 @@ impl ActivityLogNode {
     }
 
     pub async fn to(&self) -> &Option<String> {
-        &self.row().change_to
+        &self.row().changed_to
     }
 
     pub async fn from(&self) -> &Option<String> {
-        &self.row().change_from
+        &self.row().changed_from
     }
 
     pub async fn user(&self, ctx: &Context<'_>) -> Result<Option<UserNode>> {

--- a/server/graphql/types/src/types/activity_log.rs
+++ b/server/graphql/types/src/types/activity_log.rs
@@ -76,8 +76,12 @@ impl ActivityLogNode {
         DateTime::<Utc>::from_utc(self.row().datetime.clone(), Utc)
     }
 
-    pub async fn event(&self) -> &Option<String> {
-        &self.row().event
+    pub async fn to(&self) -> &Option<String> {
+        &self.row().change_to
+    }
+
+    pub async fn from(&self) -> &Option<String> {
+        &self.row().change_from
     }
 
     pub async fn user(&self, ctx: &Context<'_>) -> Result<Option<UserNode>> {

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -15,8 +15,8 @@ table! {
         store_id -> Nullable<Text>,
         record_id -> Nullable<Text>,
         datetime -> Timestamp,
-        change_to -> Nullable<Text>,
-        change_from -> Nullable<Text>,
+        changed_to -> Nullable<Text>,
+        changed_from -> Nullable<Text>,
     }
 }
 
@@ -68,8 +68,8 @@ pub struct ActivityLogRow {
     pub store_id: Option<String>,
     pub record_id: Option<String>,
     pub datetime: NaiveDateTime,
-    pub change_to: Option<String>,
-    pub change_from: Option<String>,
+    pub changed_to: Option<String>,
+    pub changed_from: Option<String>,
 }
 
 pub struct ActivityLogRowRepository<'a> {

--- a/server/repository/src/db_diesel/activity_log_row.rs
+++ b/server/repository/src/db_diesel/activity_log_row.rs
@@ -15,7 +15,8 @@ table! {
         store_id -> Nullable<Text>,
         record_id -> Nullable<Text>,
         datetime -> Timestamp,
-        event -> Nullable<Text>,
+        change_to -> Nullable<Text>,
+        change_from -> Nullable<Text>,
     }
 }
 
@@ -67,7 +68,8 @@ pub struct ActivityLogRow {
     pub store_id: Option<String>,
     pub record_id: Option<String>,
     pub datetime: NaiveDateTime,
-    pub event: Option<String>,
+    pub change_to: Option<String>,
+    pub change_from: Option<String>,
 }
 
 pub struct ActivityLogRowRepository<'a> {

--- a/server/repository/src/migrations/v1_04_00/activity_log.rs
+++ b/server/repository/src/migrations/v1_04_00/activity_log.rs
@@ -5,9 +5,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         connection,
         r#"
         ALTER TABLE activity_log ADD COLUMN change_to TEXT;
-        ALTER TABLE activity_log ADD COLUMN change_from TEXT;
-        UPDATE activity_log SET change_from = event;
-        ALTER TABLE activity_log DROP COLUMN event;
+        ALTER TABLE activity_log RENAME COLUMN event TO change_from;
         "#,
     )?;
 

--- a/server/repository/src/migrations/v1_04_00/activity_log.rs
+++ b/server/repository/src/migrations/v1_04_00/activity_log.rs
@@ -4,8 +4,8 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
     sql!(
         connection,
         r#"
-        ALTER TABLE activity_log ADD COLUMN change_to TEXT;
-        ALTER TABLE activity_log RENAME COLUMN event TO change_from;
+        ALTER TABLE activity_log ADD COLUMN changed_to TEXT;
+        ALTER TABLE activity_log RENAME COLUMN event TO changed_from;
         "#,
     )?;
 

--- a/server/repository/src/migrations/v1_04_00/activity_log.rs
+++ b/server/repository/src/migrations/v1_04_00/activity_log.rs
@@ -1,0 +1,15 @@
+use crate::{migrations::sql, StorageConnection};
+
+pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
+    sql!(
+        connection,
+        r#"
+        ALTER TABLE activity_log ADD COLUMN change_to TEXT;
+        ALTER TABLE activity_log ADD COLUMN change_from TEXT;
+        UPDATE activity_log SET change_from = event;
+        ALTER TABLE activity_log DROP COLUMN event;
+        "#,
+    )?;
+
+    Ok(())
+}

--- a/server/repository/src/migrations/v1_04_00/mod.rs
+++ b/server/repository/src/migrations/v1_04_00/mod.rs
@@ -2,6 +2,7 @@ use super::{version::Version, Migration};
 
 use crate::StorageConnection;
 pub(crate) struct V1_04_00;
+mod activity_log;
 mod contact_trace;
 mod date_of_death;
 
@@ -13,6 +14,7 @@ impl Migration for V1_04_00 {
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         contact_trace::migrate(connection)?;
         date_of_death::migrate(connection)?;
+        activity_log::migrate(connection)?;
         Ok(())
     }
 }

--- a/server/repository/src/mock/activity_log.rs
+++ b/server/repository/src/mock/activity_log.rs
@@ -13,7 +13,8 @@ pub fn activity_log_a() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        event: None,
+        change_to: None,
+        change_from: None,
     }
 }
 
@@ -28,7 +29,8 @@ pub fn activity_log_b() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        event: None,
+        change_to: None,
+        change_from: None,
     }
 }
 
@@ -43,7 +45,8 @@ pub fn activity_log_c() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        event: None,
+        change_to: None,
+        change_from: None,
     }
 }
 

--- a/server/repository/src/mock/activity_log.rs
+++ b/server/repository/src/mock/activity_log.rs
@@ -13,8 +13,8 @@ pub fn activity_log_a() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        change_to: None,
-        change_from: None,
+        changed_to: None,
+        changed_from: None,
     }
 }
 
@@ -29,8 +29,8 @@ pub fn activity_log_b() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        change_to: None,
-        change_from: None,
+        changed_to: None,
+        changed_from: None,
     }
 }
 
@@ -45,8 +45,8 @@ pub fn activity_log_c() -> ActivityLogRow {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap(),
-        change_to: None,
-        change_from: None,
+        changed_to: None,
+        changed_from: None,
     }
 }
 

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -262,7 +262,8 @@ mod repository_test {
                 store_id: None,
                 record_id: None,
                 datetime: NaiveDateTime::from_timestamp_opt(2000, 0).unwrap(),
-                event: None,
+                change_to: None,
+                change_from: None,
             }
         }
     }

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -262,8 +262,8 @@ mod repository_test {
                 store_id: None,
                 record_id: None,
                 datetime: NaiveDateTime::from_timestamp_opt(2000, 0).unwrap(),
-                change_to: None,
-                change_from: None,
+                changed_to: None,
+                changed_from: None,
             }
         }
     }

--- a/server/service/src/activity_log.rs
+++ b/server/service/src/activity_log.rs
@@ -35,8 +35,8 @@ pub fn activity_log_entry(
     ctx: &ServiceContext,
     log_type: ActivityLogType,
     record_id: Option<String>,
-    change_from: Option<String>,
-    change_to: Option<String>,
+    changed_from: Option<String>,
+    changed_to: Option<String>,
 ) -> Result<(), RepositoryError> {
     let log = &ActivityLogRow {
         id: uuid(),
@@ -53,8 +53,8 @@ pub fn activity_log_entry(
         },
         record_id,
         datetime: Utc::now().naive_utc(),
-        change_to,
-        change_from,
+        changed_to,
+        changed_from,
     };
 
     Ok(ActivityLogRowRepository::new(&ctx.connection).insert_one(log)?)
@@ -73,8 +73,8 @@ pub fn system_activity_log_entry(
         store_id: Some(store_id.to_string()),
         record_id: Some(record_id.to_string()),
         datetime: Utc::now().naive_utc(),
-        change_from: None,
-        change_to: None,
+        changed_from: None,
+        changed_to: None,
     };
 
     Ok(ActivityLogRowRepository::new(&connection).insert_one(log)?)

--- a/server/service/src/activity_log.rs
+++ b/server/service/src/activity_log.rs
@@ -35,7 +35,8 @@ pub fn activity_log_entry(
     ctx: &ServiceContext,
     log_type: ActivityLogType,
     record_id: Option<String>,
-    event: Option<String>,
+    change_from: Option<String>,
+    change_to: Option<String>,
 ) -> Result<(), RepositoryError> {
     let log = &ActivityLogRow {
         id: uuid(),
@@ -52,26 +53,11 @@ pub fn activity_log_entry(
         },
         record_id,
         datetime: Utc::now().naive_utc(),
-        event,
+        change_to,
+        change_from,
     };
 
     Ok(ActivityLogRowRepository::new(&ctx.connection).insert_one(log)?)
-}
-
-pub fn activity_log_stock_entry(
-    ctx: &ServiceContext,
-    log_type: ActivityLogType,
-    record_id: Option<String>,
-    from: Option<String>,
-    to: Option<String>,
-) -> Result<(), RepositoryError> {
-    let event = Some(format!(
-        "Changed from [{}] to [{}]",
-        from.unwrap_or_default(),
-        to.unwrap_or_default()
-    ));
-
-    Ok(activity_log_entry(ctx, log_type, record_id, event)?)
 }
 
 pub fn system_activity_log_entry(
@@ -87,7 +73,8 @@ pub fn system_activity_log_entry(
         store_id: Some(store_id.to_string()),
         record_id: Some(record_id.to_string()),
         datetime: Utc::now().naive_utc(),
-        event: None,
+        change_from: None,
+        change_to: None,
     };
 
     Ok(ActivityLogRowRepository::new(&connection).insert_one(log)?)

--- a/server/service/src/invoice/inbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/delete/mod.rs
@@ -49,6 +49,7 @@ pub fn delete_inbound_shipment(
                 ActivityLogType::InvoiceDeleted,
                 Some(input.id.to_owned()),
                 None,
+                None,
             )?;
 
             match InvoiceRowRepository::new(&connection).delete(&input.id.clone()) {

--- a/server/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -40,6 +40,7 @@ pub fn insert_inbound_shipment(
                 ActivityLogType::InvoiceCreated,
                 Some(new_invoice.id.to_owned()),
                 None,
+                None,
             )?;
 
             get_invoice(ctx, None, &new_invoice.id)

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -99,6 +99,7 @@ pub fn update_inbound_shipment(
                     log_type_from_invoice_status(&update_invoice.status, false),
                     Some(update_invoice.id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/invoice/outbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/delete/mod.rs
@@ -46,6 +46,7 @@ pub fn delete_outbound_shipment(
                 ActivityLogType::InvoiceDeleted,
                 Some(id.to_owned()),
                 None,
+                None,
             )?;
 
             match InvoiceRowRepository::new(&connection).delete(&id) {

--- a/server/service/src/invoice/outbound_shipment/insert/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/insert/mod.rs
@@ -54,6 +54,7 @@ pub fn insert_outbound_shipment(
                 ActivityLogType::InvoiceCreated,
                 Some(new_invoice.id.to_owned()),
                 None,
+                None,
             )?;
 
             get_invoice(ctx, None, &new_invoice.id)

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -102,6 +102,7 @@ pub fn update_outbound_shipment(
                     log_type_from_invoice_status(&update_invoice.status, false),
                     Some(update_invoice.id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/invoice/prescription/delete/mod.rs
+++ b/server/service/src/invoice/prescription/delete/mod.rs
@@ -44,6 +44,7 @@ pub fn delete_prescription(
                 ActivityLogType::PrescriptionDeleted,
                 Some(id.to_owned()),
                 None,
+                None,
             )?;
 
             match InvoiceRowRepository::new(&connection).delete(&id) {

--- a/server/service/src/invoice/prescription/insert/mod.rs
+++ b/server/service/src/invoice/prescription/insert/mod.rs
@@ -47,6 +47,7 @@ pub fn insert_prescription(
                 ActivityLogType::PrescriptionCreated,
                 Some(new_invoice.id.to_owned()),
                 None,
+                None,
             )?;
 
             get_invoice(ctx, None, &new_invoice.id)

--- a/server/service/src/invoice/prescription/update/mod.rs
+++ b/server/service/src/invoice/prescription/update/mod.rs
@@ -79,6 +79,7 @@ pub fn update_prescription(
                     log_type_from_invoice_status(&update_invoice.status, true),
                     Some(update_invoice.id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -135,7 +135,13 @@ impl LoginService {
         };
         service_ctx.user_id = user_account.id.clone();
 
-        activity_log_entry(&service_ctx, ActivityLogType::UserLoggedIn, None, None)?;
+        activity_log_entry(
+            &service_ctx,
+            ActivityLogType::UserLoggedIn,
+            None,
+            None,
+            None,
+        )?;
 
         let mut token_service = TokenService::new(
             &auth_data.token_bucket,

--- a/server/service/src/repack/generate.rs
+++ b/server/service/src/repack/generate.rs
@@ -50,8 +50,8 @@ pub fn generate(
         store_id: Some(ctx.store_id.clone()),
         record_id: Some(new_stock_line.id),
         datetime: Utc::now().naive_utc(),
-        change_from: Some(stock_line_to_update.id),
-        change_to: None,
+        changed_from: Some(stock_line_to_update.id),
+        changed_to: None,
     };
 
     Ok(GenerateRepack {

--- a/server/service/src/repack/generate.rs
+++ b/server/service/src/repack/generate.rs
@@ -50,7 +50,8 @@ pub fn generate(
         store_id: Some(ctx.store_id.clone()),
         record_id: Some(new_stock_line.id),
         datetime: Utc::now().naive_utc(),
-        event: Some(stock_line_to_update.id),
+        change_from: Some(stock_line_to_update.id),
+        change_to: None,
     };
 
     Ok(GenerateRepack {

--- a/server/service/src/repack/insert.rs
+++ b/server/service/src/repack/insert.rs
@@ -562,8 +562,8 @@ mod test {
                     r#type: ActivityLogType::Repack,
                     record_id: Some(new_stock.id.clone()),
                     datetime: activity_log.activity_log_row.datetime,
-                    change_from: Some(updated_stock.id),
-                    change_to: None
+                    changed_from: Some(updated_stock.id),
+                    changed_to: None
                 }
             }
         )

--- a/server/service/src/repack/insert.rs
+++ b/server/service/src/repack/insert.rs
@@ -562,7 +562,8 @@ mod test {
                     r#type: ActivityLogType::Repack,
                     record_id: Some(new_stock.id.clone()),
                     datetime: activity_log.activity_log_row.datetime,
-                    event: Some(updated_stock.id),
+                    change_from: Some(updated_stock.id),
+                    change_to: None
                 }
             }
         )

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -69,6 +69,7 @@ pub fn delete_request_requisition(
                 ActivityLogType::RequisitionDeleted,
                 Some(input.id.to_owned()),
                 None,
+                None,
             )?;
 
             match RequisitionRowRepository::new(&connection).delete(&input.id) {

--- a/server/service/src/requisition/request_requisition/insert.rs
+++ b/server/service/src/requisition/request_requisition/insert.rs
@@ -58,6 +58,7 @@ pub fn insert_request_requisition(
                 ActivityLogType::RequisitionCreated,
                 Some(new_requisition.id.to_owned()),
                 None,
+                None,
             )?;
 
             get_requisition(ctx, None, &new_requisition.id)

--- a/server/service/src/requisition/request_requisition/insert_program.rs
+++ b/server/service/src/requisition/request_requisition/insert_program.rs
@@ -65,6 +65,7 @@ pub fn insert_program_request_requisition(
                 ActivityLogType::RequisitionCreated,
                 Some(new_requisition.id.to_owned()),
                 None,
+                None,
             )?;
 
             get_requisition(ctx, None, &new_requisition.id)

--- a/server/service/src/requisition/request_requisition/update/mod.rs
+++ b/server/service/src/requisition/request_requisition/update/mod.rs
@@ -90,6 +90,7 @@ pub fn update_request_requisition(
                     ActivityLogType::RequisitionStatusSent,
                     Some(updated_requisition_row.id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
@@ -61,6 +61,7 @@ pub fn create_requisition_shipment(
                 ActivityLogType::InvoiceCreated,
                 Some(invoice_row.id.to_owned()),
                 None,
+                None,
             )?;
 
             // TODO use invoice service if it accepts ctx

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -58,6 +58,7 @@ pub fn update_response_requisition(
                     ActivityLogType::RequisitionStatusFinalised,
                     Some(updated_requisition.id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -283,8 +283,8 @@ fn log_stock_changes(
             &ctx,
             ActivityLogType::StockOnHold,
             Some(new.id.to_owned()),
-            Some("\u{2705}".to_string()), // tick unicode
-            Some("\u{274C}".to_string()), // cross unicode
+            None,
+            None,
         )?;
     }
     if existing.on_hold != new.on_hold && !new.on_hold {
@@ -292,8 +292,8 @@ fn log_stock_changes(
             &ctx,
             ActivityLogType::StockOffHold,
             Some(new.id),
-            Some("\u{274C}".to_string()),
-            Some("\u{2705}".to_string()),
+            None,
+            None,
         )?;
     }
 

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -8,7 +8,7 @@ use repository::{
 use util::uuid::uuid;
 
 use crate::{
-    activity_log::activity_log_stock_entry,
+    activity_log::activity_log_entry,
     barcode::{self, BarcodeInput},
     common_stock::{check_stock_line_exists, CommonStockLineError},
     service_provider::ServiceContext,
@@ -219,10 +219,10 @@ fn log_stock_changes(
         let previous_location = if let Some(location_id) = existing.location_id {
             Some(location_id)
         } else {
-            Some("no location".to_string())
+            Some("-".to_string())
         };
 
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockLocationChange,
             Some(new.id.to_owned()),
@@ -234,10 +234,10 @@ fn log_stock_changes(
         let previous_batch = if let Some(batch) = existing.batch {
             Some(batch)
         } else {
-            Some("no batch".to_string())
+            Some("-".to_string())
         };
 
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockBatchChange,
             Some(new.id.to_owned()),
@@ -246,7 +246,7 @@ fn log_stock_changes(
         )?;
     }
     if existing.cost_price_per_pack != new.cost_price_per_pack {
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockCostPriceChange,
             Some(new.id.to_owned()),
@@ -255,7 +255,7 @@ fn log_stock_changes(
         )?;
     }
     if existing.sell_price_per_pack != new.sell_price_per_pack {
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockSellPriceChange,
             Some(new.id.to_owned()),
@@ -267,10 +267,10 @@ fn log_stock_changes(
         let previous_expiry_date = if let Some(expiry_date) = existing.expiry_date {
             Some(expiry_date.to_string())
         } else {
-            Some("no expiry date".to_string())
+            Some("-".to_string())
         };
 
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockExpiryDateChange,
             Some(new.id.to_owned()),
@@ -279,21 +279,21 @@ fn log_stock_changes(
         )?;
     }
     if existing.on_hold != new.on_hold && new.on_hold {
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockOnHold,
             Some(new.id.to_owned()),
-            Some("off hold".to_string()),
-            Some("on hold".to_string()),
+            Some("\u{2705}".to_string()),
+            Some("\u{274C}".to_string()),
         )?;
     }
     if existing.on_hold != new.on_hold && !new.on_hold {
-        activity_log_stock_entry(
+        activity_log_entry(
             &ctx,
             ActivityLogType::StockOffHold,
             Some(new.id),
-            Some("on hold".to_string()),
-            Some("off hold".to_string()),
+            Some("\u{274C}".to_string()),
+            Some("\u{2705}".to_string()),
         )?;
     }
 

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -283,8 +283,8 @@ fn log_stock_changes(
             &ctx,
             ActivityLogType::StockOnHold,
             Some(new.id.to_owned()),
-            Some("\u{2705}".to_string()),
-            Some("\u{274C}".to_string()),
+            Some("\u{2705}".to_string()), // tick unicode
+            Some("\u{274C}".to_string()), // cross unicode
         )?;
     }
     if existing.on_hold != new.on_hold && !new.on_hold {

--- a/server/service/src/stocktake/delete.rs
+++ b/server/service/src/stocktake/delete.rs
@@ -85,6 +85,7 @@ pub fn delete_stocktake(
                 ActivityLogType::StocktakeDeleted,
                 Some(stocktake_id.to_owned()),
                 None,
+                None,
             )?;
 
             StocktakeRowRepository::new(&connection).delete(&stocktake_id)?;

--- a/server/service/src/stocktake/insert.rs
+++ b/server/service/src/stocktake/insert.rs
@@ -376,6 +376,7 @@ pub fn insert_stocktake(
                 ActivityLogType::StocktakeCreated,
                 Some(new_stocktake.id.to_owned()),
                 None,
+                None,
             )?;
             let stocktake = get_stocktake(ctx, new_stocktake.id)?;
             stocktake.ok_or(InsertStocktakeError::InternalError(

--- a/server/service/src/stocktake/update.rs
+++ b/server/service/src/stocktake/update.rs
@@ -701,6 +701,7 @@ pub fn update_stocktake(
                     ActivityLogType::StocktakeStatusFinalised,
                     Some(stocktake_id.to_owned()),
                     None,
+                    None,
                 )?;
             }
 

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -15,7 +15,8 @@ const ACTIVITY_LOG_1: (&'static str, &'static str) = (
     "store_ID": "store_b",
     "record_ID": "outbound_shipment_a",
     "datetime": "2020-01-01T00:00:00",
-    "event": ""
+    "change_to": "",
+    "change_from": ""
     }"#,
 );
 
@@ -28,7 +29,8 @@ const ACTIVITY_LOG_2: (&'static str, &'static str) = (
     "store_ID": "store_b",
     "record_ID": "inbound_shipment_a",
     "datetime": "2020-01-01T00:00:00",
-    "event": ""
+    "change_to": "",
+    "change_from": ""
     }"#,
 );
 
@@ -47,7 +49,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                event: None,
+                change_to: None,
+                change_from: None,
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
@@ -63,7 +66,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                event: None,
+                change_to: None,
+                change_from: None,
             }),
         ),
     ]
@@ -84,7 +88,8 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                event: None,
+                change_to: None,
+                change_from: None,
             }),
         },
         TestSyncPushRecord {
@@ -100,7 +105,8 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                event: None,
+                change_to: None,
+                change_from: None,
             }),
         },
     ]

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -88,8 +88,8 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                change_to: None,
-                change_from: None,
+                changed_to: None,
+                changed_from: None,
             }),
         },
         TestSyncPushRecord {
@@ -105,8 +105,8 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                change_to: None,
-                change_from: None,
+                changed_to: None,
+                changed_from: None,
             }),
         },
     ]

--- a/server/service/src/sync/test/test_data/activity_log.rs
+++ b/server/service/src/sync/test/test_data/activity_log.rs
@@ -15,8 +15,8 @@ const ACTIVITY_LOG_1: (&'static str, &'static str) = (
     "store_ID": "store_b",
     "record_ID": "outbound_shipment_a",
     "datetime": "2020-01-01T00:00:00",
-    "change_to": "",
-    "change_from": ""
+    "changed_to": "",
+    "changed_from": ""
     }"#,
 );
 
@@ -29,8 +29,8 @@ const ACTIVITY_LOG_2: (&'static str, &'static str) = (
     "store_ID": "store_b",
     "record_ID": "inbound_shipment_a",
     "datetime": "2020-01-01T00:00:00",
-    "change_to": "",
-    "change_from": ""
+    "changed_to": "",
+    "changed_from": ""
     }"#,
 );
 
@@ -49,8 +49,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                change_to: None,
-                change_from: None,
+                changed_to: None,
+                changed_from: None,
             }),
         ),
         TestSyncPullRecord::new_pull_upsert(
@@ -66,8 +66,8 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap(),
-                change_to: None,
-                change_from: None,
+                changed_to: None,
+                changed_from: None,
             }),
         ),
     ]

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -35,7 +35,9 @@ pub struct LegacyActivityLogRow {
     pub record_id: String,
     pub datetime: NaiveDateTime,
     #[serde(deserialize_with = "empty_str_as_option_string")]
-    pub event: Option<String>,
+    pub change_to: Option<String>,
+    #[serde(deserialize_with = "empty_str_as_option_string")]
+    pub change_from: Option<String>,
 }
 
 pub(crate) struct ActivityLogTranslation {}
@@ -65,7 +67,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id: Some(data.store_id),
             record_id: Some(data.record_id),
             datetime: data.datetime,
-            event: data.event,
+            change_to: data.change_to,
+            change_from: data.change_from,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -89,7 +92,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id,
             record_id,
             datetime,
-            event,
+            change_to,
+            change_from,
         } = ActivityLogRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -109,7 +113,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id,
             record_id,
             datetime,
-            event,
+            change_to,
+            change_from,
         };
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,

--- a/server/service/src/sync/translations/activity_log.rs
+++ b/server/service/src/sync/translations/activity_log.rs
@@ -35,9 +35,9 @@ pub struct LegacyActivityLogRow {
     pub record_id: String,
     pub datetime: NaiveDateTime,
     #[serde(deserialize_with = "empty_str_as_option_string")]
-    pub change_to: Option<String>,
+    pub changed_to: Option<String>,
     #[serde(deserialize_with = "empty_str_as_option_string")]
-    pub change_from: Option<String>,
+    pub changed_from: Option<String>,
 }
 
 pub(crate) struct ActivityLogTranslation {}
@@ -67,8 +67,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id: Some(data.store_id),
             record_id: Some(data.record_id),
             datetime: data.datetime,
-            change_to: data.change_to,
-            change_from: data.change_from,
+            changed_to: data.changed_to,
+            changed_from: data.changed_from,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -92,8 +92,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id,
             record_id,
             datetime,
-            change_to,
-            change_from,
+            changed_to,
+            changed_from,
         } = ActivityLogRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -113,8 +113,8 @@ impl SyncTranslation for ActivityLogTranslation {
             store_id,
             record_id,
             datetime,
-            change_to,
-            change_from,
+            changed_to,
+            changed_from,
         };
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1493 

# 👩🏻‍💻 What does this PR do? 
Adds two new fields to the activity log for better translatability: `change_from` and `change_to`. Migrates the existing `event` column to `change_from` and remove it. Updated this change through backend and frontend.

# 🧪 How has/should this change been tested? 
- [ ] Go to stock line detail view
- [ ] Update any of the fields in stock line
- [ ] Go to log (currently no other translation for this other than English so....)

## 💌 Any notes for the reviewer?
Current mSupply PR for this change https://github.com/openmsupply/msupply/pull/13752