### PR TITLE
2333  add new fields to patient window

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1655,9 +1655,11 @@ export type InsertPatientInput = {
   code: Scalars['String']['input'];
   code2?: InputMaybe<Scalars['String']['input']>;
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
+  dateOfDeath?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   gender?: InputMaybe<GenderInput>;
   id: Scalars['String']['input'];
+  isDeceased?: InputMaybe<Scalars['Boolean']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
 };
@@ -5049,9 +5051,11 @@ export type UpdatePatientInput = {
   code: Scalars['String']['input'];
   code2?: InputMaybe<Scalars['String']['input']>;
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
+  dateOfDeath?: InputMaybe<Scalars['NaiveDate']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   gender?: InputMaybe<GenderInput>;
   id: Scalars['String']['input'];
+  isDeceased?: InputMaybe<Scalars['Boolean']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
 };

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1651,6 +1651,7 @@ export type InsertOutboundShipmentUnallocatedLineResponseWithId = {
 };
 
 export type InsertPatientInput = {
+  address1?: InputMaybe<Scalars['String']['input']>;
   code: Scalars['String']['input'];
   code2?: InputMaybe<Scalars['String']['input']>;
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
@@ -1658,6 +1659,7 @@ export type InsertPatientInput = {
   gender?: InputMaybe<GenderInput>;
   id: Scalars['String']['input'];
   lastName?: InputMaybe<Scalars['String']['input']>;
+  phone?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InsertPatientResponse = PatientNode;
@@ -5043,6 +5045,7 @@ export type UpdateOutboundShipmentUnallocatedLineResponseWithId = {
  * For example, if the last_name is not provided, the last_name in the patient record will be cleared.
  */
 export type UpdatePatientInput = {
+  address1?: InputMaybe<Scalars['String']['input']>;
   code: Scalars['String']['input'];
   code2?: InputMaybe<Scalars['String']['input']>;
   dateOfBirth?: InputMaybe<Scalars['NaiveDate']['input']>;
@@ -5050,6 +5053,7 @@ export type UpdatePatientInput = {
   gender?: InputMaybe<GenderInput>;
   id: Scalars['String']['input'];
   lastName?: InputMaybe<Scalars['String']['input']>;
+  phone?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdatePatientResponse = PatientNode;

--- a/client/packages/programs/src/hooks/usePatientStore.ts
+++ b/client/packages/programs/src/hooks/usePatientStore.ts
@@ -29,6 +29,8 @@ export interface CreateNewPatient {
   gender?: Gender;
   address1?: string;
   phone?: string;
+  dateOfDeath?: string;
+  isDeceased?: boolean;
 }
 /**
  * Stores:

--- a/client/packages/programs/src/hooks/usePatientStore.ts
+++ b/client/packages/programs/src/hooks/usePatientStore.ts
@@ -27,6 +27,8 @@ export interface CreateNewPatient {
   lastName?: string;
   dateOfBirth?: string;
   gender?: Gender;
+  address1?: string;
+  phone?: string;
 }
 /**
  * Stores:

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientFormTab.tsx
@@ -21,6 +21,8 @@ type Patient = {
   lastName?: string;
   dateOfBirth?: string;
   gender?: Gender;
+  address1?: string;
+  phone?: string;
 };
 
 export const PatientFormTab: FC<PatientPanel> = ({ patient, value }) => {
@@ -49,6 +51,8 @@ export const PatientFormTab: FC<PatientPanel> = ({ patient, value }) => {
         lastName: patientData?.lastName,
         dateOfBirth: patientData?.dateOfBirth,
         gender: patientData?.gender,
+        address1: patientData?.address1,
+        phone: patientData?.phone,
       });
     }
   };

--- a/client/packages/system/src/Patient/DefaultPatientSchema.json
+++ b/client/packages/system/src/Patient/DefaultPatientSchema.json
@@ -44,6 +44,14 @@
         "lastName": {
           "description": "Patient Surname",
           "type": "string"
+        },
+        "address1": {
+          "description": "Address",
+          "type": "string"
+        },
+        "phone": {
+          "description": "Phone number",
+          "type": "string"
         }
       },
       "required": ["id", "code"],

--- a/client/packages/system/src/Patient/DefaultPatientUISchema.json
+++ b/client/packages/system/src/Patient/DefaultPatientUISchema.json
@@ -66,6 +66,16 @@
               ["UNKOWN", "Unknown"]
             ]
           }
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/address1",
+          "label": "Address"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/phone",
+          "label": "Phone"
         }
       ]
     }

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -122,6 +122,8 @@ const PatientDetailView = ({
           lastName: createNewPatient.lastName,
           gender: createNewPatient.gender,
           dateOfBirth: createNewPatient.dateOfBirth,
+          phone: createNewPatient.phone,
+          address1: createNewPatient.address1,
         },
         isCreating: true,
       };
@@ -138,8 +140,9 @@ const PatientDetailView = ({
           lastName: currentPatient.lastName ?? undefined,
           gender: currentPatient.gender ?? undefined,
           dateOfBirth: currentPatient.dateOfBirth ?? undefined,
-          isDeceased: currentPatient.isDeceased ?? undefined,
           dateOfDeath: currentPatient.dateOfDeath ?? undefined,
+          phone: currentPatient.phone ?? undefined,
+          address1: currentPatient.address1 ?? undefined,
         },
         isCreating: false,
       };

--- a/client/packages/system/src/Patient/PatientView/PatientView.tsx
+++ b/client/packages/system/src/Patient/PatientView/PatientView.tsx
@@ -124,6 +124,8 @@ const PatientDetailView = ({
           dateOfBirth: createNewPatient.dateOfBirth,
           phone: createNewPatient.phone,
           address1: createNewPatient.address1,
+          isDeceased: createNewPatient.isDeceased,
+          dateOfDeath: createNewPatient.dateOfDeath,
         },
         isCreating: true,
       };
@@ -141,6 +143,7 @@ const PatientDetailView = ({
           gender: currentPatient.gender ?? undefined,
           dateOfBirth: currentPatient.dateOfBirth ?? undefined,
           dateOfDeath: currentPatient.dateOfDeath ?? undefined,
+          isDeceased: currentPatient.isDeceased ?? undefined,
           phone: currentPatient.phone ?? undefined,
           address1: currentPatient.address1 ?? undefined,
         },

--- a/client/packages/system/src/Patient/api/operations.generated.ts
+++ b/client/packages/system/src/Patient/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type PatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
+export type PatientRowFragment = { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } };
 
 export type PatientsQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -14,7 +14,7 @@ export type PatientsQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientsQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
+export type PatientsQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
 
 export type PatientByIdQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -22,7 +22,7 @@ export type PatientByIdQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientByIdQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
+export type PatientByIdQuery = { __typename: 'Queries', patients: { __typename: 'PatientConnector', totalCount: number, nodes: Array<{ __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } }> } };
 
 export type PatientSearchQueryVariables = Types.Exact<{
   input: Types.PatientSearchInput;
@@ -30,7 +30,7 @@ export type PatientSearchQueryVariables = Types.Exact<{
 }>;
 
 
-export type PatientSearchQuery = { __typename: 'Queries', patientSearch: { __typename: 'PatientSearchConnector', totalCount: number, nodes: Array<{ __typename: 'PatientSearchNode', score: number, patient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } }> } };
+export type PatientSearchQuery = { __typename: 'Queries', patientSearch: { __typename: 'PatientSearchConnector', totalCount: number, nodes: Array<{ __typename: 'PatientSearchNode', score: number, patient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } }> } };
 
 export type CentralPatientSearchQueryVariables = Types.Exact<{
   input: Types.CentralPatientSearchInput;
@@ -54,7 +54,7 @@ export type InsertProgramPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertProgramPatientMutation = { __typename: 'Mutations', insertProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type InsertProgramPatientMutation = { __typename: 'Mutations', insertProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type UpdateProgramPatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -62,7 +62,7 @@ export type UpdateProgramPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateProgramPatientMutation = { __typename: 'Mutations', updateProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type UpdateProgramPatientMutation = { __typename: 'Mutations', updateProgramPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type InsertPatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -70,7 +70,7 @@ export type InsertPatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertPatientMutation = { __typename: 'Mutations', insertPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type InsertPatientMutation = { __typename: 'Mutations', insertPatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export type UpdatePatientMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -78,7 +78,7 @@ export type UpdatePatientMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdatePatientMutation = { __typename: 'Mutations', updatePatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
+export type UpdatePatientMutation = { __typename: 'Mutations', updatePatient: { __typename: 'PatientNode', id: string, code: string, code2?: string | null, firstName?: string | null, lastName?: string | null, name: string, dateOfBirth?: string | null, address1?: string | null, phone?: string | null, gender?: Types.GenderType | null, email?: string | null, isDeceased: boolean, dateOfDeath?: string | null, document?: { __typename: 'DocumentNode', data: any, id: string, name: string, type: string } | null, programEnrolments: { __typename: 'ProgramEnrolmentConnector', totalCount: number, nodes: Array<{ __typename: 'ProgramEnrolmentNode', programEnrolmentId?: string | null, document: { __typename: 'DocumentNode', documentRegistry?: { __typename: 'DocumentRegistryNode', name?: string | null } | null } }> } } };
 
 export const PatientRowFragmentDoc = gql`
     fragment PatientRow on PatientNode {
@@ -89,6 +89,8 @@ export const PatientRowFragmentDoc = gql`
   lastName
   name
   dateOfBirth
+  address1
+  phone
   gender
   email
   document {

--- a/client/packages/system/src/Patient/api/operations.graphql
+++ b/client/packages/system/src/Patient/api/operations.graphql
@@ -6,6 +6,8 @@ fragment PatientRow on PatientNode {
   lastName
   name
   dateOfBirth
+  address1
+  phone
   gender
   email
   document {

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -20,6 +20,8 @@ pub struct InsertPatientInput {
     pub last_name: Option<String>,
     pub gender: Option<GenderInput>,
     pub date_of_birth: Option<NaiveDate>,
+    pub address1: Option<String>,
+    pub phone: Option<String>,
 }
 
 #[derive(Union)]
@@ -86,6 +88,8 @@ impl InsertPatientInput {
             last_name,
             gender,
             date_of_birth,
+            address1,
+            phone,
         } = self;
 
         ServiceInput {
@@ -96,6 +100,8 @@ impl InsertPatientInput {
             last_name,
             gender: gender.map(|g| g.to_domain()),
             date_of_birth,
+            address1,
+            phone,
             r#type: NameType::Patient,
         }
     }

--- a/server/graphql/programs/src/mutations/patient/insert.rs
+++ b/server/graphql/programs/src/mutations/patient/insert.rs
@@ -22,6 +22,8 @@ pub struct InsertPatientInput {
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,
+    pub is_deceased: Option<bool>,
+    pub date_of_death: Option<NaiveDate>,
 }
 
 #[derive(Union)]
@@ -90,6 +92,8 @@ impl InsertPatientInput {
             date_of_birth,
             address1,
             phone,
+            date_of_death,
+            is_deceased,
         } = self;
 
         ServiceInput {
@@ -102,6 +106,8 @@ impl InsertPatientInput {
             date_of_birth,
             address1,
             phone,
+            date_of_death,
+            is_deceased,
             r#type: NameType::Patient,
         }
     }

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -23,6 +23,8 @@ pub struct UpdatePatientInput {
     pub last_name: Option<String>,
     pub gender: Option<GenderInput>,
     pub date_of_birth: Option<NaiveDate>,
+    pub address1: Option<String>,
+    pub phone: Option<String>,
 }
 
 #[derive(Union)]
@@ -41,6 +43,8 @@ pub fn update_patient(
         last_name,
         gender,
         date_of_birth,
+        address1,
+        phone,
     }: UpdatePatientInput,
 ) -> Result<UpdatePatientResponse> {
     let user = validate_auth(
@@ -66,6 +70,8 @@ pub fn update_patient(
             n.last_name = last_name;
             n.gender = gender.map(|g| g.to_domain());
             n.date_of_birth = date_of_birth;
+            n.address1 = address1;
+            n.phone = phone;
         }),
     ) {
         Ok(patient) => Ok(UpdatePatientResponse::Response(PatientNode {

--- a/server/graphql/programs/src/mutations/patient/update.rs
+++ b/server/graphql/programs/src/mutations/patient/update.rs
@@ -25,6 +25,8 @@ pub struct UpdatePatientInput {
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,
+    pub is_deceased: Option<bool>,
+    pub date_of_death: Option<NaiveDate>,
 }
 
 #[derive(Union)]
@@ -45,6 +47,8 @@ pub fn update_patient(
         date_of_birth,
         address1,
         phone,
+        is_deceased,
+        date_of_death,
     }: UpdatePatientInput,
 ) -> Result<UpdatePatientResponse> {
     let user = validate_auth(
@@ -72,6 +76,8 @@ pub fn update_patient(
             n.date_of_birth = date_of_birth;
             n.address1 = address1;
             n.phone = phone;
+            n.is_deceased = is_deceased;
+            n.date_of_death = date_of_death;
         }),
     ) {
         Ok(patient) => Ok(UpdatePatientResponse::Response(PatientNode {

--- a/server/service/src/programs/patient/insert_patient.rs
+++ b/server/service/src/programs/patient/insert_patient.rs
@@ -82,10 +82,7 @@ fn generate(input: InsertPatient, store_id: &str) -> NameRow {
         address1,
         phone,
         date_of_death,
-        is_deceased: match is_deceased {
-            Some(is_deceased) => is_deceased,
-            None => false,
-        },
+        is_deceased: is_deceased.unwrap_or(false),
         national_health_number: code_2,
         created_datetime: Some(Utc::now().naive_utc()),
         ..Default::default()

--- a/server/service/src/programs/patient/insert_patient.rs
+++ b/server/service/src/programs/patient/insert_patient.rs
@@ -17,6 +17,8 @@ pub struct InsertPatient {
     pub last_name: Option<String>,
     pub gender: Option<Gender>,
     pub date_of_birth: Option<NaiveDate>,
+    pub address1: Option<String>,
+    pub phone: Option<String>,
     pub r#type: NameType,
 }
 
@@ -56,6 +58,8 @@ fn generate(input: InsertPatient, store_id: &str) -> NameRow {
         last_name,
         gender,
         date_of_birth,
+        address1,
+        phone,
         r#type,
     } = input;
 
@@ -71,6 +75,8 @@ fn generate(input: InsertPatient, store_id: &str) -> NameRow {
         last_name,
         gender,
         date_of_birth,
+        address1,
+        phone,
         national_health_number: code_2,
         created_datetime: Some(Utc::now().naive_utc()),
         ..Default::default()

--- a/server/service/src/programs/patient/insert_patient.rs
+++ b/server/service/src/programs/patient/insert_patient.rs
@@ -19,6 +19,8 @@ pub struct InsertPatient {
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,
+    pub is_deceased: Option<bool>,
+    pub date_of_death: Option<NaiveDate>,
     pub r#type: NameType,
 }
 
@@ -60,6 +62,8 @@ fn generate(input: InsertPatient, store_id: &str) -> NameRow {
         date_of_birth,
         address1,
         phone,
+        date_of_death,
+        is_deceased,
         r#type,
     } = input;
 
@@ -77,6 +81,11 @@ fn generate(input: InsertPatient, store_id: &str) -> NameRow {
         date_of_birth,
         address1,
         phone,
+        date_of_death,
+        is_deceased: match is_deceased {
+            Some(is_deceased) => is_deceased,
+            None => false,
+        },
         national_health_number: code_2,
         created_datetime: Some(Utc::now().naive_utc()),
         ..Default::default()

--- a/server/service/src/programs/patient/update_patient.rs
+++ b/server/service/src/programs/patient/update_patient.rs
@@ -44,6 +44,8 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
         last_name,
         gender,
         date_of_birth,
+        address1,
+        phone,
     } = update;
 
     NameRow {
@@ -53,6 +55,8 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
         last_name,
         gender,
         date_of_birth,
+        address1,
+        phone,
         national_health_number: code_2,
         ..existing
     }
@@ -67,6 +71,8 @@ pub struct UpdatePatient {
     pub last_name: Option<String>,
     pub gender: Option<Gender>,
     pub date_of_birth: Option<NaiveDate>,
+    pub address1: Option<String>,
+    pub phone: Option<String>,
 }
 
 pub(crate) fn update_patient(

--- a/server/service/src/programs/patient/update_patient.rs
+++ b/server/service/src/programs/patient/update_patient.rs
@@ -60,10 +60,7 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
         address1,
         phone,
         date_of_death,
-        is_deceased: match is_deceased {
-            Some(is_deceased) => is_deceased,
-            None => false,
-        },
+        is_deceased: is_deceased.unwrap_or(false),
         national_health_number: code_2,
         ..existing
     }

--- a/server/service/src/programs/patient/update_patient.rs
+++ b/server/service/src/programs/patient/update_patient.rs
@@ -46,6 +46,8 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
         date_of_birth,
         address1,
         phone,
+        is_deceased,
+        date_of_death,
     } = update;
 
     NameRow {
@@ -57,6 +59,11 @@ fn generate(existing: NameRow, update: UpdatePatient) -> NameRow {
         date_of_birth,
         address1,
         phone,
+        date_of_death,
+        is_deceased: match is_deceased {
+            Some(is_deceased) => is_deceased,
+            None => false,
+        },
         national_health_number: code_2,
         ..existing
     }
@@ -73,6 +80,8 @@ pub struct UpdatePatient {
     pub date_of_birth: Option<NaiveDate>,
     pub address1: Option<String>,
     pub phone: Option<String>,
+    pub is_deceased: Option<bool>,
+    pub date_of_death: Option<NaiveDate>,
 }
 
 pub(crate) fn update_patient(


### PR DESCRIPTION
Fixes #2333 

# 👩🏻‍💻 What does this PR do? 
Adds extra fields to patient create and update forms.
Adds these fields to the graphql insert and update schema
Also adds isDeceased and dateOfDeath to graphql schema (minor fix)

# 🧪 How has/should this change been tested? 
- [ ] Navigate to patients
- [ ] Update or create a new patient
- [ ] See new fields 'address' and 'phone'
- [ ] Try adding values to these, and saving
- [ ] See new data is saved

## 💌 Any notes for the reviewer?
There is currently no validation for address or phone number.
I considered adding a simple regex expression for phone number, but now I wonder if it would be better to leave for a separate issue where a new plugin could be added for validation in case something more dynamic is required for localisations.