### PR TITLE
Remove recursive loading in temperature logs

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/BreachIcon.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/BreachIcon.tsx
@@ -45,6 +45,7 @@ export const BreachIcon = ({
           startDateTime:
             DateUtils.getDateOrNull(payload.breach?.startDatetime) ??
             payload.date,
+          location: payload.breach?.location?.name,
         });
       }}
       x={cx - 13.5}

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/BreachPopover.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/BreachPopover.tsx
@@ -61,7 +61,7 @@ export const BreachPopover = ({
           {sensor && sensor.name} {t('heading.breach')}
           <BreachIcon type={breach.type} />
         </Typography>
-        <Row label={t('label.location')} value={sensor?.location ?? ''} />
+        <Row label={t('label.location')} value={breach?.location ?? ''} />
         <Row
           label={t('label.breach-start')}
           value={Formatter.dateTime(breach.startDateTime)}

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/TemperatureChart.tsx
@@ -35,6 +35,7 @@ export interface Breach {
   breachId: string;
   endDateTime: Date | null;
   startDateTime: Date;
+  location?: string;
 }
 
 export const TemperatureChart = () => {

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureChart/useTemperatureChartData.ts
@@ -16,7 +16,6 @@ export type Sensor = {
   colour: string | undefined;
   id: string;
   name: string;
-  location?: string | null;
   logs: Log[];
 };
 
@@ -39,7 +38,6 @@ export const useTemperatureChartData = () => {
           id: sensor.id,
           name: sensor.name,
           logs: [],
-          location: sensor.location?.name,
         });
         sensorIndex = sensors.length - 1;
       }

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
@@ -3,10 +3,8 @@ import * as Types from '@openmsupply-client/common';
 import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
-import { SensorFragmentDoc } from '../../../Sensor/api/operations.generated';
-import { LocationRowFragmentDoc } from '../../../../../system/src/Location/api/operations.generated';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null };
+export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null };
 
 export type Temperature_BreachesQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
@@ -16,7 +14,7 @@ export type Temperature_BreachesQueryVariables = Types.Exact<{
 }>;
 
 
-export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null }> } };
+export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null }> } };
 
 export const TemperatureBreachFragmentDoc = gql`
     fragment TemperatureBreach on TemperatureBreachNode {
@@ -29,14 +27,14 @@ export const TemperatureBreachFragmentDoc = gql`
   type
   maxOrMinTemperature
   sensor {
-    ...Sensor
+    id
+    name
   }
   location {
-    ...LocationRow
+    name
   }
 }
