### PR TITLE
Make store tags optional

### DIFF
--- a/server/service/src/sync/test/integration/remote/activity_log.rs
+++ b/server/service/src/sync/test/integration/remote/activity_log.rs
@@ -26,13 +26,16 @@ impl SyncRecordTester for ActivityLogRecordTester {
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap(),
-            event: None,
+            changed_to: Some("from".to_string()),
+            changed_from: Some("to".to_string()),
         };
 
         let log_2 = inline_edit(&log_1, |mut l| {
             l.id = uuid();
             l.r#type = ActivityLogType::InvoiceStatusAllocated;
             l.record_id = Some("inbound_shipment_a".to_string());
+            l.changed_to = None;
+            l.changed_from = None;
             l
         });
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2407 

# 👩🏻‍💻 What does this PR do? 
Make the storeTags optional. Reason is that mSupply can't handle and empty storeTags object right now.

# Testing run integration tests