### PR TITLE
LocationSearchInput fixes

### DIFF
--- a/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
+++ b/client/packages/coldchain/src/Sensor/Components/SensorLineForm.tsx
@@ -33,6 +33,7 @@ export const SensorLineForm: FC<UseDraftSensorControl> = ({
             onChange={location => {
               onUpdate({ location });
             }}
+            canRemove={true}
           />
         }
       />

--- a/client/packages/common/src/utils/functions/ApiUtils.tsx
+++ b/client/packages/common/src/utils/functions/ApiUtils.tsx
@@ -2,9 +2,9 @@ export const setNullableInput = <NODE, KEY extends keyof NODE>(
   key: KEY,
   entity?: NODE | null | undefined
 ) => {
-  if (!entity) return undefined;
-
   if (entity == null) return { value: undefined };
+
+  if (!entity) return undefined;
 
   return { value: entity[key] };
 };

--- a/client/packages/system/src/Location/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Location/ListView/Toolbar.tsx
@@ -24,7 +24,7 @@ export const Toolbar: FC<{
 }> = ({ data }) => {
   const t = useTranslation('inventory');
   const { mutateAsync: deleteLocation } = useLocation.document.delete();
-  const { success, info } = useNotification();
+  const { error, info, success } = useNotification();
   const [deleteErrors, setDeleteErrors] = React.useState<DeleteError[]>([]);
   const { selectedRows } = useTableStore(state => ({
     selectedRows: Object.keys(state.rowState)
@@ -48,16 +48,22 @@ export const Toolbar: FC<{
             }
           });
         })
-      ).then(() => {
-        setDeleteErrors(errors);
-        if (errors.length === 0) {
-          const deletedMessage = t('messages.deleted-locations', {
-            count: numberSelected,
-          });
-          const successSnack = success(deletedMessage);
-          successSnack();
-        }
-      });
+      )
+        .then(() => {
+          setDeleteErrors(errors);
+          if (errors.length === 0) {
+            const deletedMessage = t('messages.deleted-locations', {
+              count: numberSelected,
+            });
+            const successSnack = success(deletedMessage);
+            successSnack();
+          }
+        })
+        .catch(_ =>
+          error(
+            t('messages.error-deleting-locations', { count: numberSelected })
+          )()
+        );
     } else {
       const selectRowsSnack = info(t('messages.select-rows-to-delete'));
       selectRowsSnack();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2418 

I also noticed that this happens when you try to delete a location which is assigned to a sensor:

<img width="901" alt="Screenshot 2023-11-02 at 1 23 34 PM" src="https://github.com/openmsupply/open-msupply/assets/9192912/08291c2e-6540-4147-930d-56fcc007615e">

# 👩🏻‍💻 What does this PR do? 
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

- When there are no locations, display a message saying that there are no locations
- Make the 'Remove' option, well, optional (only implemented for Sensors, so only enabled for them)
- Make the 'Remove' option look nicer
- Fix the removal of locations for sensors
- Catch the location delete error (bonus task)

---
**No locations**
<img width="636" alt="Screenshot 2023-11-02 at 2 10 21 PM" src="https://github.com/openmsupply/open-msupply/assets/9192912/e88249c3-116e-407a-8048-59d5cf99ac1b">
---
**Locations, none selected**
<img width="399" alt="Screenshot 2023-11-02 at 1 02 20 PM" src="https://github.com/openmsupply/open-msupply/assets/9192912/5fa8937e-325e-4b04-9213-c7d5843b4af2">
---
**Locations, with one selected**
<img width="396" alt="Screenshot 2023-11-02 at 1 04 43 PM" src="https://github.com/openmsupply/open-msupply/assets/9192912/10ddc349-9990-493d-8295-3e0fb1e7379f">


# 🧪 How has/should this change been tested? 
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Try to assign locations to a sensor, then remove.
Check stock line editing and repacks - these will not have the 'remove' option ( it doesn't work for them, so needed removing! )
Check when there are no locations


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