-    ${SensorFragmentDoc}
-${LocationRowFragmentDoc}`;
+    `;
 export const Temperature_BreachesDocument = gql`
     query temperature_breaches($page: PaginationInput, $sort: [TemperatureBreachSortInput!], $filter: TemperatureBreachFilterInput, $storeId: String!) {
   temperatureBreaches(

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
@@ -9,11 +9,12 @@ fragment TemperatureBreach on TemperatureBreachNode {
   maxOrMinTemperature
 
   sensor {
-    ...Sensor
+    id
+    name
   }
 
   location {
-    ...LocationRow
+    name
   }
 }
 

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.generated.ts
@@ -3,216 +3,75 @@ import * as Types from '@openmsupply-client/common';
 import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
-import { SensorFragmentDoc } from '../../../Sensor/api/operations.generated';
-import { LocationRowFragmentDoc } from '../../../../../system/src/Location/api/operations.generated';
-import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw';
-export type TemperatureBreachRowFragment = {
-  __typename: 'TemperatureBreachNode';
-  id: string;
-  acknowledged: boolean;
-  endDatetime?: string | null;
-  startDatetime: string;
-  type: Types.TemperatureBreachNodeType;
-};
+import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
+export type TemperatureBreachRowFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, startDatetime: string, endDatetime?: string | null, type: Types.TemperatureBreachNodeType, location?: { __typename: 'LocationNode', name: string } | null };
 
-export type TemperatureLogFragment = {
-  __typename: 'TemperatureLogNode';
-  id: string;
-  datetime: string;
-  temperature: number;
-  sensor?: {
-    __typename: 'SensorNode';
-    id: string;
-    isActive: boolean;
-    name: string;
-    serial: string;
-    batteryLevel?: number | null;
-    breach?: Types.TemperatureBreachNodeType | null;
-    type: Types.SensorNodeType;
-    location?: {
-      __typename: 'LocationNode';
-      id: string;
-      name: string;
-      onHold: boolean;
-      code: string;
-    } | null;
-    latestTemperatureLog?: {
-      __typename: 'TemperatureLogConnector';
-      totalCount: number;
-      nodes: Array<{
-        __typename: 'TemperatureLogNode';
-        temperature: number;
-        datetime: string;
-      }>;
-    } | null;
-  } | null;
-  location?: {
-    __typename: 'LocationNode';
-    id: string;
-    name: string;
-    onHold: boolean;
-    code: string;
-  } | null;
-  temperatureBreach?: {
-    __typename: 'TemperatureBreachNode';
-    id: string;
-    acknowledged: boolean;
-    endDatetime?: string | null;
-    startDatetime: string;
-    type: Types.TemperatureBreachNodeType;
-  } | null;
-};
+export type TemperatureLogFragment = { __typename: 'TemperatureLogNode', id: string, datetime: string, temperature: number, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null, temperatureBreach?: { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, startDatetime: string, endDatetime?: string | null, type: Types.TemperatureBreachNodeType, location?: { __typename: 'LocationNode', name: string } | null } | null };
 
 export type Temperature_LogsQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
-  sort?: Types.InputMaybe<
-    Array<Types.TemperatureLogSortInput> | Types.TemperatureLogSortInput
-  >;
+  sort?: Types.InputMaybe<Array<Types.TemperatureLogSortInput> | Types.TemperatureLogSortInput>;
   filter?: Types.InputMaybe<Types.TemperatureLogFilterInput>;
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type Temperature_LogsQuery = {
-  __typename: 'Queries';
-  temperatureLogs: {
-    __typename: 'TemperatureLogConnector';
-    totalCount: number;
-    nodes: Array<{
-      __typename: 'TemperatureLogNode';
-      id: string;
-      datetime: string;
-      temperature: number;
-      sensor?: {
-        __typename: 'SensorNode';
-        id: string;
-        isActive: boolean;
-        name: string;
-        serial: string;
-        batteryLevel?: number | null;
-        breach?: Types.TemperatureBreachNodeType | null;
-        type: Types.SensorNodeType;
-        location?: {
-          __typename: 'LocationNode';
-          id: string;
-          name: string;
-          onHold: boolean;
-          code: string;
-        } | null;
-        latestTemperatureLog?: {
-          __typename: 'TemperatureLogConnector';
-          totalCount: number;
-          nodes: Array<{
-            __typename: 'TemperatureLogNode';
-            temperature: number;
-            datetime: string;
-          }>;
-        } | null;
-      } | null;
-      location?: {
-        __typename: 'LocationNode';
-        id: string;
-        name: string;
-        onHold: boolean;
-        code: string;
-      } | null;
-      temperatureBreach?: {
-        __typename: 'TemperatureBreachNode';
-        id: string;
-        acknowledged: boolean;
-        endDatetime?: string | null;
-        startDatetime: string;
-        type: Types.TemperatureBreachNodeType;
-      } | null;
-    }>;
-  };
-};
+
+export type Temperature_LogsQuery = { __typename: 'Queries', temperatureLogs: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', id: string, datetime: string, temperature: number, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null, temperatureBreach?: { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, startDatetime: string, endDatetime?: string | null, type: Types.TemperatureBreachNodeType, location?: { __typename: 'LocationNode', name: string } | null } | null }> } };
 
 export const TemperatureBreachRowFragmentDoc = gql`
