### PR TITLE
Add preliminary raw currency state which allows decimal point

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -37,11 +37,13 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   defaultValue = 0,
   onChangeNumber,
   maxWidth,
+  value,
   ...restOfProps
 }) => {
   const { c, options, language } = useCurrency();
   const prefix = language !== 'fr' ? options.symbol : '';
   const suffix = language === 'fr' ? options.symbol : '';
+  const [rawValue, setRawValue] = React.useState(value);
 
   return (
     <StyledCurrencyInput
@@ -53,7 +55,11 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
             : theme.palette.background.menu,
       }}
       defaultValue={defaultValue}
-      onValueChange={newValue => onChangeNumber(c(newValue || '').value)}
+      onValueChange={newValue => {
+        onChangeNumber(c(newValue || '').value);
+        setRawValue(newValue);
+      }}
+      value={rawValue}
       onFocus={e => e.target.select()}
       allowNegativeValue={allowNegativeValue}
       prefix={prefix}

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import RCInput, {
   CurrencyInputProps as RCInputProps,
@@ -43,7 +43,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   const { c, options, language } = useCurrency();
   const prefix = language !== 'fr' ? options.symbol : '';
   const suffix = language === 'fr' ? options.symbol : '';
-  const [rawValue, setRawValue] = React.useState(value);
+  const [rawValue, setRawValue] = useState(value);
 
   return (
     <StyledCurrencyInput


### PR DESCRIPTION
Fixes #2328 

# 👩🏻‍💻 What does this PR do? 
Adds an intermediate currency input state which allows decimal inputs
Parses a formatted currency to the StockLineRowFragment type.

# 🧪 How has/should this change been tested? 
You can test this by trying to type decimals into the stock line details modal

## 💌 Any notes for the reviewer?
I don't really understand how I've gotten this to work, and would love if anyone would be willing to explain to me (if they have time.

Specifically I'm struggling to understand why it is allowing decimals, but not other inputs ie '/'
I also don't have a clear understanding of the {...restOfProps} passing into StyledCurrencyInput. There are so many props! 
was the displaying value being passed in this massive lump of props initially?
