### PR TITLE
2420 upload fridge tag data

### DIFF
--- a/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
@@ -1,0 +1,75 @@
+import React, { useRef, useState } from 'react';
+import { AppBarButtonsPortal, LoadingButton } from '@common/components';
+import { RadioIcon } from '@common/icons';
+import { useTranslation } from '@common/intl';
+import { Environment } from 'packages/config/src';
+import { useNotification } from '@common/hooks';
+
+import { useAuthContext } from 'packages/common/src/authentication/AuthContext';
+import { useQueryClient } from 'packages/common/src';
+import { useSensorApi } from '../api/hooks/utils/useSensorApi';
+
+export const AppBarButtons = () => {
+  const t = useTranslation('coldchain');
+  const hiddenFileInput = useRef<HTMLInputElement>(null);
+  const { storeId } = useAuthContext();
+  const [isUploadingFridgeTag, setIsUploadingFridgeTag] = useState(false);
+  const { success, error } = useNotification();
+  const queryClient = useQueryClient();
+  const api = useSensorApi();
+
+  const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    let file = e?.target?.files?.[0];
+    if (!file) return;
+
+    setIsUploadingFridgeTag(true);
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const result = await fetch(
+        `${Environment.UPLOAD_FRIDGE_TAG}?store-id=${storeId}`,
+        {
+          method: 'POST',
+          body: formData,
+        }
+      );
+
+      if (!result.ok) {
+        throw new Error(await result.text());
+      }
+      // TODO prettify
+      const resultJson = await result.json();
+      success(JSON.stringify(resultJson))();
+
+      queryClient.invalidateQueries(api.keys.base());
+    } catch (e) {
+      console.error(e);
+      // TODO prettify
+      error(String(e))();
+    } finally {
+      setIsUploadingFridgeTag(false);
+      // If value is not reset then upload button only works once
+      if (e?.target?.value) e.target.value = '';
+    }
+  };
+
+  return (
+    <AppBarButtonsPortal>
+      <input
+        type="file"
+        onChange={onUpload}
+        ref={hiddenFileInput}
+        style={{ display: 'none' }} // Make the file input element invisible
+      />
+      <LoadingButton
+        startIcon={<RadioIcon />}
+        onClick={() => hiddenFileInput?.current?.click()}
+        isLoading={isUploadingFridgeTag}
+      >
+        {t('button.fridge-tag')}
+      </LoadingButton>
+    </AppBarButtonsPortal>
+  );
+};

--- a/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from '@common/intl';
 import { Environment } from 'packages/config/src';
 import { useNotification } from '@common/hooks';
 
