### PR TITLE
Update date component

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Date.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Date.tsx
@@ -60,6 +60,11 @@ const UIComponent = (props: ControlProps) => {
           error={customError ?? props.errors ?? zErrors ?? ''}
           disableFuture={disableFuture}
           onError={validationError => setCustomError(validationError)}
+          slotProps={{
+            actionBar: {
+              actions: ['clear'],
+            },
+          }}
         />
       }
     />

--- a/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
+++ b/client/packages/programs/src/JsonForms/components/DateOfBirth.tsx
@@ -95,6 +95,11 @@ const UIComponent = (props: ControlProps) => {
             disabled={!props.enabled}
             onError={validationError => setCustomError(validationError)}
             error={customError}
+            slotProps={{
+              actionBar: {
+                actions: ['clear'],
+              },
+            }}
           />
           <Box
             flex={0}


### PR DESCRIPTION
Fixes #2316 

Initially I was curious as to why the patient form was using the 'Date' component rather than the 'DateOfBirth' picker component to set the patient's DOB.

In the end I opted to go for changing just the 'Date' component rather than 'DateOfBirth'  as the 'DateOfBirth' component includes an age display that might not fit with the patient form.

The clearing button is very unobtrusive as it is part of the date picker modal, and seems like it wouldn't ever be obtrusive.

Possibly this could also be used in the dateOfBirth date picker component in a future issue? (I'm not sure where this is currently being used)

# 👩🏻‍💻 What does this PR do? 
Adds  simple fix to clear date

# 🧪 How has/should this change been tested? 
- [ ] navigate to Dispensary/patients
- [ ] Create new patient
- [ ] Enter or select a date
- [ ] Open the date picker and click 'clear'
- [ ] See date empties easily without error
