### PR TITLE
Simplify currency fix

### DIFF
--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -62,8 +62,9 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
       suffix={suffix}
       decimalSeparator={options.decimal}
       groupSeparator={options.separator}
-      decimalsLimit={2}
+      decimalsLimit={options.precision}
       allowDecimals={allowDecimals}
+      fixedDecimalLength={allowDecimals ? options.precision : undefined}
       {...restOfProps}
     />
   );

--- a/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import { styled } from '@mui/material/styles';
 import RCInput, {
   CurrencyInputProps as RCInputProps,
@@ -34,7 +34,7 @@ const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
 export const CurrencyInput: FC<CurrencyInputProps> = ({
   allowNegativeValue = false,
   allowDecimals = true,
-  defaultValue = 0,
+  defaultValue,
   onChangeNumber,
   maxWidth,
   value,
@@ -43,7 +43,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   const { c, options, language } = useCurrency();
   const prefix = language !== 'fr' ? options.symbol : '';
   const suffix = language === 'fr' ? options.symbol : '';
-  const [rawValue, setRawValue] = useState(value);
+  const valueAsNumber = Number.isNaN(value) ? 0 : Number(value);
 
   return (
     <StyledCurrencyInput
@@ -54,12 +54,8 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
             ? theme.palette.background.toolbar
             : theme.palette.background.menu,
       }}
-      defaultValue={defaultValue}
-      onValueChange={newValue => {
-        onChangeNumber(c(newValue || '').value);
-        setRawValue(newValue);
-      }}
-      value={rawValue}
+      defaultValue={defaultValue ?? valueAsNumber}
+      onValueChange={newValue => onChangeNumber(c(newValue || '').value)}
       onFocus={e => e.target.select()}
       allowNegativeValue={allowNegativeValue}
       prefix={prefix}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2328 

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
I had a look at the merged fix for the above issue, and now that I've poked around, think that I have a simpler solution. 
As noted in the PR comments, the original issue is that the text value of the input field is being parsed as a number and this is fed back to the input `value` prop. The net effect is that typing in `2.` will set the input value to `2` and then if you type another digit, the decimal separator is 'lost'. 

Rather than store the value in local state, I've removed the `value` prop which is passed into the CurrencyInput component. That is now used to set the DefaultValue if a default is not provided, and is otherwise ignored. The input is already handling state internally, so there's no need to lift that out.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Try to type a decimal currency into any of the currency input fields.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
