### PR TITLE
2405 Rename duration fields to also include the unit

### DIFF
--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
@@ -88,7 +88,7 @@ const ListView: FC = () => {
         key: 'duration',
         label: 'label.duration',
         accessor: ({ rowData }) => {
-          return Formatter.milliseconds(rowData.duration);
+          return Formatter.milliseconds(rowData.durationMilliseconds);
         },
         sortable: false,
       },

--- a/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
+++ b/client/packages/coldchain/src/Monitoring/ListView/TemperatureBreach/TemperatureBreachList.tsx
@@ -88,7 +88,7 @@ const ListView: FC = () => {
         key: 'duration',
         label: 'label.duration',
         accessor: ({ rowData }) => {
-          return Formatter.milliseconds(rowData.durationMilliseconds);
+          return Formatter.milliseconds(rowData.duration);
         },
         sortable: false,
       },

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import { SensorFragmentDoc } from '../../../Sensor/api/operations.generated';
 import { LocationRowFragmentDoc } from '../../../../../system/src/Location/api/operations.generated';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null };
+export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null };
 
 export type Temperature_BreachesQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
@@ -16,14 +16,14 @@ export type Temperature_BreachesQueryVariables = Types.Exact<{
 }>;
 
 
-export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null }> } };
+export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null }> } };
 
 export const TemperatureBreachFragmentDoc = gql`
     fragment TemperatureBreach on TemperatureBreachNode {
   __typename
   id
   acknowledged
-  duration
+  durationMilliseconds
   endDatetime
   startDatetime
   type

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import { SensorFragmentDoc } from '../../../Sensor/api/operations.generated';
 import { LocationRowFragmentDoc } from '../../../../../system/src/Location/api/operations.generated';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null };
+export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null };
 
 export type Temperature_BreachesQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
@@ -16,14 +16,14 @@ export type Temperature_BreachesQueryVariables = Types.Exact<{
 }>;
 
 
-export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null }> } };
+export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, duration: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, isActive: boolean, name: string, serial: string, batteryLevel?: number | null, breach?: Types.TemperatureBreachNodeType | null, type: Types.SensorNodeType, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null, latestTemperatureLog?: { __typename: 'TemperatureLogConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureLogNode', temperature: number, datetime: string }> } | null } | null, location?: { __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string } | null }> } };
 
 export const TemperatureBreachFragmentDoc = gql`
     fragment TemperatureBreach on TemperatureBreachNode {
   __typename
   id
   acknowledged
-  durationMilliseconds
+  duration
   endDatetime
   startDatetime
   type

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.generated.ts
@@ -3,124 +3,66 @@ import * as Types from '@openmsupply-client/common';
 import { GraphQLClient } from 'graphql-request';
 import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
-import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw';
-export type TemperatureBreachFragment = {
-  __typename: 'TemperatureBreachNode';
-  id: string;
-  acknowledged: boolean;
-  durationMilliseconds: number;
-  endDatetime?: string | null;
-  startDatetime: string;
-  type: Types.TemperatureBreachNodeType;
-  maxOrMinTemperature?: number | null;
-  sensor?: { __typename: 'SensorNode'; id: string; name: string } | null;
-  location?: { __typename: 'LocationNode'; name: string } | null;
-};
+import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
+export type TemperatureBreachFragment = { __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null };
 
 export type Temperature_BreachesQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
-  sort?: Types.InputMaybe<
-    Array<Types.TemperatureBreachSortInput> | Types.TemperatureBreachSortInput
-  >;
+  sort?: Types.InputMaybe<Array<Types.TemperatureBreachSortInput> | Types.TemperatureBreachSortInput>;
   filter?: Types.InputMaybe<Types.TemperatureBreachFilterInput>;
   storeId: Types.Scalars['String']['input'];
 }>;
 
-export type Temperature_BreachesQuery = {
-  __typename: 'Queries';
-  temperatureBreaches: {
-    __typename: 'TemperatureBreachConnector';
-    totalCount: number;
-    nodes: Array<{
-      __typename: 'TemperatureBreachNode';
-      id: string;
-      acknowledged: boolean;
-      durationMilliseconds: number;
-      endDatetime?: string | null;
-      startDatetime: string;
-      type: Types.TemperatureBreachNodeType;
-      maxOrMinTemperature?: number | null;
-      sensor?: { __typename: 'SensorNode'; id: string; name: string } | null;
-      location?: { __typename: 'LocationNode'; name: string } | null;
-    }>;
-  };
-};
+
+export type Temperature_BreachesQuery = { __typename: 'Queries', temperatureBreaches: { __typename: 'TemperatureBreachConnector', totalCount: number, nodes: Array<{ __typename: 'TemperatureBreachNode', id: string, acknowledged: boolean, durationMilliseconds: number, endDatetime?: string | null, startDatetime: string, type: Types.TemperatureBreachNodeType, maxOrMinTemperature?: number | null, sensor?: { __typename: 'SensorNode', id: string, name: string } | null, location?: { __typename: 'LocationNode', name: string } | null }> } };
 
 export const TemperatureBreachFragmentDoc = gql`
-  fragment TemperatureBreach on TemperatureBreachNode {
-    __typename
+    fragment TemperatureBreach on TemperatureBreachNode {
+  __typename
+  id
+  acknowledged
+  durationMilliseconds
+  endDatetime
+  startDatetime
+  type
+  maxOrMinTemperature
+  sensor {
     id
-    acknowledged
-    durationMilliseconds
-    endDatetime
-    startDatetime
-    type
-    maxOrMinTemperature
-    sensor {
-      id
-      name
-    }
-    location {
-      name
-    }
+    name
   }
-`;
+  location {
+    name
+  }
+}
+    `;
 export const Temperature_BreachesDocument = gql`
