### PR TITLE
Add routing for contact-trace

### DIFF
--- a/client/packages/common/src/hooks/useBreadcrumbs/useBreadcrumbs.tsx
+++ b/client/packages/common/src/hooks/useBreadcrumbs/useBreadcrumbs.tsx
@@ -4,6 +4,7 @@ import { LocaleKey } from '@common/intl';
 import { create } from 'zustand';
 
 export interface UrlPart {
+  disabled?: boolean;
   path: string;
   key: LocaleKey;
   value: string;

--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -52,6 +52,10 @@ export const Breadcrumbs = ({
       }
     }
 
+    if (part.disabled) {
+      return <span key={part.key}>{parseTitle(part)}</span>;
+    }
+
     return (
       <Breadcrumb to={part.path} key={part.key}>
         {t(part.key)}

--- a/client/packages/host/src/routers/DispensaryRouter.tsx
+++ b/client/packages/host/src/routers/DispensaryRouter.tsx
@@ -47,6 +47,10 @@ const fullContactTracesPath = RouteBuilder.create(AppRoute.Dispensary)
   .addWildCard()
   .build();
 
+const contactTracesListPath = RouteBuilder.create(AppRoute.Dispensary)
+  .addPart(AppRoute.ContactTrace)
+  .build();
+
 const fullReportsPath = RouteBuilder.create(AppRoute.Dispensary)
   .addPart(AppRoute.Reports)
   .build();
@@ -57,6 +61,7 @@ export const DispensaryRouter: FC = () => {
   const gotoEncounters = useMatch(fullEncountersPath);
   const gotoContactTraces = useMatch(fullContactTracesPath);
   const gotoReports = useMatch(fullReportsPath);
+  const gotoContactTracesList = useMatch(contactTracesListPath);
 
   if (gotoDistribution) {
     return <InvoiceService />;
@@ -68,6 +73,12 @@ export const DispensaryRouter: FC = () => {
 
   if (gotoEncounters) {
     return <EncounterService />;
+  }
+  if (gotoContactTracesList) {
+    const patientListRoute = RouteBuilder.create(AppRoute.Dispensary)
+      .addPart(AppRoute.Patients)
+      .build();
+    return <Navigate to={patientListRoute} />;
   }
 
   if (gotoContactTraces) {

--- a/client/packages/system/src/ContactTrace/DetailView/DetailView.tsx
+++ b/client/packages/system/src/ContactTrace/DetailView/DetailView.tsx
@@ -38,7 +38,7 @@ export const DetailView: FC<DetailViewProps> = ({
 }) => {
   const t = useTranslation('dispensary');
   const navigate = useNavigate();
-  const { setSuffix } = useBreadcrumbs([AppRoute.ContactTrace]);
+  const { setSuffix, urlParts } = useBreadcrumbs([AppRoute.ContactTrace]);
   const dateFormat = useFormatDateTime();
   const { getLocalisedFullName } = useIntlUtils();
   const id = useContactTraces.utils.idFromUrl();
@@ -109,6 +109,9 @@ export const DetailView: FC<DetailViewProps> = ({
       );
     }
   }, [isDirty, contactTraceId, id, navigate]);
+
+  const urlStart = urlParts[0];
+  if (urlStart) urlStart.disabled = true;
 
   const updateContactTrace = useDebounceCallback(
     (patch: Partial<ContactTrace>) =>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2322

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds another route which will redirect `/dispensary/contact-trace` to the patient list view.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Add a contact, and click on the breadcrumb:
- Root part ( saying 'Contact Tracing' ) takes you to a list of patients
- Patient name takes you to the patient detail view

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