-import { useAuthContext } from 'packages/common/src/authentication/AuthContext';
-import { useQueryClient } from 'packages/common/src';
+import { useAuthContext, useQueryClient } from '@openmsupply-client/common';
 import { useSensorApi } from '../api/hooks/utils/useSensorApi';
 
 export const AppBarButtons = () => {

--- a/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
@@ -67,7 +67,7 @@ export const AppBarButtons = () => {
         onClick={() => hiddenFileInput?.current?.click()}
         isLoading={isUploadingFridgeTag}
       >
-        {t('button.fridge-tag')}
+        {t('button.import-fridge-tag')}
       </LoadingButton>
     </AppBarButtonsPortal>
   );

--- a/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/AppBarButtons.tsx
@@ -19,7 +19,7 @@ export const AppBarButtons = () => {
   const api = useSensorApi();
 
   const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    let file = e?.target?.files?.[0];
+    const file = e?.target?.files?.[0];
     if (!file) return;
 
     setIsUploadingFridgeTag(true);

--- a/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
+++ b/client/packages/coldchain/src/Sensor/ListView/ListView.tsx
@@ -13,6 +13,7 @@ import {
 import { useSensor, SensorFragment } from '../api';
 import { SensorEditModal } from '../Components';
 import { BreachTypeCell } from '../../common';
+import { AppBarButtons } from './AppBarButtons';
 
 export const SensorListView: FC = () => {
   const {
@@ -103,6 +104,7 @@ export const SensorListView: FC = () => {
 
   return (
     <>
+      <AppBarButtons />
       {isOpen && entity && (
         <SensorEditModal isOpen={isOpen} onClose={onClose} sensor={entity} />
       )}

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -14,6 +14,7 @@
   "button.create-a-new-one": "Create a new one",
   "button.delete-lines": "Delete selected lines",
   "button.export": "Export",
+  "button.fridge-tag": "Fridge tag",
   "button.initialise": "Initialise",
   "button.language": "Language",
   "button.more": "More",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -14,7 +14,7 @@
   "button.create-a-new-one": "Create a new one",
   "button.delete-lines": "Delete selected lines",
   "button.export": "Export",
-  "button.fridge-tag": "Fridge tag",
+  "button.import-fridge-tag": "Import fridge tag",
   "button.initialise": "Initialise",
   "button.language": "Language",
   "button.more": "More",

--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -1,8 +1,8 @@
 declare const API_HOST: string;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
-// i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql 
-// and files on https://my.openmsupply.com/files 
+// i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql
+// and files on https://my.openmsupply.com/files
 
 // For development, API server and front end are launched seperately on different ports and possible different IPs
 // by default we assume development API server is launched on the same domain/ip and on port 8000. We can overwrite this
@@ -17,7 +17,7 @@ const { port, hostname, protocol } = window.location;
 const defaultDevelopmentApiHost = `${protocol}//${hostname}:8000`;
 const productionApiHost = `${protocol}//${hostname}:${port}`;
 
-const developmentApiHost = 
+const developmentApiHost =
   (typeof API_HOST !== 'undefined' && API_HOST) || defaultDevelopmentApiHost;
 
 const apiHost = isProductionBuild ? productionApiHost : developmentApiHost;
@@ -25,7 +25,8 @@ const apiHost = isProductionBuild ? productionApiHost : developmentApiHost;
 export const Environment = {
   API_HOST: apiHost,
   FILE_URL: `${apiHost}/files?id=`,
+  UPLOAD_FRIDGE_TAG: `${apiHost}/fridge-tag`,
   GRAPHQL_URL: `${apiHost}/graphql`,
-}
+};
 
 export default Environment;

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
 dependencies = [
  "actix-rt",
  "actix_derive",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -42,7 +42,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -79,7 +79,7 @@ dependencies = [
  "actix-utils",
  "actix-web",
  "askama_escape",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "derive_more",
  "futures-core",
@@ -104,7 +104,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.7.6",
  "base64",
- "bitflags",
+ "bitflags 1.3.2",
  "brotli",
  "bytes",
  "bytestring",
@@ -137,6 +137,44 @@ checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
  "syn 1.0.100",
+]
+
+[[package]]
+name = "actix-multipart"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b960e2aea75f49c8f069108063d12a48d329fc8b60b786dfc7552a9d5918d2d"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "serde 1.0.137",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0a77f836d869f700e5b47ac7c3c8b9c8bc82e4aec861954c6198abee3ebd4d"
+dependencies = [
+ "darling 0.20.3",
+ "parse-size",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -548,7 +586,7 @@ checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand",
+ "fastrand 1.5.0",
  "futures-lite",
  "once_cell",
  "slab",
@@ -907,6 +945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +998,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.5.0",
  "futures-lite",
  "once_cell",
 ]
@@ -1129,7 +1173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive 3.1.7",
  "indexmap",
  "lazy_static",
@@ -1158,7 +1202,7 @@ checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -1467,6 +1511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1549,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1582,17 @@ dependencies = [
  "darling_core 0.14.3",
  "quote",
  "syn 1.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1584,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
  "bigdecimal",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -1821,6 +1900,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,7 +2021,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
- "fastrand",
+ "fastrand 1.5.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -2058,7 +2143,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -2907,7 +2992,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -3127,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "ryu",
  "static_assertions",
@@ -3192,6 +3277,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "local-channel"
@@ -3597,7 +3688,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3714,6 +3805,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.32.0",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "parse-zoneinfo"
@@ -4080,7 +4177,16 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4116,19 +4222,10 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3b6d580d46b9d6d6c291f90c5d762e8b93a268a96e429556419fcd7e349f94"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "log",
  "thiserror",
  "utfx",
- "winapi",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
  "winapi",
 ]
 
@@ -4297,11 +4394,24 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.10",
  "windows-sys 0.48.0",
 ]
 
@@ -4437,7 +4547,7 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4532,6 +4642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde 1.0.137",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4582,6 +4701,7 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-files",
+ "actix-multipart",
  "actix-rt",
  "actix-web",
  "anyhow",
@@ -4928,16 +5048,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "libc",
- "rand",
- "redox_syscall 0.2.10",
- "remove_dir_all",
- "winapi",
+ "fastrand 2.0.1",
+ "redox_syscall 0.3.5",
+ "rustix 0.38.13",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5092,9 +5211,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5102,13 +5221,12 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5461,6 +5579,7 @@ checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
 name = "util"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "env_logger 0.8.4",
  "serde 1.0.137",
@@ -5701,7 +5820,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917fdb865e7ff03af9dd86609f8767bc88fefba89e8efd569de8e208af8724b3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "err-derive",
  "widestring",
  "windows-sys 0.36.1",
@@ -5735,11 +5854,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5748,14 +5891,20 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
  "windows_i686_gnu 0.48.0",
  "windows_i686_msvc 0.48.0",
  "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.48.0",
  "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5777,6 +5926,12 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
@@ -5792,6 +5947,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5813,6 +5974,12 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
@@ -5831,9 +5998,21 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5852,6 +6031,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,8 @@ thiserror = "1.0.30"
 actix-rt = "2.6.0"
 assert-json-diff = "2.0.1"
 
+anyhow = "1.0.56"
+
 [workspace]
 
 members = [

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -30,7 +30,7 @@ simple-log = { version = "1.6" }
 log = "0.4.14"
 async-graphql = "3.0.35"
 
-anyhow.worspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -29,7 +29,8 @@ tokio = { version = "1.17.0", features = ["macros"] }
 simple-log = { version = "1.6" }
 log = "0.4.14"
 async-graphql = "3.0.35"
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/graphql/form_schema/Cargo.toml
+++ b/server/graphql/form_schema/Cargo.toml
@@ -25,7 +25,8 @@ reqwest = { version = "0.11.10", features = ["json"] }
 serde = "1.0.126"
 serde_json = "1.0.66"
 thiserror = "1.0.30"
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/graphql/form_schema/Cargo.toml
+++ b/server/graphql/form_schema/Cargo.toml
@@ -26,7 +26,7 @@ serde = "1.0.126"
 serde_json = "1.0.66"
 thiserror = "1.0.30"
 
-anyhow.worspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/graphql/repack/Cargo.toml
+++ b/server/graphql/repack/Cargo.toml
@@ -26,8 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-
-anyhow.worspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/graphql/repack/Cargo.toml
+++ b/server/graphql/repack/Cargo.toml
@@ -26,7 +26,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/graphql/reports/Cargo.toml
+++ b/server/graphql/reports/Cargo.toml
@@ -26,8 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-
-anyhow.worspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/graphql/reports/Cargo.toml
+++ b/server/graphql/reports/Cargo.toml
@@ -26,7 +26,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/server/report_builder/Cargo.toml
+++ b/server/report_builder/Cargo.toml
@@ -16,7 +16,8 @@ bench = false
 [dependencies]
 service = { path = "../service" }
 
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 clap = { version = "3.1.8", features = ["derive"] }
 serde = "1.0.126"
 serde_json = "1.0.66"

--- a/server/report_builder/Cargo.toml
+++ b/server/report_builder/Cargo.toml
@@ -16,8 +16,8 @@ bench = false
 [dependencies]
 service = { path = "../service" }
 
+anyhow.workspace = true
 
-anyhow.worspace = true
 clap = { version = "3.1.8", features = ["derive"] }
 serde = "1.0.126"
 serde_json = "1.0.66"

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -31,7 +31,8 @@ log = "0.4.14"
 # via ::get(""), which doesn't work in debug (test) mode on linux, debug-embed features makes rust-embed
 # behave as if it is in release mode 
 rust-embed = { version = "6.4.0", features = ["debug-embed"] }
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 pretty_assertions = "1.3.0"
 
 [dev-dependencies]

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -32,7 +32,8 @@ log = "0.4.14"
 # behave as if it is in release mode 
 rust-embed = { version = "6.4.0", features = ["debug-embed"] }
 
-anyhow.worspace = true
+anyhow.workspace = true
+
 pretty_assertions = "1.3.0"
 
 [dev-dependencies]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -33,7 +33,8 @@ actix-files = "0.6.0"
 # the openssl shared lib which is not easily available on the host platform. To enable the
 # "openssl/vendored" feature on Android (see below) the openssl crate needs to be a dependency.
 openssl = { version = "0.10", features = ["v110"] }
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 config = "0.11.0"
 chrono = { workspace = true }
 log = "0.4.14"
@@ -51,6 +52,7 @@ futures = "0.3"
 simple-log = { version = "1.6" }
 rcgen = "0.9.2"
 regex = "1.5.5"
+actix-multipart = "0.6.1"
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -34,7 +34,8 @@ actix-files = "0.6.0"
 # "openssl/vendored" feature on Android (see below) the openssl crate needs to be a dependency.
 openssl = { version = "0.10", features = ["v110"] }
 
-anyhow.worspace = true
+anyhow.workspace = true
+
 config = "0.11.0"
 chrono = { workspace = true }
 log = "0.4.14"

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -4,6 +4,7 @@ extern crate machine_uid;
 use crate::{
     certs::Certificates, cold_chain::config_cold_chain, configuration::get_or_create_token_secret,
     cors::cors_policy, serve_frontend::config_server_frontend, static_files::config_static_files,
+    upload_fridge_tag::config_upload_fridge_tag,
 };
 
 use self::middleware::{compress as compress_middleware, logger as logger_middleware};
@@ -38,6 +39,7 @@ mod logging;
 pub mod middleware;
 mod serve_frontend;
 pub mod static_files;
+mod upload_fridge_tag;
 pub use self::logging::*;
 
 // Only import discovery for non android features (otherwise build for android targets would fail due to local-ip-address)
@@ -281,6 +283,8 @@ pub async fn start_server(
             .configure(attach_graphql_schema(graphql_schema.clone()))
             .configure(config_static_files)
             .configure(config_cold_chain)
+            .configure(config_upload_fridge_tag)
+            // Needs to be last to capture all unmatches routes
             .configure(config_server_frontend)
     })
     .disable_signals();

--- a/server/server/src/upload_fridge_tag.rs
+++ b/server/server/src/upload_fridge_tag.rs
@@ -1,0 +1,78 @@
+use actix_multipart::form::{tempfile::TempFile, MultipartForm};
+use actix_web::{
+    post,
+    web::{self, Data},
+    HttpResponse,
+};
+use anyhow::Context;
+
+use serde::Deserialize;
+
+use service::{
+    sensor::berlinger::{read_sensors, ReadSensor},
+    service_provider::ServiceProvider,
+    settings::Settings,
+};
+use util::perpare_file_dir;
+
+const TEMP_FRIDGETAG_FILE_DIR: &'static str = "fridge_tag";
+
+// this function could be located in different module
+pub fn config_upload_fridge_tag(cfg: &mut web::ServiceConfig) {
+    cfg.service(upload);
+}
+
+#[derive(Debug, MultipartForm)]
+struct UploadForm {
+    #[multipart(rename = "file")]
+    files: Vec<TempFile>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct UrlParams {
+    store_id: String,
+}
+
+#[post("/fridge-tag")]
+async fn upload(
+    MultipartForm(form): MultipartForm<UploadForm>,
+    url_params: web::Query<UrlParams>,
+    settings: Data<Settings>,
+    service_provider: Data<ServiceProvider>,
+) -> HttpResponse {
+    // TODO Permissions
+
+    match upload_fridge_tag(form, url_params.into_inner(), &settings, &service_provider) {
+        Ok(result) => HttpResponse::Ok().json(result),
+        Err(error) => HttpResponse::InternalServerError().body(format!("{:#?}", error)),
+    }
+}
+
+fn upload_fridge_tag(
+    mut form: UploadForm,
+    url_params: UrlParams,
+    settings: &Settings,
+    service_provider: &ServiceProvider,
+) -> anyhow::Result<ReadSensor> {
+    let ctx = service_provider
+        .basic_context()
+        .context("Cannot get connection")?;
+
+    let file = form.files.pop().context("Cannot find attached file")?;
+    let file_name = file.file_name.context("Filename is not specified")?;
+
+    let dir = perpare_file_dir(TEMP_FRIDGETAG_FILE_DIR, &settings.server.base_dir)?;
+
+    let new_file_path = dir.join(file_name);
+
+    // Move file
+    std::fs::rename(file.file.path(), &new_file_path)?;
+
+    ctx.connection
+        .transaction_sync(|con| {
+            read_sensors(&con, &url_params.store_id, new_file_path)
+                .context("Error while integrating sensor data")
+        })
+        .map_err(|error| error.to_inner_error())
+}

--- a/server/server/src/upload_fridge_tag.rs
+++ b/server/server/src/upload_fridge_tag.rs
@@ -13,11 +13,10 @@ use service::{
     service_provider::ServiceProvider,
     settings::Settings,
 };
-use util::perpare_file_dir;
+use util::prepare_file_dir;
 
 const TEMP_FRIDGETAG_FILE_DIR: &'static str = "fridge_tag";
 
-// this function could be located in different module
 pub fn config_upload_fridge_tag(cfg: &mut web::ServiceConfig) {
     cfg.service(upload);
 }
@@ -62,7 +61,7 @@ fn upload_fridge_tag(
     let file = form.files.pop().context("Cannot find attached file")?;
     let file_name = file.file_name.context("Filename is not specified")?;
 
-    let dir = perpare_file_dir(TEMP_FRIDGETAG_FILE_DIR, &settings.server.base_dir)?;
+    let dir = prepare_file_dir(TEMP_FRIDGETAG_FILE_DIR, &settings.server.base_dir)?;
 
     let new_file_path = dir.join(file_name);
 

--- a/server/server/src/upload_fridge_tag.rs
+++ b/server/server/src/upload_fridge_tag.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use serde::Deserialize;
 
 use service::{
-    sensor::berlinger::{read_sensors, ReadSensor},
+    sensor::berlinger::{read_sensor, ReadSensor},
     service_provider::ServiceProvider,
     settings::Settings,
 };
@@ -70,7 +70,7 @@ fn upload_fridge_tag(
 
     ctx.connection
         .transaction_sync(|con| {
-            read_sensors(&con, &url_params.store_id, new_file_path)
+            read_sensor(&con, &url_params.store_id, new_file_path)
                 .context("Error while integrating sensor data")
         })
         .map_err(|error| error.to_inner_error())

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -12,7 +12,8 @@ repository = { path = "../repository" }
 util = { path = "../util" }
 
 anymap = "0.12"
-anyhow = "1.0.56"
+
+anyhow.worspace = true
 async-trait = "0.1.57"
 thiserror = "1"
 topological-sort = "0.2.2"

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -13,7 +13,8 @@ util = { path = "../util" }
 
 anymap = "0.12"
 
-anyhow.worspace = true
+anyhow.workspace = true
+
 async-trait = "0.1.57"
 thiserror = "1"
 topological-sort = "0.2.2"

--- a/server/service/src/sensor/berlinger.rs
+++ b/server/service/src/sensor/berlinger.rs
@@ -283,7 +283,7 @@ pub enum ReadSensorError {
     Other(#[from] anyhow::Error),
 }
 
-pub fn read_sensors(
+pub fn read_sensor(
     connection: &StorageConnection,
     store_id: &str,
     fridgetag_file: PathBuf,

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -2,7 +2,7 @@ use std::io::Error;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use util::perpare_file_dir;
+use util::prepare_file_dir;
 use util::uuid::uuid;
 
 #[derive(Debug, PartialEq)]
@@ -27,7 +27,7 @@ pub struct StaticFileService {
 impl StaticFileService {
     pub fn new(base_dir: &Option<String>) -> anyhow::Result<Self> {
         Ok(StaticFileService {
-            dir: perpare_file_dir(STATIC_FILE_DIR, base_dir)?,
+            dir: prepare_file_dir(STATIC_FILE_DIR, base_dir)?,
             max_lifetime_millis: 60 * 60 * 1000, // 1 hours
         })
     }

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -1,8 +1,8 @@
 use std::io::Error;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
+use util::perpare_file_dir;
 use util::uuid::uuid;
 
 #[derive(Debug, PartialEq)]
@@ -26,20 +26,14 @@ pub struct StaticFileService {
 }
 impl StaticFileService {
     pub fn new(base_dir: &Option<String>) -> anyhow::Result<Self> {
-        let file_dir = match base_dir {
-            Some(file_dir) => PathBuf::from_str(file_dir)?.join(STATIC_FILE_DIR),
-            None => PathBuf::from_str(STATIC_FILE_DIR)?,
-        };
-
         Ok(StaticFileService {
-            dir: file_dir,
+            dir: perpare_file_dir(STATIC_FILE_DIR, base_dir)?,
             max_lifetime_millis: 60 * 60 * 1000, // 1 hours
         })
     }
 
     pub fn store_file(&self, file_name: &str, bytes: &[u8]) -> anyhow::Result<StaticFile> {
         let id = uuid();
-        std::fs::create_dir_all(&self.dir)?;
         let file_path = self.dir.join(format!("{}_{}", id, file_name));
         std::fs::write(&file_path, bytes).unwrap();
         Ok(StaticFile {

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -14,5 +14,7 @@ serde = "1.0.126"
 env_logger = "0.8.3"
 serde_json = "1.0.66"
 
+anyhow.workspace = true
+
 [dev-dependencies]
 thiserror = "1"

--- a/server/util/src/file.rs
+++ b/server/util/src/file.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, str::FromStr};
 
-pub fn perpare_file_dir(dir: &'static str, base_dir: &Option<String>) -> anyhow::Result<PathBuf> {
+pub fn prepare_file_dir(dir: &'static str, base_dir: &Option<String>) -> anyhow::Result<PathBuf> {
     let file_dir = match base_dir {
         Some(file_dir) => PathBuf::from_str(file_dir)?.join(dir),
         None => PathBuf::from_str(dir)?,

--- a/server/util/src/file.rs
+++ b/server/util/src/file.rs
@@ -1,0 +1,12 @@
+use std::{path::PathBuf, str::FromStr};
+
+pub fn perpare_file_dir(dir: &'static str, base_dir: &Option<String>) -> anyhow::Result<PathBuf> {
+    let file_dir = match base_dir {
+        Some(file_dir) => PathBuf::from_str(file_dir)?.join(dir),
+        None => PathBuf::from_str(dir)?,
+    };
+
+    std::fs::create_dir_all(&file_dir)?;
+
+    Ok(file_dir)
+}

--- a/server/util/src/lib.rs
+++ b/server/util/src/lib.rs
@@ -24,3 +24,6 @@ pub use json::*;
 
 mod error;
 pub use error::*;
+
+mod file;
+pub use file::*;


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #2420 

# 👩🏻‍💻 What does this PR do? 

Add upload fridgetag button to top left of sensor list. When fridgetag file is selected it will be uploaded and then integrated.

It's branched from this PR: ~~https://github.com/openmsupply/open-msupply/pull/2421 please see description there~~ https://github.com/openmsupply/open-msupply/pull/2383.

This PR also not directly related changes:
* anyhow dependency moved to workspace 
* created prepare file dir utility, since I saw common functionality when looking up static file for reference

# 🧪 How has/should this change been tested? 

I used [the blank test data file](https://drive.google.com/drive/u/1/search?q=simple%20sync), turned on vaccine module preference for the store. Synced, then went to sensor list, pressed the fridge tag button and used this file: https://github.com/openmsupply/temperature-sensor/blob/main/data/FridgeTag%202L/130500109088_202206081014.txt

## 💌 Any notes for the reviewer?

Turn off white space diff, especially for the .rs files (a few indentation changes).

Cargo.lock file is due to adding multipart form for actix-web, btw, that's half of the diff

There is a bit of carry over, to be done in subsequent issues, but I think what we have here should be sufficient form MVP, thanks @adrianwb for majority of the work done with Berlinger Fridge tags.

Carry over issue here (TODO)

## 📃 Documentation
 
Instruction on how to upload berlinger fridge tag info and what fridgetags we support should be added to cold chain docs