-  fragment TemperatureBreachRow on TemperatureBreachNode {
-    __typename
-    id
-    acknowledged
-    endDatetime
-    startDatetime
-    type
+    fragment TemperatureBreachRow on TemperatureBreachNode {
+  __typename
+  id
+  acknowledged
+  startDatetime
+  endDatetime
+  type
+  location {
+    name
   }
-`;
+}
+    `;
 export const TemperatureLogFragmentDoc = gql`
-  fragment TemperatureLog on TemperatureLogNode {
-    __typename
+    fragment TemperatureLog on TemperatureLogNode {
+  __typename
+  id
+  datetime
+  temperature
+  sensor {
     id
-    datetime
-    temperature
-    sensor {
-      ...Sensor
-    }
-    location {
-      ...LocationRow
-    }
-    temperatureBreach {
-      ...TemperatureBreachRow
-    }
+    name
   }
-  ${SensorFragmentDoc}
-  ${LocationRowFragmentDoc}
-  ${TemperatureBreachRowFragmentDoc}
-`;
+  location {
+    name
+  }
+  temperatureBreach {
+    ...TemperatureBreachRow
+  }
+}
+    ${TemperatureBreachRowFragmentDoc}`;
 export const Temperature_LogsDocument = gql`
-  query temperature_logs(
-    $page: PaginationInput
-    $sort: [TemperatureLogSortInput!]
-    $filter: TemperatureLogFilterInput
-    $storeId: String!
-  ) {
-    temperatureLogs(
-      page: $page
-      sort: $sort
-      filter: $filter
-      storeId: $storeId
-    ) {
-      ... on TemperatureLogConnector {
-        totalCount
-        nodes {
-          ...TemperatureLog
-        }
+    query temperature_logs($page: PaginationInput, $sort: [TemperatureLogSortInput!], $filter: TemperatureLogFilterInput, $storeId: String!) {
+  temperatureLogs(page: $page, sort: $sort, filter: $filter, storeId: $storeId) {
+    ... on TemperatureLogConnector {
+      totalCount
+      nodes {
+        ...TemperatureLog
       }
     }
   }
-  ${TemperatureLogFragmentDoc}
-`;
+}
+    ${TemperatureLogFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    temperature_logs(
-      variables: Temperature_LogsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<Temperature_LogsQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<Temperature_LogsQuery>(
-            Temperature_LogsDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'temperature_logs',
-        'query'
-      );
-    },
+    temperature_logs(variables: Temperature_LogsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Temperature_LogsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<Temperature_LogsQuery>(Temperature_LogsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'temperature_logs', 'query');
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;
@@ -228,14 +87,8 @@ export type Sdk = ReturnType<typeof getSdk>;
  *   )
  * })
  */
-export const mockTemperatureLogsQuery = (
-  resolver: ResponseResolver<
-    GraphQLRequest<Temperature_LogsQueryVariables>,
-    GraphQLContext<Temperature_LogsQuery>,
-    any
-  >
-) =>
+export const mockTemperatureLogsQuery = (resolver: ResponseResolver<GraphQLRequest<Temperature_LogsQueryVariables>, GraphQLContext<Temperature_LogsQuery>, any>) =>
   graphql.query<Temperature_LogsQuery, Temperature_LogsQueryVariables>(
     'temperature_logs',
     resolver
-  );
+  )

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.graphql
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.graphql
@@ -2,8 +2,12 @@ fragment TemperatureBreachRow on TemperatureBreachNode {
   __typename
   id
   acknowledged
+  startDatetime
   endDatetime
   type
+  location {
+    name
+  }
 }
 
 fragment TemperatureLog on TemperatureLogNode {
@@ -13,11 +17,12 @@ fragment TemperatureLog on TemperatureLogNode {
   temperature
 
   sensor {
-    ...Sensor
+    id
+    name
   }
 
   location {
-    ...LocationRow
+    name
   }
 
   temperatureBreach {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2369

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
The temperature logs query was loading a `sensor` for each log entry. 
Each `sensor` would then load the `latest_temperature_log` which queried `temperature_log`s from the database, with a filter and sort to fetch the latest one.

The end result was that a query for 100 temperature logs would run 100 database queries for temperature logs. Slimming down the graphQL query has resulted in an almost instant query response.

# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Fetch a list of temperature logs (the `Log` or `Chart` tabs) and see how long that takes. Try again with this branch.
You could also put a `println` into the `temperature_log` query to see how often this is called.


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
