### PR TITLE
Store user selected variants in the local storage

### DIFF
--- a/client/packages/common/src/authentication/api/hooks/useLogin.ts
+++ b/client/packages/common/src/authentication/api/hooks/useLogin.ts
@@ -139,7 +139,7 @@ export const useLogin = (
       store,
       token,
       user: {
-        id: '',
+        id: userDetails?.userId ?? '',
         name: username,
         permissions,
         firstName: userDetails?.firstName,

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -12,8 +12,8 @@ export type AuthenticationCredentials = {
   store?: UserStoreNodeFragment | undefined;
   username: string;
 };
-export type UserSelectedVariants = {
-  [itemId: string]: /* userSelectedVariantId */ string;
+export type UserSelectedUnits = {
+  [itemId: string]: /* userSelectedUnitId */ string;
 };
 
 export type LocalStorageRecord = {
@@ -29,9 +29,6 @@ export type LocalStorageRecord = {
   '/auth/error': AuthError | undefined;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;
-} & Record<
-  `/user/${string}/store/${string}/selectedVariants`,
-  UserSelectedVariants
->;
+} & Record<`/user/${string}/store/${string}/selectedunits`, UserSelectedUnits>;
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/client/packages/common/src/localStorage/keys.ts
+++ b/client/packages/common/src/localStorage/keys.ts
@@ -12,6 +12,9 @@ export type AuthenticationCredentials = {
   store?: UserStoreNodeFragment | undefined;
   username: string;
 };
+export type UserSelectedVariants = {
+  [itemId: string]: /* userSelectedVariantId */ string;
+};
 
 export type LocalStorageRecord = {
   '/appdrawer/open': boolean;
@@ -26,6 +29,9 @@ export type LocalStorageRecord = {
   '/auth/error': AuthError | undefined;
   '/pagination/rowsperpage': number;
   '/columns/hidden': Record<string, string[]> | undefined;
-};
+} & Record<
+  `/user/${string}/store/${string}/selectedVariants`,
+  UserSelectedVariants
+>;
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/client/packages/common/src/localStorage/useLocalStorage.ts
+++ b/client/packages/common/src/localStorage/useLocalStorage.ts
@@ -12,11 +12,11 @@ import LocalStorage from './LocalStorage';
 type LocalStorageSetter<T> = [
   value: T | null,
   setItem: (value: T) => void,
-  removeItem: () => void
+  removeItem: () => void,
 ];
 
 export const useLocalStorage = <
-  StorageKey extends Extract<LocalStorageKey, string>
+  StorageKey extends Extract<LocalStorageKey, string>,
 >(
   key: StorageKey,
   defaultValue: LocalStorageRecord[StorageKey] | null = null

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -88,12 +88,12 @@ export const useUnitVariant = (
 } => {
   const authContext = useAuthContext();
   const [userSelectedVariants, setUserSelectedVariant] = useLocalStorage(
-    `/user/${authContext.user?.id ?? '?'}/store/${
+    `/user/${authContext.user?.id ?? ''}/store/${
       authContext.storeId
     }/selectedVariants`
   );
   const userSelectedVariantId = userSelectedVariants?.[itemId];
-  const [item] = useUnitStore(state => [state.items[itemId]], isEqual);
+  const item = useUnitStore(state => state.items[itemId], isEqual);
   const t = useTranslation();
 
   if (!item || item.packUnits.length == 0) {

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -90,7 +90,7 @@ export const useUnitVariant = (
   const [userSelectedVariants, setUserSelectedVariant] = useLocalStorage(
     `/user/${authContext.user?.id ?? ''}/store/${
       authContext.storeId
-    }/selectedVariants`
+    }/selectedunits`
   );
   const userSelectedVariantId = userSelectedVariants?.[itemId];
   const item = useUnitStore(state => state.items[itemId], isEqual);

--- a/client/packages/system/src/Item/context/useUnitVariant.ts
+++ b/client/packages/system/src/Item/context/useUnitVariant.ts
@@ -4,17 +4,13 @@ import { ItemPackUnitNode, UnitNode } from '@common/types';
 import { ArrayUtils, NumUtils, isEqual } from '@common/utils';
 import { useEffect } from 'react';
 import { LocaleKey, TypedTFunction, useTranslation } from '@common/intl';
+import { useAuthContext, useLocalStorage } from '@openmsupply-client/common';
 
-type UserSelectedVariants = {
-  [itemId: string]: /* userSelectedVariantId */ string;
-};
 interface UnitState {
   // From back end
   items: {
     [itemId: string]: ItemPackUnitNode;
   };
-  userSelectedVariants: UserSelectedVariants;
-  setUserSelectedVariant: (_: { itemId: string; variantId: string }) => void;
   // Should be called on startup when fetching multi unit variants
   setItems: (newItems: ItemPackUnitNode[]) => void;
 }
@@ -22,19 +18,11 @@ interface UnitState {
 const useUnitStore = create<UnitState>(set => {
   return {
     items: {},
-    userSelectedVariants: {},
-    // TODO add user selected
-    setUserSelectedVariant: ({ itemId, variantId }) =>
-      set(({ userSelectedVariants, items }) => ({
-        items,
-        userSelectedVariants: { ...userSelectedVariants, [itemId]: variantId },
-      })),
     setItems: newItems =>
-      set(({ userSelectedVariants }) => {
+      set(() => {
         return {
           // Using function for iterator instead of just itemId for type safety
           items: ArrayUtils.keyBy(newItems, item => item.itemId),
-          userSelectedVariants,
         };
       }),
   };
@@ -98,14 +86,14 @@ export const useUnitVariant = (
   variantsControl?: VariantControl;
   unitVariantsExist: boolean;
 } => {
-  const [item, userSelectedVariantId, setUserSelectedVariant] = useUnitStore(
-    state => [
-      state.items[itemId],
-      state.userSelectedVariants[itemId],
-      state.setUserSelectedVariant,
-    ],
-    isEqual
+  const authContext = useAuthContext();
+  const [userSelectedVariants, setUserSelectedVariant] = useLocalStorage(
+    `/user/${authContext.user?.id ?? '?'}/store/${
+      authContext.storeId
+    }/selectedVariants`
   );
+  const userSelectedVariantId = userSelectedVariants?.[itemId];
+  const [item] = useUnitStore(state => [state.items[itemId]], isEqual);
   const t = useTranslation();
 
   if (!item || item.packUnits.length == 0) {
@@ -154,7 +142,10 @@ export const useUnitVariant = (
       variants: packUnits,
       activeVariant,
       setUserSelectedVariant: variantId =>
-        setUserSelectedVariant({ itemId, variantId }),
+        setUserSelectedVariant({
+          ...userSelectedVariants,
+          [itemId]: variantId,
+        }),
     },
     unitVariantsExist: true,
     activePackUnit: commonAsPackUnit({


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #2313 

Stores the user selected variant in the local storage. This is stored per user and per store.


# Testing
Create a database like:
`cargo run --bin remote_server_cli -- initialise-from-export -n reference1`

and manually apply sql:
```sql
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('amo-one', 'E43D125F51DE4355AE1233DA449ED08A', 'tab', 'tablet', 1);
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('amo-ten', 'E43D125F51DE4355AE1233DA449ED08A', 'blist of 10 tabs', 'blister of 10 tablets', 10);
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('amo-50', 'E43D125F51DE4355AE1233DA449ED08A', 'box of 5 blist', 'box of 5 blist', 50);
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('ace-one', '179D364578D343C8BC45930C16A1D61C', 'tab', 'tablet', 1);
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('ace-ten', '179D364578D343C8BC45930C16A1D61C', 'blist of 10 tab', 'blister of 10 tablets', 10);
INSERT INTO pack_unit ("id", "item_id", "short_name", "long_name", "pack_size") VALUES ('ace-twenty', '179D364578D343C8BC45930C16A1D61C', 'blist of 20 tab', 'blist of 20 tab', 20);
```

Selecting a unit should create an entry in the local storage and this unit should be used after reloading the page. Note, unit is not stored if the selected unit is the "default" unit.