### PR TITLE
Update sync api version

### DIFF
--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_VERSION: u32 = 2;
+pub(crate) static SYNC_VERSION: u32 = 3;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct SyncSettings {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2304

To be reviewed together with the mSupply PR: https://github.com/openmsupply/msupply/pull/13759

# Testing

Reproduce problem:
- Checkout omSupply `develop`
- Checkout mSupply `V7-07-00`
- Try to sync -> no names should be synced and there should be error msg in the logs

Actual test:
- Checkout mSupply `2304-update-api-versions`
- Try to sync -> should fail with version mismatch error
- Checkout this branch -> sync should work now and (names are in the DB)