### PR TITLE
Add missing integration dependency

### DIFF
--- a/server/service/src/sync/translations/report.rs
+++ b/server/service/src/sync/translations/report.rs
@@ -67,7 +67,7 @@ impl SyncTranslation for ReportTranslation {
     fn pull_dependencies(&self) -> PullDependency {
         PullDependency {
             table: LegacyTableName::REPORT,
-            dependencies: vec![],
+            dependencies: vec![LegacyTableName::FORM_SCHEMA],
         }
     }
 


### PR DESCRIPTION
Fixes #2331 

This fixes an issue on the demo server where report with argument schemas went missing. Just tested on the ,new program demo and this fixes the issue.