### PR TITLE
2393 Customer Name to be locked in and non-changeable when you select create shipment 

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -18,17 +18,22 @@ import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
 
 export const Toolbar: FC = () => {
+  const t = useTranslation('distribution');
   const onDelete = useOutbound.line.deleteSelected();
   const { onAllocate } = useOutbound.line.allocateSelected();
-  const { id, otherParty, theirReference, update } =
-    useOutbound.document.fields(['id', 'otherParty', 'theirReference']);
+  const { id, otherParty, theirReference, update, requisition } =
+    useOutbound.document.fields([
+      'id',
+      'otherParty',
+      'theirReference',
+      'requisition',
+    ]);
   const { isGrouped, toggleIsGrouped } = useIsGrouped('outboundShipment');
   const [theirReferenceBuffer, setTheirReferenceBuffer] =
     useBufferState(theirReference);
   const { mutateAsync: updateName } = useOutbound.document.updateName();
 
   const isDisabled = useOutbound.utils.isDisabled();
-  const t = useTranslation('distribution');
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -46,7 +51,7 @@ export const Toolbar: FC = () => {
                 label={t('label.customer-name')}
                 Input={
                   <CustomerSearchInput
-                    disabled={isDisabled}
+                    disabled={isDisabled || !!requisition}
                     value={otherParty}
                     onChange={async ({ id: otherPartyId }) => {
                       await updateName({ id, otherPartyId });


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2393

# 👩🏻‍💻 What does this PR do? 
Disable customer name if outbound shipment has been created from a requisition

# 🧪 How has/should this change been tested? 
- [ ] Send an internal order to a store B
- [ ] Go to store B and supply some units in `Requisition`
- [ ] Create outbound shipment
- [ ] See customer name is disabled