### PR TITLE
1268 Error changes size of component

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/CategorizationTabLayout.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/CategorizationTabLayout.tsx
@@ -239,7 +239,7 @@ const UIComponent: FC<LayoutProps & AjvProps> = ({
       padding={2}
     >
       {categories.map((category: Category, idx: number) => (
-        <Grid item key={category.label} display="inline-flex">
+        <Grid item key={category.label}>
           <Button
             variant="outlined"
             startIcon={<Icon className={`${category.options?.['icon']}`} />}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #1268

# 👩🏻‍💻 What does this PR do? 
Fixes width of component changing because of error
![Screenshot 2023-10-19 at 08 41 02](https://github.com/openmsupply/open-msupply/assets/61820074/79976eee-f579-4de5-aec1-d5589b4e4b1d)

# 🧪 How has/should this change been tested? 
- [ ] Have programs set up
- [ ] Create an Encounter for a patient
- [ ] Enter a value for Systolic and see Diastolic's error input doesn't change size