-  query temperature_breaches(
-    $page: PaginationInput
-    $sort: [TemperatureBreachSortInput!]
-    $filter: TemperatureBreachFilterInput
-    $storeId: String!
+    query temperature_breaches($page: PaginationInput, $sort: [TemperatureBreachSortInput!], $filter: TemperatureBreachFilterInput, $storeId: String!) {
+  temperatureBreaches(
+    page: $page
+    sort: $sort
+    filter: $filter
+    storeId: $storeId
   ) {
-    temperatureBreaches(
-      page: $page
-      sort: $sort
-      filter: $filter
-      storeId: $storeId
-    ) {
-      ... on TemperatureBreachConnector {
-        totalCount
-        nodes {
-          ...TemperatureBreach
-        }
+    ... on TemperatureBreachConnector {
+      totalCount
+      nodes {
+        ...TemperatureBreach
       }
     }
   }
-  ${TemperatureBreachFragmentDoc}
-`;
+}
+    ${TemperatureBreachFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    temperature_breaches(
-      variables: Temperature_BreachesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders
-    ): Promise<Temperature_BreachesQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<Temperature_BreachesQuery>(
-            Temperature_BreachesDocument,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders }
-          ),
-        'temperature_breaches',
-        'query'
-      );
-    },
+    temperature_breaches(variables: Temperature_BreachesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Temperature_BreachesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<Temperature_BreachesQuery>(Temperature_BreachesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'temperature_breaches', 'query');
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;
@@ -136,14 +78,8 @@ export type Sdk = ReturnType<typeof getSdk>;
  *   )
  * })
  */
-export const mockTemperatureBreachesQuery = (
-  resolver: ResponseResolver<
-    GraphQLRequest<Temperature_BreachesQueryVariables>,
-    GraphQLContext<Temperature_BreachesQuery>,
-    any
-  >
-) =>
+export const mockTemperatureBreachesQuery = (resolver: ResponseResolver<GraphQLRequest<Temperature_BreachesQueryVariables>, GraphQLContext<Temperature_BreachesQuery>, any>) =>
   graphql.query<Temperature_BreachesQuery, Temperature_BreachesQueryVariables>(
     'temperature_breaches',
     resolver
-  );
+  )

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
@@ -2,7 +2,7 @@ fragment TemperatureBreach on TemperatureBreachNode {
   __typename
   id
   acknowledged
-  duration
+  durationMilliseconds
   endDatetime
   startDatetime
   type

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureBreach/operations.graphql
@@ -2,7 +2,7 @@ fragment TemperatureBreach on TemperatureBreachNode {
   __typename
   id
   acknowledged
-  durationMilliseconds
+  duration
   endDatetime
   startDatetime
   type

--- a/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.generated.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureLog/operations.generated.ts
@@ -92,4 +92,4 @@ export const mockTemperatureLogsQuery = (resolver: ResponseResolver<GraphQLReque
   graphql.query<Temperature_LogsQuery, Temperature_LogsQueryVariables>(
     'temperature_logs',
     resolver
-  );
+  )

--- a/client/packages/coldchain/src/Sensor/api/api.ts
+++ b/client/packages/coldchain/src/Sensor/api/api.ts
@@ -35,7 +35,7 @@ export const getSensorQueries = (sdk: Sdk, storeId: string) => ({
         id: patch.id,
         isActive: patch.isActive,
         name: patch.name,
-        location: setNullableInput('id', patch.location),
+        locationId: setNullableInput('id', patch.location),
       },
     });
 

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4845,7 +4845,7 @@ export type TemperatureBreachFilterInput = {
 export type TemperatureBreachNode = {
   __typename: 'TemperatureBreachNode';
   acknowledged: Scalars['Boolean']['output'];
-  duration: Scalars['Int']['output'];
+  durationMilliseconds: Scalars['Int']['output'];
   endDatetime?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['String']['output'];
   location?: Maybe<LocationNode>;
@@ -5463,7 +5463,7 @@ export type UpdateSensorErrorInterface = {
 export type UpdateSensorInput = {
   id: Scalars['String']['input'];
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
-  location?: InputMaybe<NullableStringUpdate>;
+  locationId?: InputMaybe<NullableStringUpdate>;
   name?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4845,7 +4845,7 @@ export type TemperatureBreachFilterInput = {
 export type TemperatureBreachNode = {
   __typename: 'TemperatureBreachNode';
   acknowledged: Scalars['Boolean']['output'];
-  durationMilliseconds: Scalars['Int']['output'];
+  duration: Scalars['Int']['output'];
   endDatetime?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['String']['output'];
   location?: Maybe<LocationNode>;

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4845,7 +4845,7 @@ export type TemperatureBreachFilterInput = {
 export type TemperatureBreachNode = {
   __typename: 'TemperatureBreachNode';
   acknowledged: Scalars['Boolean']['output'];
-  duration: Scalars['Int']['output'];
+  durationMilliseconds: Scalars['Int']['output'];
   endDatetime?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['String']['output'];
   location?: Maybe<LocationNode>;

--- a/server/graphql/sensor/src/mutations/update.rs
+++ b/server/graphql/sensor/src/mutations/update.rs
@@ -48,7 +48,7 @@ pub fn update_sensor(
 #[derive(InputObject)]
 pub struct UpdateSensorInput {
     pub id: String,
-    pub location: Option<NullableUpdateInput<String>>,
+    pub location_id: Option<NullableUpdateInput<String>>,
     pub name: Option<String>,
     pub is_active: Option<bool>,
 }
@@ -57,15 +57,15 @@ impl From<UpdateSensorInput> for UpdateSensor {
     fn from(
         UpdateSensorInput {
             id,
-            location,
+            location_id,
             name,
             is_active,
         }: UpdateSensorInput,
     ) -> Self {
         UpdateSensor {
             id,
-            location: location.map(|location| NullableUpdate {
-                value: location.value,
+            location_id: location_id.map(|location_id| NullableUpdate {
+                value: location_id.value,
             }),
             name,
             is_active,

--- a/server/graphql/sensor/src/mutations/update.rs
+++ b/server/graphql/sensor/src/mutations/update.rs
@@ -48,7 +48,7 @@ pub fn update_sensor(
 #[derive(InputObject)]
 pub struct UpdateSensorInput {
     pub id: String,
-    pub location_id: Option<NullableUpdateInput<String>>,
+    pub location: Option<NullableUpdateInput<String>>,
     pub name: Option<String>,
     pub is_active: Option<bool>,
 }
@@ -57,15 +57,15 @@ impl From<UpdateSensorInput> for UpdateSensor {
     fn from(
         UpdateSensorInput {
             id,
-            location_id,
+            location,
             name,
             is_active,
         }: UpdateSensorInput,
     ) -> Self {
         UpdateSensor {
             id,
-            location_id: location_id.map(|location_id| NullableUpdate {
-                value: location_id.value,
+            location: location.map(|location| NullableUpdate {
+                value: location.value,
             }),
             name,
             is_active,

--- a/server/graphql/temperature_breach/src/lib.rs
+++ b/server/graphql/temperature_breach/src/lib.rs
@@ -142,7 +142,7 @@ mod test {
                 rows: vec![TemperatureBreach {
                     temperature_breach_row: TemperatureBreachRow {
                         id: "acknowledged_temperature_breach".to_owned(),
-                        duration: 3600,
+                        duration_milliseconds: 3600,
                         acknowledged: true,
                         r#type: TemperatureBreachRowType::ColdConsecutive,
                         store_id: Some("store_a".to_string()),
@@ -162,7 +162,7 @@ mod test {
                                 .unwrap()
                                 + Duration::seconds(50646),
                         ),
-                        threshold_duration: 3600,
+                        threshold_duration_milliseconds: 3600,
                     },
                 }],
                 count: 1,

--- a/server/graphql/types/src/types/temperature_breach.rs
+++ b/server/graphql/types/src/types/temperature_breach.rs
@@ -125,8 +125,8 @@ impl TemperatureBreachNode {
         self.row().acknowledged
     }
 
-    pub async fn duration(&self) -> i32 {
-        self.row().duration
+    pub async fn duration_milliseconds(&self) -> i32 {
+        self.row().duration_milliseconds
     }
 
     pub async fn r#type(&self) -> TemperatureBreachNodeType {

--- a/server/repository/src/db_diesel/temperature_breach_row.rs
+++ b/server/repository/src/db_diesel/temperature_breach_row.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 table! {
     temperature_breach (id) {
         id -> Text,
-        duration -> Integer,
+        duration_milliseconds -> Integer,
         #[sql_name = "type"] type_ -> crate::db_diesel::temperature_breach_row::TemperatureBreachRowTypeMapping,
         sensor_id -> Text,
         location_id -> Nullable<Text>,
@@ -23,7 +23,7 @@ table! {
         acknowledged -> Bool,
         threshold_minimum -> Double,
         threshold_maximum -> Double,
-        threshold_duration -> Integer,
+        threshold_duration_milliseconds -> Integer,
     }
 }
 
@@ -55,7 +55,7 @@ pub enum TemperatureBreachRowType {
 #[table_name = "temperature_breach"]
 pub struct TemperatureBreachRow {
     pub id: String,
-    pub duration: i32,
+    pub duration_milliseconds: i32,
     #[column_name = "type_"]
     pub r#type: TemperatureBreachRowType,
     pub sensor_id: String,
@@ -66,7 +66,7 @@ pub struct TemperatureBreachRow {
     pub acknowledged: bool,
     pub threshold_minimum: f64,
     pub threshold_maximum: f64,
-    pub threshold_duration: i32,
+    pub threshold_duration_milliseconds: i32,
 }
 
 pub struct TemperatureBreachRowRepository<'a> {

--- a/server/repository/src/migrations/v1_05_00/cold_chain.rs
+++ b/server/repository/src/migrations/v1_05_00/cold_chain.rs
@@ -1,3 +1,4 @@
+use crate::migrations::{DATETIME, DOUBLE};
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
@@ -5,8 +6,114 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         sql!(
             connection,
             r#"
-        ALTER TYPE permission_type ADD VALUE IF NOT EXISTS 'COLD_CHAIN_API';
-        "#,
+                ALTER TYPE permission_type ADD VALUE IF NOT EXISTS 'COLD_CHAIN_API';
+            "#,
+        )?;
+    }
+
+    sql!(
+        connection,
+        r#"
+            CREATE TABLE temperature_breach (
+                id TEXT NOT NULL PRIMARY KEY,
+                duration_milliseconds INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                sensor_id TEXT NOT NULL REFERENCES sensor(id),
+                store_id TEXT REFERENCES store(id),
+                location_id TEXT REFERENCES location(id),
+                start_datetime {DATETIME} NOT NULL,
+                end_datetime {DATETIME},
+                acknowledged BOOLEAN,
+                threshold_minimum {DOUBLE} NOT NULL,
+                threshold_maximum {DOUBLE} NOT NULL,
+                threshold_duration_milliseconds INTEGER NOT NULL
+            );
+
+            CREATE TABLE temperature_log (
+                id TEXT NOT NULL PRIMARY KEY,
+                temperature {DOUBLE} NOT NULL,
+                sensor_id TEXT NOT NULL REFERENCES sensor(id),
+                store_id TEXT REFERENCES store(id),
+                location_id TEXT REFERENCES location(id),
+                datetime {DATETIME} NOT NULL,
+                temperature_breach_id TEXT REFERENCES temperature_breach(id)
+            );      
+            "#
+    )?;
+
+    if cfg!(feature = "postgres") {
+        sql!(
+            connection,
+            r#"
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'temperature_breach';
+                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'temperature_log';
+
+                CREATE TRIGGER temperature_breach_trigger
+                AFTER INSERT OR UPDATE OR DELETE ON temperature_breach
+                FOR EACH ROW EXECUTE PROCEDURE update_changelog();
+                
+                CREATE TRIGGER temperature_log_trigger
+                AFTER INSERT OR UPDATE OR DELETE ON temperature_log
+                FOR EACH ROW EXECUTE PROCEDURE update_changelog();
+            "#
+        )?;
+    } else {
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER temperature_breach_insert_trigger
+                AFTER INSERT ON temperature_breach
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ("temperature_breach", NEW.id, "UPSERT");
+                END;
+
+
+                CREATE TRIGGER temperature_log_insert_trigger
+                AFTER INSERT ON temperature_log
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ("temperature_log", NEW.id, "UPSERT");
+                END;
+            "#
+        )?;
+
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER temperature_breach_update_trigger
+                AFTER UPDATE ON temperature_breach
+                BEGIN
+                INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('temperature_breach', NEW.id, 'UPSERT');
+                END;
+
+                CREATE TRIGGER temperature_log_update_trigger
+                AFTER UPDATE ON temperature_log
+                BEGIN
+                INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('temperature_log', NEW.id, 'UPSERT');
+                END;          
+            "#
+        )?;
+
+        sql!(
+            connection,
+            r#"
+                CREATE TRIGGER temperature_breach_delete_trigger
+                AFTER DELETE ON temperature_breach
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('temperature_breach', OLD.id, 'DELETE');
+                END;
+
+                CREATE TRIGGER temperature_log_delete_trigger
+                AFTER DELETE ON temperature_log
+                BEGIN
+                    INSERT INTO changelog (table_name, record_id, row_action)
+                    VALUES ('temperature_log', OLD.id, 'DELETE');
+                END;
+            "#
         )?;
     }
 

--- a/server/repository/src/migrations/v1_05_00/permissions_preferences.rs
+++ b/server/repository/src/migrations/v1_05_00/permissions_preferences.rs
@@ -7,7 +7,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
         sql!(
             connection,
             r#"
-            ALTER TABLE store_preference ADD COLUMN vaccine_module bool NOT NULL DEFAULT false;
             ALTER TYPE permission_type ADD VALUE 'SENSOR_QUERY';
             ALTER TYPE permission_type ADD VALUE 'SENSOR_MUTATE'; 
             ALTER TYPE permission_type ADD VALUE 'TEMPERATURE_BREACH_QUERY';

--- a/server/repository/src/migrations/v1_05_00/sensor.rs
+++ b/server/repository/src/migrations/v1_05_00/sensor.rs
@@ -35,7 +35,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
 
             CREATE TABLE temperature_breach (
                 id TEXT NOT NULL PRIMARY KEY,
-                duration INTEGER NOT NULL,
+                duration_milliseconds INTEGER NOT NULL,
                 type TEXT NOT NULL,
                 sensor_id TEXT NOT NULL REFERENCES sensor(id),
                 store_id TEXT REFERENCES store(id),
@@ -45,7 +45,7 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                 acknowledged BOOLEAN,
                 threshold_minimum {DOUBLE} NOT NULL,
                 threshold_maximum {DOUBLE} NOT NULL,
-                threshold_duration INTEGER NOT NULL
+                threshold_duration_milliseconds INTEGER NOT NULL
             );
 
             CREATE TABLE temperature_log (

--- a/server/repository/src/migrations/v1_05_00/sensor.rs
+++ b/server/repository/src/migrations/v1_05_00/sensor.rs
@@ -1,4 +1,4 @@
-use crate::migrations::{DATETIME, DOUBLE};
+use crate::migrations::DATETIME;
 use crate::{migrations::sql, StorageConnection};
 
 pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
@@ -32,31 +32,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                 last_connection_datetime {DATETIME},
                 type {SENSOR_TYPE}
             );
-
-            CREATE TABLE temperature_breach (
-                id TEXT NOT NULL PRIMARY KEY,
-                duration_milliseconds INTEGER NOT NULL,
-                type TEXT NOT NULL,
-                sensor_id TEXT NOT NULL REFERENCES sensor(id),
-                store_id TEXT REFERENCES store(id),
-                location_id TEXT REFERENCES location(id),
-                start_datetime {DATETIME} NOT NULL,
-                end_datetime {DATETIME},
-                acknowledged BOOLEAN,
-                threshold_minimum {DOUBLE} NOT NULL,
-                threshold_maximum {DOUBLE} NOT NULL,
-                threshold_duration_milliseconds INTEGER NOT NULL
-            );
-
-            CREATE TABLE temperature_log (
-                id TEXT NOT NULL PRIMARY KEY,
-                temperature {DOUBLE} NOT NULL,
-                sensor_id TEXT NOT NULL REFERENCES sensor(id),
-                store_id TEXT REFERENCES store(id),
-                location_id TEXT REFERENCES location(id),
-                datetime {DATETIME} NOT NULL,
-                temperature_breach_id TEXT REFERENCES temperature_breach(id)
-            );      
             "#
     )?;
 
@@ -65,20 +40,9 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
             connection,
             r#"
                 ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'sensor';
-                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'temperature_breach';
-                ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'temperature_log';
-
 
                 CREATE TRIGGER sensor_trigger
                 AFTER INSERT OR UPDATE OR DELETE ON sensor
-                FOR EACH ROW EXECUTE PROCEDURE update_changelog();
-
-                CREATE TRIGGER temperature_breach_trigger
-                AFTER INSERT OR UPDATE OR DELETE ON temperature_breach
-                FOR EACH ROW EXECUTE PROCEDURE update_changelog();
-                
-                CREATE TRIGGER temperature_log_trigger
-                AFTER INSERT OR UPDATE OR DELETE ON temperature_log
                 FOR EACH ROW EXECUTE PROCEDURE update_changelog();
             "#
         )?;
@@ -92,21 +56,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                     INSERT INTO changelog (table_name, record_id, row_action)
                     VALUES ("sensor", NEW.id, "UPSERT");
                 END;
-
-                CREATE TRIGGER temperature_breach_insert_trigger
-                AFTER INSERT ON temperature_breach
-                BEGIN
-                    INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ("temperature_breach", NEW.id, "UPSERT");
-                END;
-
-
-                CREATE TRIGGER temperature_log_insert_trigger
-                AFTER INSERT ON temperature_log
-                BEGIN
-                    INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ("temperature_log", NEW.id, "UPSERT");
-                END;
             "#
         )?;
 
@@ -119,20 +68,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                 INSERT INTO changelog (table_name, record_id, row_action)
                     VALUES ('sensor', NEW.id, 'UPSERT');
                 END;
-
-                CREATE TRIGGER temperature_breach_update_trigger
-                AFTER UPDATE ON temperature_breach
-                BEGIN
-                INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ('temperature_breach', NEW.id, 'UPSERT');
-                END;
-
-                CREATE TRIGGER temperature_log_update_trigger
-                AFTER UPDATE ON temperature_log
-                BEGIN
-                INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ('temperature_log', NEW.id, 'UPSERT');
-                END;          
             "#
         )?;
 
@@ -144,20 +79,6 @@ pub(crate) fn migrate(connection: &StorageConnection) -> anyhow::Result<()> {
                 BEGIN
                     INSERT INTO changelog (table_name, record_id, row_action)
                     VALUES ('sensor', OLD.id, 'DELETE');
-                END;
-
-                CREATE TRIGGER temperature_breach_delete_trigger
-                AFTER DELETE ON temperature_breach
-                BEGIN
-                    INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ('temperature_breach', OLD.id, 'DELETE');
-                END;
-
-                CREATE TRIGGER temperature_log_delete_trigger
-                AFTER DELETE ON temperature_log
-                BEGIN
-                    INSERT INTO changelog (table_name, record_id, row_action)
-                    VALUES ('temperature_log', OLD.id, 'DELETE');
                 END;
             "#
         )?;

--- a/server/repository/src/mock/temperature_breach.rs
+++ b/server/repository/src/mock/temperature_breach.rs
@@ -11,9 +11,9 @@ pub fn mock_temperature_breach_1() -> TemperatureBreachRow {
         store_id: Some("store_a".to_string()),
         threshold_minimum: 8.0,
         threshold_maximum: 100.0,
-        threshold_duration: 3600,
+        threshold_duration_milliseconds: 3600,
         sensor_id: "sensor_1".to_owned(),
-        duration: 6000,
+        duration_milliseconds: 6000,
         location_id: None,
         start_datetime: NaiveDate::from_ymd_opt(2022, 7, 1)
             .unwrap()
@@ -39,9 +39,9 @@ pub fn mock_temperature_breach_acknowledged() -> TemperatureBreachRow {
         store_id: Some("store_a".to_string()),
         threshold_minimum: 8.0,
         threshold_maximum: 100.0,
-        threshold_duration: 3600,
+        threshold_duration_milliseconds: 3600,
         sensor_id: "sensor_1".to_owned(),
-        duration: 86400,
+        duration_milliseconds: 86400,
         location_id: None,
         start_datetime: NaiveDate::from_ymd_opt(2022, 8, 1)
             .unwrap()
@@ -67,9 +67,9 @@ pub fn mock_temperature_breach_2() -> TemperatureBreachRow {
         store_id: Some("store_b".to_string()),
         threshold_minimum: -273.0,
         threshold_maximum: 2.0,
-        threshold_duration: 3600,
+        threshold_duration_milliseconds: 3600,
         sensor_id: "sensor_1".to_owned(),
-        duration: 6000,
+        duration_milliseconds: 6000,
         location_id: None,
         start_datetime: NaiveDate::from_ymd_opt(2022, 7, 1)
             .unwrap()

--- a/server/server/src/cold_chain/sensor.rs
+++ b/server/server/src/cold_chain/sensor.rs
@@ -151,7 +151,7 @@ fn upsert_sensor(
                 id: id.clone(),
                 name: Some(sensor.name.clone()),
                 is_active: None,
-                location_id: None,
+                location: None,
                 log_interval: Some(sensor.log_interval),
                 battery_level: Some(sensor.battery_level),
             };

--- a/server/server/src/cold_chain/sensor.rs
+++ b/server/server/src/cold_chain/sensor.rs
@@ -151,7 +151,7 @@ fn upsert_sensor(
                 id: id.clone(),
                 name: Some(sensor.name.clone()),
                 is_active: None,
-                location: None,
+                location_id: None,
                 log_interval: Some(sensor.log_interval),
                 battery_level: Some(sensor.battery_level),
             };

--- a/server/service/src/sensor/tests/update.rs
+++ b/server/service/src/sensor/tests/update.rs
@@ -37,7 +37,7 @@ mod query {
                 &context,
                 UpdateSensor {
                     id: "invalid".to_owned(),
-                    location: None,
+                    location_id: None,
                     name: None,
                     is_active: None,
                     log_interval: None,
@@ -53,7 +53,7 @@ mod query {
                 &context,
                 UpdateSensor {
                     id: sensors_not_in_store[0].sensor_row.id.clone(),
-                    location: None,
+                    location_id: None,
                     name: None,
                     is_active: None,
                     log_interval: None,
@@ -89,7 +89,7 @@ mod query {
                 &context,
                 UpdateSensor {
                     id: sensor.sensor_row.id.clone(),
-                    location: None,
+                    location_id: None,
                     name: None,
                     is_active: None,
                     log_interval: None,
@@ -119,7 +119,7 @@ mod query {
                 &context,
                 UpdateSensor {
                     id: sensor.sensor_row.id.clone(),
-                    location: Some(NullableUpdate {
+                    location_id: Some(NullableUpdate {
                         value: Some("location_1".to_string())
                     }),
                     name: Some(sensor.sensor_row.name.clone()),
@@ -148,7 +148,7 @@ mod query {
                 &context,
                 UpdateSensor {
                     id: sensor.sensor_row.id.clone(),
-                    location: Some(NullableUpdate { value: None }),
+                    location_id: Some(NullableUpdate { value: None }),
                     name: None,
                     is_active: None,
                     log_interval: None,

--- a/server/service/src/sensor/update.rs
+++ b/server/service/src/sensor/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateSensor {
     pub id: String,
     pub name: Option<String>,
     pub is_active: Option<bool>,
-    pub location_id: Option<NullableUpdate<String>>,
+    pub location: Option<NullableUpdate<String>>,
     pub log_interval: Option<i32>,
     pub battery_level: Option<i32>,
 }
@@ -38,7 +38,7 @@ pub fn update_sensor(
             let updated_sensor_row = generate(input.clone(), sensor_row.clone());
             SensorRowRepository::new(&connection).upsert_one(&updated_sensor_row)?;
 
-            if let Some(location_update) = input.location_id {
+            if let Some(location_update) = input.location {
                 if sensor_row.location_id == location_update.value {
                     activity_log_entry(
                         ctx,
@@ -76,17 +76,17 @@ pub fn generate(
         id: _,
         name,
         is_active,
-        location_id,
+        location,
         log_interval,
         battery_level,
     }: UpdateSensor,
     mut sensor_row: SensorRow,
 ) -> SensorRow {
-    // if location_id has been passed, update sensor_row to the value passed (including if this is null)
-    // A null value being passed as the LocationUpdate is the unassignment of location_id
+    // if location has been passed, update sensor_row to the value passed (including if this is null)
+    // A null value being passed as the LocationUpdate is the unassignment of location
     // no LocationUpdate being passed is the location not being updated
-    if let Some(location_id) = location_id {
-        sensor_row.location_id = location_id.value;
+    if let Some(location) = location {
+        sensor_row.location_id = location.value;
     }
     sensor_row.name = name.unwrap_or(sensor_row.name);
     sensor_row.is_active = is_active.unwrap_or(sensor_row.is_active);

--- a/server/service/src/sensor/update.rs
+++ b/server/service/src/sensor/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateSensor {
     pub id: String,
     pub name: Option<String>,
     pub is_active: Option<bool>,
-    pub location: Option<NullableUpdate<String>>,
+    pub location_id: Option<NullableUpdate<String>>,
     pub log_interval: Option<i32>,
     pub battery_level: Option<i32>,
 }
@@ -38,7 +38,7 @@ pub fn update_sensor(
             let updated_sensor_row = generate(input.clone(), sensor_row.clone());
             SensorRowRepository::new(&connection).upsert_one(&updated_sensor_row)?;
 
-            if let Some(location_update) = input.location {
+            if let Some(location_update) = input.location_id {
                 if sensor_row.location_id == location_update.value {
                     activity_log_entry(
                         ctx,
@@ -76,7 +76,7 @@ pub fn generate(
         id: _,
         name,
         is_active,
-        location,
+        location_id,
         log_interval,
         battery_level,
     }: UpdateSensor,
@@ -85,8 +85,8 @@ pub fn generate(
     // if location has been passed, update sensor_row to the value passed (including if this is null)
     // A null value being passed as the LocationUpdate is the unassignment of location
     // no LocationUpdate being passed is the location not being updated
-    if let Some(location) = location {
-        sensor_row.location_id = location.value;
+    if let Some(location_id) = location_id {
+        sensor_row.location_id = location_id.value;
     }
     sensor_row.name = name.unwrap_or(sensor_row.name);
     sensor_row.is_active = is_active.unwrap_or(sensor_row.is_active);

--- a/server/service/src/sensor/update.rs
+++ b/server/service/src/sensor/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateSensor {
     pub id: String,
     pub name: Option<String>,
     pub is_active: Option<bool>,
-    pub location: Option<NullableUpdate<String>>,
+    pub location_id: Option<NullableUpdate<String>>,
     pub log_interval: Option<i32>,
     pub battery_level: Option<i32>,
 }
@@ -38,7 +38,7 @@ pub fn update_sensor(
             let updated_sensor_row = generate(input.clone(), sensor_row.clone());
             SensorRowRepository::new(&connection).upsert_one(&updated_sensor_row)?;
 
-            if let Some(location_update) = input.location {
+            if let Some(location_update) = input.location_id {
                 if sensor_row.location_id == location_update.value {
                     activity_log_entry(
                         ctx,
@@ -76,17 +76,17 @@ pub fn generate(
         id: _,
         name,
         is_active,
-        location,
+        location_id,
         log_interval,
         battery_level,
     }: UpdateSensor,
     mut sensor_row: SensorRow,
 ) -> SensorRow {
-    // if location has been passed, update sensor_row to the value passed (including if this is null)
-    // A null value being passed as the LocationUpdate is the unassignment of location
+    // if location_id has been passed, update sensor_row to the value passed (including if this is null)
+    // A null value being passed as the LocationUpdate is the unassignment of location_id
     // no LocationUpdate being passed is the location not being updated
-    if let Some(location) = location {
-        sensor_row.location_id = location.value;
+    if let Some(location_id) = location_id {
+        sensor_row.location_id = location_id.value;
     }
     sensor_row.name = name.unwrap_or(sensor_row.name);
     sensor_row.is_active = is_active.unwrap_or(sensor_row.is_active);

--- a/server/service/src/sync/test/test_data/temperature_breach.rs
+++ b/server/service/src/sync/test/test_data/temperature_breach.rs
@@ -38,12 +38,12 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncPullRecord> {
             store_id: Some("store_a".to_string()),
             location_id: None,
             r#type: TemperatureBreachRowType::ColdConsecutive,
-            duration: 86400,
+            duration_milliseconds: 86400,
             acknowledged: false,
             sensor_id: "cf5812e0c33911eb9757779d39ae2dbd".to_string(),
             threshold_minimum: -273.0,
             threshold_maximum: 2.0,
-            threshold_duration: 3600,
+            threshold_duration_milliseconds: 3600,
             start_datetime: NaiveDate::from_ymd_opt(2023, 7, 1)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
@@ -67,14 +67,14 @@ pub(crate) fn test_push_records() -> Vec<TestSyncPushRecord> {
         push_data: json!(LegacyTemperatureBreachRow {
             id: TEMPERATURE_BREACH_1.0.to_string(),
             r#type: LegacyTemperatureBreachType::ColdConsecutive,
-            duration: 86400,
+            duration_milliseconds: 86400,
             acknowledged: false,
             sensor_id: "cf5812e0c33911eb9757779d39ae2dbd".to_string(),
             store_id: Some("store_a".to_string()),
             location_id: None,
             threshold_minimum: -273.0,
             threshold_maximum: 2.0,
-            threshold_duration: 3600,
+            threshold_duration_milliseconds: 3600,
             start_date: NaiveDate::from_ymd_opt(2023, 7, 1).unwrap(),
             start_time: NaiveTime::from_hms_opt(13, 4, 6).unwrap(),
             end_date: Some(NaiveDate::from_ymd_opt(2023, 7, 2).unwrap()),

--- a/server/service/src/sync/translations/temperature_breach.rs
+++ b/server/service/src/sync/translations/temperature_breach.rs
@@ -40,7 +40,8 @@ pub enum LegacyTemperatureBreachType {
 pub struct LegacyTemperatureBreachRow {
     #[serde(rename = "ID")]
     pub id: String,
-    pub duration: i32,
+    #[serde(rename = "duration")]
+    pub duration_milliseconds: i32,
     #[serde(rename = "type")]
     pub r#type: LegacyTemperatureBreachType,
     #[serde(rename = "sensor_ID")]
@@ -65,7 +66,8 @@ pub struct LegacyTemperatureBreachRow {
     pub threshold_minimum: f64,
     #[serde(rename = "threshold_maximum_temperature")]
     pub threshold_maximum: f64,
-    pub threshold_duration: i32,
+    #[serde(rename = "threshold_duration")]
+    pub threshold_duration_milliseconds: i32,
 }
 
 pub(crate) struct TemperatureBreachTranslation {}
@@ -100,7 +102,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
 
         let result = TemperatureBreachRow {
             id: data.id,
-            duration: data.duration,
+            duration_milliseconds: data.duration_milliseconds,
             r#type,
             sensor_id: data.sensor_id,
             location_id: data.location_id,
@@ -110,7 +112,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             acknowledged: data.acknowledged,
             threshold_minimum: data.threshold_minimum,
             threshold_maximum: data.threshold_maximum,
-            threshold_duration: data.threshold_duration,
+            threshold_duration_milliseconds: data.threshold_duration_milliseconds,
         };
 
         Ok(Some(IntegrationRecords::from_upsert(
@@ -129,7 +131,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
 
         let TemperatureBreachRow {
             id,
-            duration,
+            duration_milliseconds,
             r#type,
             sensor_id,
             location_id,
@@ -139,7 +141,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             acknowledged,
             threshold_minimum,
             threshold_maximum,
-            threshold_duration,
+            threshold_duration_milliseconds,
         } = TemperatureBreachRowRepository::new(connection)
             .find_one_by_id(&changelog.record_id)?
             .ok_or(anyhow::Error::msg(format!(
@@ -154,7 +156,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
 
         let legacy_row = LegacyTemperatureBreachRow {
             id,
-            duration,
+            duration_milliseconds,
             r#type,
             sensor_id,
             location_id,
@@ -168,7 +170,7 @@ impl SyncTranslation for TemperatureBreachTranslation {
             acknowledged,
             threshold_minimum,
             threshold_maximum,
-            threshold_duration,
+            threshold_duration_milliseconds,
         };
         Ok(Some(vec![RemoteSyncRecordV5::new_upsert(
             changelog,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2405 

# 👩🏻‍💻 What does this PR do? 
Rename duration fields in temperature breach to include unit.

## 💌 Any notes for the reviewer?
Should threshold_min/max on temperature_breach also be renamed to add temperature? It took me a bit of browsing around to find out what the thresholds were for.
Also, temperature breach config got deleted in a PR a while back.... so can rename the duration fields for that when it get re-implemented..
